### PR TITLE
fix(webui): improve mobile overflow handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+## v1.1.13 (2026-07-10)
+
+- Fix #24 by allowing long mobile WebUI text to scroll horizontally while
+  preserving page zoom and pinch gestures.
+- Keep the top WebUI controls on a single line with a compact narrow-screen
+  layout.
+- Move the KAM dev staging path to `/sdcard/Download/MagicNet`.
+
 ## v1.1.12 (2026-07-10)
 
 - Add a WebUI control workspace with functional diagnostic and configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## v1.1.13 (2026-07-10)
+## v1.1.13 (2026-07-11)
 
 - Fix #24 by allowing long mobile WebUI text to scroll horizontally while
   preserving page zoom and pinch gestures.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   <p>
-    <a href="kam.toml"><img alt="MagicNet v1.1.12" src="https://img.shields.io/badge/MagicNet-v1.1.12-31c2f2" /></a>
+    <a href="kam.toml"><img alt="MagicNet v1.1.13" src="https://img.shields.io/badge/MagicNet-v1.1.13-31c2f2" /></a>
     <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-green.svg" /></a>
     <a href="Cargo.toml"><img alt="Rust workspace" src="https://img.shields.io/badge/Rust-workspace-f46623?logo=rust&logoColor=white" /></a>
     <a href="webui/package.json"><img alt="Vue WebUI" src="https://img.shields.io/badge/WebUI-Vue%203-42b883?logo=vue.js&logoColor=white" /></a>
@@ -27,7 +27,7 @@ MagicNet 是一个 Android root 网络编排模块，把设备流量或显式代
 
 当前主线已经收敛为 **sing-box + 用户态编排**。`sing-box` 是唯一代理核心；MagicNet 提供 `proxy`、`external-tun`、`hybrid` 和兼容 `tun` 四种运行模式。下一代设计详见 [docs/next-gen-architecture.md](docs/next-gen-architecture.md)。旧的 TProxy 主路径、多核心切换和抓包代理功能都不再作为主线能力维护。
 
-需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.12`。Release 以发布页为准。
+需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.13`。Release 以发布页为准。
 
 ## 成果
 
@@ -108,9 +108,9 @@ chmod +x kam.sh
 
 ### Release 包
 
-当前 release 下载页：<https://github.com/LIghtJUNction/MagicNet/releases/tag/v1.1.12>
+当前 release 下载页：<https://github.com/LIghtJUNction/MagicNet/releases/tag/v1.1.13>
 
-直接下载当前模块包：<https://github.com/LIghtJUNction/MagicNet/releases/download/v1.1.12/MagicNet.zip>
+直接下载当前模块包：<https://github.com/LIghtJUNction/MagicNet/releases/download/v1.1.13/MagicNet.zip>
 
 ```bash
 kam -S MagicNet

--- a/kam.toml
+++ b/kam.toml
@@ -1,8 +1,8 @@
 [prop]
 id = "MagicNet"
 name = "MagicNet"
-version = "v1.1.12"
-versionCode = 1783666293362
+version = "v1.1.13"
+versionCode = 1783698673521
 author = "LIghtJUNction"
 description = "[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM."
 updateJson = "https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json"
@@ -100,6 +100,6 @@ ignore = [
     "*.bak",
     "*.kam-tmp",
 ]
-staging = "/data/local/tmp/kam-dev/{{id}}"
+staging = "/sdcard/Download/MagicNet/kam-dev/{{id}}"
 
 [tool]

--- a/scripts/fake-magisk-smoke.sh
+++ b/scripts/fake-magisk-smoke.sh
@@ -762,6 +762,7 @@ assert_transparent_mode() {
     local before_marker after_marker
 
     before_marker="$(wc -l <"$MOCK_LOG")"
+    # shellcheck disable=SC2016
     run env MAGICNET_TEST_MODE="$mode" sh -c '
         . "$MODDIR/lib/kamfw/.kamfwrc"
         import __runtime__

--- a/scripts/package-smoke.sh
+++ b/scripts/package-smoke.sh
@@ -164,6 +164,7 @@ JSON
 (
     import() { :; }
     set_i18n() { :; }
+    # shellcheck disable=SC2034
     MODDIR="$route_fixture_dir"
     # shellcheck disable=SC1091
     . "$route_fixture_dir/__singbox__.sh"

--- a/src/MagicNet/module.prop
+++ b/src/MagicNet/module.prop
@@ -1,7 +1,7 @@
 id=MagicNet
 name=MagicNet
-version=v1.1.12
-versionCode=1783666293362
+version=v1.1.13
+versionCode=1783698673521
 author=LIghtJUNction
 description=[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM.
 updateJson=https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
   "changelog": "https://github.com/LIghtJUNction/MagicNet/blob/main/CHANGELOG.md",
-  "version": "v1.1.12",
-  "versionCode": 1783666293362,
+  "version": "v1.1.13",
+  "versionCode": 1783698673521,
   "zipUrl": "https://github.com/LIghtJUNction/MagicNet/releases/latest/download/MagicNet.zip"
 }

--- a/webui/index.html
+++ b/webui/index.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover" />
     <meta name="color-scheme" content="dark light" />
     <title>MagicNet</title>
     <link rel="icon" href="data:," />

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -74,10 +74,6 @@ const activeComponent = computed(() => ({
 }[activeTab.value]));
 
 const statusMessage = computed(() => state.task ? `正在执行：${state.task}` : state.notice || "等待操作");
-const shortStatusMessage = computed(() => {
-  const message = statusMessage.value;
-  return message.length > 38 ? `${message.slice(0, 34)}...` : message;
-});
 
 function setTab(tab: TabKey): void {
   activeTab.value = tab;
@@ -144,7 +140,7 @@ onUnmounted(() => {
 
 <template>
   <div class="relative mx-auto min-h-dvh w-full max-w-[1500px] px-3 pb-28 pt-3 sm:px-5 md:px-7 md:pb-12 md:pt-6">
-    <header class="mb-5 flex flex-wrap items-center justify-between gap-1 md:mb-7">
+    <header class="mb-5 flex flex-nowrap items-center justify-between gap-1 md:mb-7">
       <div class="flex min-w-0 items-center gap-1 rounded-full bg-white/[0.045] p-0.5 pr-1.5 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.07),inset_0_1px_0_rgba(255,255,255,0.06)]">
         <button
           class="brand-mark grid size-[49px] shrink-0 place-items-center rounded-full bg-gradient-to-br from-emerald-300 via-cyan-300 to-rose-300 text-[#05110e] shadow-[inset_0_1px_0_rgba(255,255,255,0.7),0_8px_24px_rgba(34,211,238,0.14)] transition-[transform,opacity] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200/80 active:scale-[0.94]"
@@ -155,7 +151,7 @@ onUnmounted(() => {
         >
           <Zap :size="21" />
         </button>
-        <div class="min-w-0">
+        <div class="hidden min-w-0 min-[360px]:block">
           <h1 class="truncate text-[17px] font-semibold leading-tight tracking-[-0.03em] text-white sm:text-xl">MagicNet</h1>
           <p class="hidden truncate text-[11px] text-zinc-500 sm:block">Root network workspace</p>
         </div>
@@ -209,11 +205,11 @@ onUnmounted(() => {
     <section class="runtime-cockpit relative z-20 mb-5 grid gap-4 rounded-[2rem] bg-[#0b0d0f]/94 p-2 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08),inset_0_0_0_7px_rgba(255,255,255,0.018),0_18px_60px_rgba(0,0,0,0.16)] md:sticky md:top-4 md:grid-cols-[minmax(220px,1.05fr)_minmax(0,1fr)_auto] md:items-center md:gap-2 md:backdrop-blur-xl">
       <div class="rounded-[1.55rem] bg-gradient-to-br from-emerald-400/[0.09] via-white/[0.025] to-cyan-400/[0.07] px-4 py-3 shadow-[inset_0_0_0_1px_rgba(110,231,183,0.09)]">
         <div class="flex items-center justify-between gap-3">
-          <div class="min-w-0">
+          <div class="min-w-0 flex-1">
             <span class="text-[9px] font-semibold uppercase tracking-[0.22em] text-zinc-500">Runtime status</span>
-            <div class="mt-1.5 flex items-center gap-2.5">
+            <div class="mt-1.5 flex min-w-0 items-center gap-2.5">
               <span :class="['size-2.5 shrink-0 rounded-full shadow-[0_0_18px_currentColor]', state.runtime.singBoxState === 'sing-box' ? 'bg-emerald-300 text-emerald-300' : state.runtime.singBoxState === 'stopped' ? 'bg-rose-300 text-rose-300' : 'bg-amber-300 text-amber-300']" />
-              <strong class="truncate text-lg font-semibold tracking-[-0.03em] text-white">
+              <strong class="w-0 min-w-0 flex-1 truncate text-lg font-semibold tracking-[-0.03em] text-white">
                 {{ state.runtime.singBoxState === "sing-box" ? "sing-box online" : state.runtime.singBoxState === "unknown" ? "状态未知" : state.runtime.singBoxState }}
               </strong>
             </div>
@@ -233,7 +229,7 @@ onUnmounted(() => {
         </div>
         <div class="col-span-2 flex min-w-0 items-center gap-2 text-xs leading-5 text-zinc-400 md:text-sm">
           <ScrollText class="shrink-0 text-rose-300" :size="14" />
-          <span class="min-w-0 truncate" :title="statusMessage">{{ shortStatusMessage }}</span>
+          <span class="min-w-0 truncate" :title="statusMessage">{{ statusMessage }}</span>
         </div>
       </div>
 

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -30,7 +30,8 @@ body {
     radial-gradient(circle at 72% 78%, rgba(251, 113, 133, 0.055), transparent 34rem),
     linear-gradient(145deg, #060708 0%, #090a0c 48%, #060708 100%);
   color: #f4f4f5;
-  overflow-x: hidden;
+  overflow-x: auto;
+  touch-action: pan-x pan-y pinch-zoom;
 }
 
 body::before {
@@ -53,6 +54,16 @@ body::before {
 
 button {
   -webkit-tap-highlight-color: transparent;
+}
+
+.truncate {
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  text-overflow: clip;
+  white-space: nowrap;
+  touch-action: pan-x pan-y pinch-zoom;
+  -webkit-overflow-scrolling: touch;
 }
 
 .lucide {


### PR DESCRIPTION
## Summary

- Allow long mobile WebUI text to scroll horizontally while preserving page zoom and pinch gestures.
- Keep the top WebUI controls on a single line with a compact narrow-screen layout.
- Prepare the v1.1.13 patch metadata and move KAM dev staging under `/sdcard/Download/MagicNet`.
- Document the two intentional ShellCheck expansion/source patterns required by the validation hook.

## Validation

- `npm ci` (0 vulnerabilities)
- `npm run typecheck`
- `npm run build`
- `kam validate`
- `jq empty update.json`
- version/versionCode consistency check
- `git diff --check`
- pre-commit `magicnet-validate`

Closes #24

## Summary by Sourcery

改进 WebUI 在移动端的体验，并准备 v1.1.13 版本的发布元数据。

新功能：
- 在移动端为较长的 WebUI 文本启用横向滚动，同时保留缩放和双指捏合手势。

增强优化：
- 调整页眉和运行时状态布局，使顶部控制项保持在同一行，并更好地适配窄屏幕。

部署：
- 将 KAM 开发环境的预发布路径更改为 `/sdcard/Download/MagicNet`，用于开发构建。

文档：
- 更新变更日志和 README，记录 v1.1.13 版本以及新的分发链接。

杂项工作：
- 更新模块版本和 `versionCode` 元数据，并为验证脚本所需的 ShellCheck 例外添加注释。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the WebUI mobile experience and prepare the v1.1.13 release metadata.

New Features:
- Enable horizontal scrolling for long WebUI text on mobile while preserving zoom and pinch gestures.

Enhancements:
- Adjust header and runtime status layout to keep top controls on a single line and better handle narrow screens.

Deployment:
- Change KAM dev staging path to /sdcard/Download/MagicNet for development builds.

Documentation:
- Update changelog and README to document the v1.1.13 release and new distribution links.

Chores:
- Update module version and versionCode metadata and annotate ShellCheck exceptions required by validation scripts.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进 WebUI 在移动端的体验，并准备 v1.1.13 版本的发布元数据。

新功能：
- 在移动端为较长的 WebUI 文本启用横向滚动，同时保留缩放和双指捏合手势。

增强优化：
- 调整页眉和运行时状态布局，使顶部控制项保持在同一行，并更好地适配窄屏幕。

部署：
- 将 KAM 开发环境的预发布路径更改为 `/sdcard/Download/MagicNet`，用于开发构建。

文档：
- 更新变更日志和 README，记录 v1.1.13 版本以及新的分发链接。

杂项工作：
- 更新模块版本和 `versionCode` 元数据，并为验证脚本所需的 ShellCheck 例外添加注释。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the WebUI mobile experience and prepare the v1.1.13 release metadata.

New Features:
- Enable horizontal scrolling for long WebUI text on mobile while preserving zoom and pinch gestures.

Enhancements:
- Adjust header and runtime status layout to keep top controls on a single line and better handle narrow screens.

Deployment:
- Change KAM dev staging path to /sdcard/Download/MagicNet for development builds.

Documentation:
- Update changelog and README to document the v1.1.13 release and new distribution links.

Chores:
- Update module version and versionCode metadata and annotate ShellCheck exceptions required by validation scripts.

</details>

</details>