### PR TITLE
chore(release): bump version to v1.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Unreleased
 
+## v1.1.12 (2026-07-10)
+
+- Add a WebUI control workspace with functional diagnostic and configuration
+  preview tools.
+- Recover routing after interface changes, and improve CLI backup and help
+  flows plus default node handling.
+- Update the bundled MagicBox and Zashboard revisions.
+- Preserve AnyTLS and TUIC nodes during subscription imports, with packaged
+  regression coverage.
+- Remove tracked local runtime state from the repository.
+
 ## v1.1.11 (2026-06-30)
 
 - Avoid manager/non-TTY install hangs by skipping MagicNet interactive prompts

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   <p>
-    <a href="kam.toml"><img alt="MagicNet v1.1.11" src="https://img.shields.io/badge/MagicNet-v1.1.11-31c2f2" /></a>
+    <a href="kam.toml"><img alt="MagicNet v1.1.12" src="https://img.shields.io/badge/MagicNet-v1.1.12-31c2f2" /></a>
     <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-green.svg" /></a>
     <a href="Cargo.toml"><img alt="Rust workspace" src="https://img.shields.io/badge/Rust-workspace-f46623?logo=rust&logoColor=white" /></a>
     <a href="webui/package.json"><img alt="Vue WebUI" src="https://img.shields.io/badge/WebUI-Vue%203-42b883?logo=vue.js&logoColor=white" /></a>
@@ -27,7 +27,7 @@ MagicNet 是一个 Android root 网络编排模块，把设备流量或显式代
 
 当前主线已经收敛为 **sing-box + 用户态编排**。`sing-box` 是唯一代理核心；MagicNet 提供 `proxy`、`external-tun`、`hybrid` 和兼容 `tun` 四种运行模式。下一代设计详见 [docs/next-gen-architecture.md](docs/next-gen-architecture.md)。旧的 TProxy 主路径、多核心切换和抓包代理功能都不再作为主线能力维护。
 
-需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.11`。Release 以发布页为准。
+需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.12`。Release 以发布页为准。
 
 ## 成果
 
@@ -108,9 +108,9 @@ chmod +x kam.sh
 
 ### Release 包
 
-当前 release 下载页：<https://github.com/LIghtJUNction/MagicNet/releases/tag/v1.1.11>
+当前 release 下载页：<https://github.com/LIghtJUNction/MagicNet/releases/tag/v1.1.12>
 
-直接下载当前模块包：<https://github.com/LIghtJUNction/MagicNet/releases/download/v1.1.11/MagicNet.zip>
+直接下载当前模块包：<https://github.com/LIghtJUNction/MagicNet/releases/download/v1.1.12/MagicNet.zip>
 
 ```bash
 kam -S MagicNet

--- a/kam.toml
+++ b/kam.toml
@@ -1,8 +1,8 @@
 [prop]
 id = "MagicNet"
 name = "MagicNet"
-version = "v1.1.11"
-versionCode = 1782797191625
+version = "v1.1.12"
+versionCode = 1783666293362
 author = "LIghtJUNction"
 description = "[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM."
 updateJson = "https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json"

--- a/src/MagicNet/module.prop
+++ b/src/MagicNet/module.prop
@@ -1,7 +1,7 @@
 id=MagicNet
 name=MagicNet
-version=v1.1.11
-versionCode=1782797191625
+version=v1.1.12
+versionCode=1783666293362
 author=LIghtJUNction
 description=[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM.
 updateJson=https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
   "changelog": "https://github.com/LIghtJUNction/MagicNet/blob/main/CHANGELOG.md",
-  "version": "v1.1.11",
-  "versionCode": 1782797191625,
+  "version": "v1.1.12",
+  "versionCode": 1783666293362,
   "zipUrl": "https://github.com/LIghtJUNction/MagicNet/releases/latest/download/MagicNet.zip"
 }


### PR DESCRIPTION
## Summary

Prepare the v1.1.12 MagicNet module release from the current main branch.

## Changes

- bump module metadata and update manifest to v1.1.12
- refresh README release links
- add release notes covering the WebUI workspace, routing and CLI fixes, bundled component updates, and AnyTLS/TUIC import repair

## Validation

- kam validate
- jq empty update.json
- version consistency across kam.toml, update.json, and module.prop
- git diff --check

The formal module release will be dispatched from main only after this PR merges and main is pulled.

## Summary by Sourcery

为 MagicNet v1.1.12 模块发布做准备，更新元数据和文档。

New Features:
- 记录新的用于诊断和配置预览的 WebUI 控制工作区。
- 记录路由恢复改进、增强的 CLI 备份/帮助流程以及默认节点处理。
- 说明捆绑的 MagicBox 和 Zashboard 组件的更新，以及 AnyTLS/TUIC 订阅导入在回归测试覆盖下的保留。

Enhancements:
- 将模块元数据和清单版本提升至 v1.1.12，并刷新 README 徽章和发布下载链接。
- 更新变更日志以记录从代码仓库中移除受跟踪的本地运行时状态。

Documentation:
- 更新 README 版本徽章和发布下载 URL，使其指向 v1.1.12。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prepare the MagicNet v1.1.12 module release with updated metadata and documentation.

New Features:
- Document the new WebUI control workspace for diagnostics and configuration preview.
- Record routing recovery improvements, enhanced CLI backup/help flows, and default node handling.
- Note updates to bundled MagicBox and Zashboard components and AnyTLS/TUIC subscription import preservation with regression coverage.

Enhancements:
- Bump module metadata and manifest to version v1.1.12 and refresh README badges and release download links.
- Update the changelog to capture removal of tracked local runtime state from the repository.

Documentation:
- Update README version badges and release download URLs to point to v1.1.12.

</details>

新特性：
- 记录新的 WebUI 控制工作区，提供诊断和配置预览工具。
- 记录路由恢复改进、CLI 备份/帮助增强以及默认节点处理方式。
- 标注随附的 MagicBox 和 Zashboard 组件的更新，以及 AnyTLS/TUIC 导入保持机制及其回归测试覆盖情况。

改进：
- 将模块元数据和清单文件更新为 v1.1.12 版本，并刷新 README 徽章和发布下载链接。
- 在新版本的变更日志中记录已移除的本地运行时状态跟踪。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 MagicNet v1.1.12 模块发布做准备，更新元数据和文档。

New Features:
- 记录新的用于诊断和配置预览的 WebUI 控制工作区。
- 记录路由恢复改进、增强的 CLI 备份/帮助流程以及默认节点处理。
- 说明捆绑的 MagicBox 和 Zashboard 组件的更新，以及 AnyTLS/TUIC 订阅导入在回归测试覆盖下的保留。

Enhancements:
- 将模块元数据和清单版本提升至 v1.1.12，并刷新 README 徽章和发布下载链接。
- 更新变更日志以记录从代码仓库中移除受跟踪的本地运行时状态。

Documentation:
- 更新 README 版本徽章和发布下载 URL，使其指向 v1.1.12。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prepare the MagicNet v1.1.12 module release with updated metadata and documentation.

New Features:
- Document the new WebUI control workspace for diagnostics and configuration preview.
- Record routing recovery improvements, enhanced CLI backup/help flows, and default node handling.
- Note updates to bundled MagicBox and Zashboard components and AnyTLS/TUIC subscription import preservation with regression coverage.

Enhancements:
- Bump module metadata and manifest to version v1.1.12 and refresh README badges and release download links.
- Update the changelog to capture removal of tracked local runtime state from the repository.

Documentation:
- Update README version badges and release download URLs to point to v1.1.12.

</details>

</details>