### PR TITLE
fix(subscription): preserve AnyTLS and TUIC nodes

### DIFF
--- a/scripts/package-smoke.sh
+++ b/scripts/package-smoke.sh
@@ -47,6 +47,10 @@ require_entry bin/ecapture
 require_entry lib/kamfw/watchdog.sh
 require_entry lib/kamfw/fswatch.sh
 require_entry lib/kamfw/__singbox__.sh
+require_entry lib/magicnet_singbox_subscribe.sh
+for entry in common fetch parse config proxylink update; do
+    require_entry "lib/magicnet/singbox_subscribe/$entry.sh"
+done
 
 require_executable_entry() {
     local entry="$1"
@@ -117,6 +121,14 @@ check_no_subscription_secret() {
 }
 
 check_no_subscription_secret '.config/sing-box/subscription.url'
+
+subscription_module_root="$elf_tmp/subscription-module"
+mkdir -p "$subscription_module_root"
+unzip -oq "$ZIP_PATH" \
+    'lib/magicnet_singbox_subscribe.sh' \
+    'lib/magicnet/singbox_subscribe/*.sh' \
+    -d "$subscription_module_root"
+bash "$ROOT/scripts/singbox-subscription-protocol-smoke.sh" "$subscription_module_root"
 
 route_fixture_dir="$elf_tmp/route-config"
 mkdir -p "$route_fixture_dir"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -34,6 +34,7 @@ mapfile -t posix_shell_files < <(
 shellcheck -s sh -e SC1091,SC1090,SC2329,SC2059 "${posix_shell_files[@]}"
 
 jq empty src/MagicNet/.config/sing-box/config.json
+bash scripts/singbox-subscription-protocol-smoke.sh
 
 KAM_HOOKS_ROOT=hooks KAM_MODULE_ROOT=src/MagicNet bash hooks/pre-build/6000.check_config.sh
 MODPATH="$ROOT/src/MagicNet" sh -c '. "$MODPATH/lib/kamfw/.kamfwrc"; import __runtime__; . "$MODPATH/lib/magicnet.sh"; kamfw run post-mount -- smoke'

--- a/scripts/singbox-subscription-protocol-smoke.sh
+++ b/scripts/singbox-subscription-protocol-smoke.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODULE_ROOT="${1:-$ROOT/src/MagicNet}"
+
+fail() {
+    printf 'sing-box subscription protocol smoke failed: %s\n' "$*" >&2
+    exit 1
+}
+
+for tool in base64 jq; do
+    command -v "$tool" >/dev/null 2>&1 || fail "missing required command: $tool"
+done
+
+[[ -f "$MODULE_ROOT/lib/magicnet_singbox_subscribe.sh" ]] \
+    || fail "subscription library not found under module root: $MODULE_ROOT"
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+    rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+# shellcheck disable=SC2034
+MODDIR="$MODULE_ROOT"
+# shellcheck disable=SC1090
+. "$MODULE_ROOT/lib/magicnet_singbox_subscribe.sh"
+
+links_fixture="$tmp_dir/mixed-links.txt"
+cat >"$links_fixture" <<'EOF'
+vless://00000000-0000-4000-8000-000000000001@vless.invalid:443#fixture-vless
+anytls://fixture-password@anytls.invalid:443#fixture-anytls
+tuic://00000000-0000-4000-8000-000000000002:fixture-password@tuic.invalid:443#fixture-tuic
+EOF
+
+assert_extracted_links() {
+    local source_file="$1"
+    local case_name="$2"
+    local nodes_dir="$tmp_dir/$case_name-nodes"
+    local count
+
+    count="$(magicnet_singbox_extract_share_links "$source_file" "$nodes_dir")"
+    [[ "$count" == "3" ]] || fail "$case_name extraction returned $count nodes, expected 3"
+    [[ "$(wc -l <"$nodes_dir/links.txt")" == "3" ]] \
+        || fail "$case_name links.txt does not contain exactly 3 links"
+    for scheme in vless anytls tuic; do
+        grep -Eq "^${scheme}://" "$nodes_dir/links.txt" \
+            || fail "$case_name links.txt is missing ${scheme}://"
+    done
+}
+
+assert_extracted_links "$links_fixture" plain
+base64 <"$links_fixture" >"$tmp_dir/mixed-links.base64"
+assert_extracted_links "$tmp_dir/mixed-links.base64" base64
+
+nodes_json="$tmp_dir/outbounds.json"
+cat >"$nodes_json" <<'JSON'
+[
+  {
+    "type": "vless",
+    "tag": "fixture-vless",
+    "server": "vless.invalid",
+    "server_port": 443,
+    "uuid": "00000000-0000-4000-8000-000000000001"
+  },
+  {
+    "type": "anytls",
+    "tag": "fixture-anytls",
+    "server": "anytls.invalid",
+    "server_port": 443,
+    "password": "fixture-password"
+  },
+  {
+    "type": "tuic",
+    "tag": "fixture-tuic",
+    "server": "tuic.invalid",
+    "server_port": 443,
+    "uuid": "00000000-0000-4000-8000-000000000002",
+    "password": "fixture-password"
+  }
+]
+JSON
+
+valid_count="$(magicnet_singbox_count_valid_outbounds_nodes "$nodes_json")"
+[[ "$valid_count" == "3" ]] || fail "valid outbound count was $valid_count, expected 3"
+
+outbounds_fragment="$tmp_dir/generated-outbounds.fragment"
+magicnet_singbox_write_outbounds_from_json "$nodes_json" "$outbounds_fragment"
+{
+    printf '{\n'
+    sed 's/,$//' "$outbounds_fragment"
+    printf '\n}\n'
+} >"$tmp_dir/generated-outbounds.json"
+
+jq -e '
+  ([.outbounds[] | select(.type == "vless" or .type == "anytls" or .type == "tuic")] | length) == 3
+  and ([.outbounds[] | select(.type == "vless") | .tag] == ["fixture-vless"])
+  and ([.outbounds[] | select(.type == "anytls") | .tag] == ["fixture-anytls"])
+  and ([.outbounds[] | select(.type == "tuic") | .tag] == ["fixture-tuic"])
+  and ((.outbounds[] | select(.type == "selector" and .tag == "proxy") | .outbounds) as $proxy
+    | ($proxy | index("fixture-vless")) != null
+    and ($proxy | index("fixture-anytls")) != null
+    and ($proxy | index("fixture-tuic")) != null)
+' "$tmp_dir/generated-outbounds.json" >/dev/null \
+    || fail "generated outbounds did not preserve all protocols in the proxy selector"
+
+printf 'sing-box subscription protocol smoke passed\n'

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
@@ -90,6 +90,8 @@ magicnet_singbox_build_outbounds_file_with_jq() {
               or (.type == "vless" and ((.uuid // "") != ""))
               or (.type == "trojan" and ((.password // "") != ""))
               or (.type == "hysteria2" and ((.password // "") != ""))
+              or (.type == "anytls" and ((.password // "") != ""))
+              or (.type == "tuic" and ((.uuid // "") != "") and ((.password // "") != ""))
             )
           ))
       ) as $nodes
@@ -139,6 +141,8 @@ magicnet_singbox_count_valid_outbounds_nodes() {
               or (.type == "vless" and ((.uuid // "") != ""))
               or (.type == "trojan" and ((.password // "") != ""))
               or (.type == "hysteria2" and ((.password // "") != ""))
+              or (.type == "anytls" and ((.password // "") != ""))
+              or (.type == "tuic" and ((.uuid // "") != "") and ((.password // "") != ""))
             )
           ))
         | length

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/parse.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/parse.sh
@@ -41,22 +41,22 @@ magicnet_singbox_extract_share_links() {
     _current_links_file=$(mktemp "${_nodes_dir}/links.current.XXXXXX") || return 1
     _first_line=$(sed -n '1{s/^[[:space:]]*//;p;}' "$_source_file" | tr -d '\r')
     case "$_first_line" in
-    vless://* | hysteria2://* | hy2://* | trojan://* | vmess://* | ss://*)
+    vless://* | anytls://* | tuic://* | hysteria2://* | hy2://* | trojan://* | vmess://* | ss://*)
         tr -d '\r' <"$_source_file" |
-            grep -E '^[[:space:]]*(vless|hysteria2|hy2|trojan|vmess|ss)://' |
+            grep -E '^[[:space:]]*(vless|anytls|tuic|hysteria2|hy2|trojan|vmess|ss)://' |
             sed 's/^[[:space:]]*//' >"$_current_links_file"
         ;;
     *)
         if command -v base64 >/dev/null 2>&1; then
             base64 -d "$_source_file" 2>/dev/null |
                 tr -d '\r' |
-                grep -E '^[[:space:]]*(vless|hysteria2|hy2|trojan|vmess|ss)://' |
+                grep -E '^[[:space:]]*(vless|anytls|tuic|hysteria2|hy2|trojan|vmess|ss)://' |
                 sed 's/^[[:space:]]*//' >"$_current_links_file"
             if [ ! -s "$_current_links_file" ]; then
                 tr '_-' '/+' <"$_source_file" 2>/dev/null |
                     base64 -d 2>/dev/null |
                     tr -d '\r' |
-                    grep -E '^[[:space:]]*(vless|hysteria2|hy2|trojan|vmess|ss)://' |
+                    grep -E '^[[:space:]]*(vless|anytls|tuic|hysteria2|hy2|trojan|vmess|ss)://' |
                     sed 's/^[[:space:]]*//' >"$_current_links_file"
             fi
         else

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
@@ -44,7 +44,7 @@ magicnet_singbox_update_subscription() {
     fi
 
     if [ "${_imported:-0}" -le 0 ]; then
-        error "No supported nodes imported. Supported: Clash ss/vmess/vless/trojan/hysteria2, share-link vless/hysteria2; Proxylink adds WireGuard/AnyTLS/TUIC when available"
+        error "No supported nodes imported. Supported: Clash ss/vmess/vless/trojan/hysteria2, share-link vless/hysteria2; Proxylink adds AnyTLS/TUIC when available"
         return 1
     fi
 


### PR DESCRIPTION
Fixes #20

## Root cause

MagicNet packaged Proxylink with AnyTLS and TUIC support, but the share-link extractor and the post-conversion jq filter only admitted the older protocol set. Valid AnyTLS and TUIC nodes were therefore dropped, and the fallback shell importer produced a shorter node list.

## Changes

- retain AnyTLS and TUIC links in plain and Base64 subscriptions
- accept valid AnyTLS and TUIC Proxylink outbounds
- add source and packaged-ZIP regression coverage
- correct the supported-protocol diagnostic

## Validation

- old v1.1.11 subscription library reproduces 1/3 imported nodes
- patched protocol smoke imports 3/3 and keeps all tags in the proxy selector
- Bash/POSIX syntax checks and scoped ShellCheck pass
- git diff --check passes

Full latest package build was not completed locally because the KAM dependency download was extremely slow; the candidate ZIP subscription seam was validated against the v1.1.11 artifact.

## Summary by Sourcery

在 sing-box 订阅中保留 AnyTLS 和 TUIC 节点，并在构建工具中添加协议冒烟覆盖。

New Features:
- 在纯文本和 Base64 编码的 sing-box 订阅中支持 AnyTLS 和 TUIC 分享链接。
- 在订阅处理过程中，将 AnyTLS 和 TUIC Proxylink 出站视为有效节点。

Enhancements:
- 在打包和 pre-commit 工作流中加入专用的 sing-box 订阅协议冒烟脚本，用于保护协议支持。
- 调整订阅诊断，以准确反映受支持的协议集合。

Tests:
- 添加回归风格的冒烟测试，用于验证 AnyTLS 和 TUIC 节点的提取和保留，包括对生成出站中的代理选择器覆盖的验证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve AnyTLS and TUIC nodes in sing-box subscriptions and add protocol smoke coverage to the build tooling.

New Features:
- Support AnyTLS and TUIC share links in plain and Base64-encoded sing-box subscriptions.
- Treat AnyTLS and TUIC Proxylink outbounds as valid nodes in subscription processing.

Enhancements:
- Include a dedicated sing-box subscription protocol smoke script in package and pre-commit workflows to guard protocol support.
- Adjust subscription diagnostics to accurately reflect the supported protocol set.

Tests:
- Add regression-style smoke tests to validate extraction and retention of AnyTLS and TUIC nodes, including proxy selector coverage in generated outbounds.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 sing-box 订阅中保留 AnyTLS 和 TUIC 节点，并在构建工具中添加协议冒烟覆盖。

New Features:
- 在纯文本和 Base64 编码的 sing-box 订阅中支持 AnyTLS 和 TUIC 分享链接。
- 在订阅处理过程中，将 AnyTLS 和 TUIC Proxylink 出站视为有效节点。

Enhancements:
- 在打包和 pre-commit 工作流中加入专用的 sing-box 订阅协议冒烟脚本，用于保护协议支持。
- 调整订阅诊断，以准确反映受支持的协议集合。

Tests:
- 添加回归风格的冒烟测试，用于验证 AnyTLS 和 TUIC 节点的提取和保留，包括对生成出站中的代理选择器覆盖的验证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve AnyTLS and TUIC nodes in sing-box subscriptions and add protocol smoke coverage to the build tooling.

New Features:
- Support AnyTLS and TUIC share links in plain and Base64-encoded sing-box subscriptions.
- Treat AnyTLS and TUIC Proxylink outbounds as valid nodes in subscription processing.

Enhancements:
- Include a dedicated sing-box subscription protocol smoke script in package and pre-commit workflows to guard protocol support.
- Adjust subscription diagnostics to accurately reflect the supported protocol set.

Tests:
- Add regression-style smoke tests to validate extraction and retention of AnyTLS and TUIC nodes, including proxy selector coverage in generated outbounds.

</details>

</details>