### PR TITLE
fix(config): secure issue diffs and tune TUN uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+## v1.1.14 (2026-07-11)
+
+- Set the managed sing-box TUN MTU to 1400 to mitigate slow uploads.
+- Generate compact, size-bounded unified diffs for configuration issues instead
+  of embedding truncated full configurations in issue URLs.
+- Use fail-closed structural redaction so node endpoints, credentials, and
+  arbitrary private configuration values cannot leak into issue drafts.
+
 ## v1.1.13 (2026-07-11)
 
 - Fix #24 by allowing long mobile WebUI text to scroll horizontally while

--- a/kam.toml
+++ b/kam.toml
@@ -1,8 +1,8 @@
 [prop]
 id = "MagicNet"
 name = "MagicNet"
-version = "v1.1.13"
-versionCode = 1783698673521
+version = "v1.1.14"
+versionCode = 1783742573329
 author = "LIghtJUNction"
 description = "[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM."
 updateJson = "https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json"

--- a/scripts/orchestrator-mode-smoke.sh
+++ b/scripts/orchestrator-mode-smoke.sh
@@ -90,7 +90,7 @@ assert_mode() {
     fi
 
     if [ "$expect_tun" = "yes" ]; then
-        jq -e '.inbounds[] | select(.type == "tun" and .tag == "tun-in" and .interface_name == "magicnet0")' "$config" >/dev/null
+        jq -e '.inbounds[] | select(.type == "tun" and .tag == "tun-in" and .interface_name == "magicnet0" and .stack == "gvisor" and .mtu == 1400)' "$config" >/dev/null
         jq -e '.route.rules[] | select(.action == "sniff" and (.inbound == ["mixed-in", "tun-in"]))' "$config" >/dev/null
     else
         if jq -e '.inbounds[] | select(.type == "tun" or .tag == "tun-in")' "$config" >/dev/null; then
@@ -114,5 +114,29 @@ assert_mode proxy no
 assert_mode external-tun no
 assert_mode hybrid yes
 assert_mode tun yes
+
+# Exercise the explicit jq-less awk fallback with a PATH that cannot discover host jq.
+rm -f "$MODDIR/bin/jq"
+FALLBACK_BIN="$TMPDIR/fallback-bin"
+mkdir -p "$FALLBACK_BIN"
+for command_name in awk mv rm; do
+    ln -s "$(command -v "$command_name")" "$FALLBACK_BIN/$command_name"
+done
+cat >"$MODDIR/.config/sing-box/config.json" <<'JSON'
+{
+  "dns": { "strategy": "prefer_ipv6", "servers": [] },
+  "inbounds": [
+    {
+      "type": "tun",
+      "tag": "old-tun"
+    }
+  ],
+  "route": { "rules": [], "final": "direct" },
+  "outbounds": [{ "type": "direct", "tag": "direct" }]
+}
+JSON
+printf 'MAGICNET_TRANSPARENT_MODE=tun\n' >"$MODDIR/.config/magicnet/transparent-mode.conf"
+PATH="$FALLBACK_BIN" /bin/sh "$TMPDIR/harness.sh"
+jq -e '.inbounds[] | select(.type == "tun" and .tag == "tun-in" and .stack == "gvisor" and .mtu == 1400)' "$MODDIR/.config/sing-box/config.json" >/dev/null
 
 echo "orchestrator mode smoke passed"

--- a/src/MagicNet/lib/magicnet/transparent.sh
+++ b/src/MagicNet/lib/magicnet/transparent.sh
@@ -51,7 +51,8 @@ magicnet_singbox_apply_transparent_mode() {
                   "fe80::/10",
                   "ff00::/8"
                 ],
-                "stack": "gvisor"
+                "stack": "gvisor",
+                "mtu": 1400
               };
             def managed_inbound:
               ((.type // "") as $type | ($type == "tun" or $type == "tproxy" or $type == "redirect"))
@@ -123,7 +124,8 @@ magicnet_singbox_apply_transparent_mode() {
             print "        \"fe80::/10\","
             print "        \"ff00::/8\""
             print "      ],"
-            print "      \"stack\": \"gvisor\""
+            print "      \"stack\": \"gvisor\","
+            print "      \"mtu\": 1400"
             printf "    }%s\n", comma
         }
         function emit_dns(comma) {

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
   "changelog": "https://github.com/LIghtJUNction/MagicNet/blob/main/CHANGELOG.md",
-  "version": "v1.1.13",
-  "versionCode": 1783698673521,
+  "version": "v1.1.14",
+  "versionCode": 1783742573329,
   "zipUrl": "https://github.com/LIghtJUNction/MagicNet/releases/latest/download/MagicNet.zip"
 }

--- a/webui/config-issue-draft.test.mjs
+++ b/webui/config-issue-draft.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { buildUnifiedConfigDiff, MAX_CONFIG_ISSUE_DIFF_BYTES, sanitizeConfigForIssue } from "./src/components/pages/configEditorInsights.ts";
+
+const canaries = ["HK-SECRET", "node.example.invalid", "44321", "PUBLIC_KEY_CANARY", "SHORT_ID_CANARY", "UUID_CANARY"];
+const before = JSON.stringify({
+  inbounds: [{ type: "tun", tag: "tun-secret", stack: "gvisor", auto_route: true }],
+  outbounds: [{ type: "vless", tag: canaries[0], server: canaries[1], server_port: 44321, uuid: canaries[5], tls: { reality: { public_key: canaries[3], short_id: canaries[4] } } }],
+  route: { rules: [{ outbound: canaries[0], domain: "private.example" }] },
+  dns: { servers: [{ server: "dns.private.example" }] }
+});
+const after = JSON.stringify({ ...JSON.parse(before), inbounds: [{ type: "tun", tag: "tun-secret", stack: "gvisor", mtu: 1400, auto_route: true }] });
+
+const sanitized = sanitizeConfigForIssue(after);
+for (const canary of canaries) assert.equal(sanitized.includes(canary), false, `leaked ${canary}`);
+assert.match(sanitized, /"mtu": 1400/);
+assert.match(sanitized, /"id": "inbound-1"/);
+
+const diff = buildUnifiedConfigDiff(before, after);
+assert.match(diff, /^--- config\.before\.json\n\+\+\+ config\.after\.json\n@@ /);
+assert.match(diff, /^\+\s+"mtu": 1400/m);
+for (const canary of canaries) assert.equal(diff.includes(canary), false, `diff leaked ${canary}`);
+assert.ok(Buffer.byteLength(diff) < 2048, "diff is not compact");
+assert.ok(Buffer.byteLength(diff) < MAX_CONFIG_ISSUE_DIFF_BYTES);
+assert.equal(buildUnifiedConfigDiff(before, before), "");
+
+for (const [section, mutate] of [
+  ["outbounds", (config) => { config.outbounds[0].server = "changed-node.example.invalid"; }],
+  ["dns", (config) => { config.dns.servers[0].server = "changed-dns.example.invalid"; }],
+  ["route", (config) => { config.route.rules[0].domain = "changed-private.example"; }]
+]) {
+  const changed = JSON.parse(before);
+  mutate(changed);
+  const sameCountDiff = buildUnifiedConfigDiff(before, JSON.stringify(changed));
+  assert.notEqual(sameCountDiff, "", `${section} same-count edit was missed`);
+  assert.match(sameCountDiff, new RegExp(`[-+]    "${section}": "(?:before|after)"`));
+  assert.equal(sameCountDiff.includes("changed-"), false, `${section} raw value leaked`);
+  for (const canary of canaries) assert.equal(sameCountDiff.includes(canary), false, `${section} diff leaked ${canary}`);
+}
+
+assert.throws(() => sanitizeConfigForIssue("not-json"));
+console.log("config issue draft tests passed");

--- a/webui/src/components/pages/ConfigPage.vue
+++ b/webui/src/components/pages/ConfigPage.vue
@@ -10,7 +10,7 @@ import { useMagicNet } from "@/composables/useMagicNet";
 import { copyText } from "@/utils";
 import ToolActionConfirmCard from "./ToolActionConfirmCard.vue";
 import type { PendingToolAction } from "./toolActions";
-import { buildConfigAudit, buildConfigOutline, sanitizeConfigText } from "./configEditorInsights";
+import { buildConfigAudit, buildConfigOutline, buildUnifiedConfigDiff, MAX_CONFIG_ISSUE_DIFF_BYTES, sanitizeConfigText } from "./configEditorInsights";
 
 const { state, loadConfig, saveConfig, syncConfigTemplate, openExternal, REPO } = useMagicNet();
 const { isRunning, withAction } = useActionLock();
@@ -18,6 +18,7 @@ const pendingConfigAction = ref<PendingToolAction | null>(null);
 const localJsonStatus = ref("");
 const sanitizedCopied = ref(false);
 const auditCopied = ref(false);
+const issueBaseline = ref("");
 const configStats = computed(() => {
   const text = state.config.text;
   const lines = text ? text.split(/\r?\n/).length : 0;
@@ -57,6 +58,11 @@ function requestSaveConfig(): void {
     command: `config-editor save-file ${state.config.target} <editor-temp-file>`,
     run: () => withAction("save-config", () => saveConfig()),
   });
+}
+
+async function loadConfigForEditing(): Promise<void> {
+  await loadConfig();
+  if (!state.config.dirty && state.config.text) issueBaseline.value = state.config.text;
 }
 
 function requestSyncTemplate(): void {
@@ -103,19 +109,37 @@ async function copyConfigAudit(): Promise<void> {
   state.output = auditCopied.value ? "配置审计摘要已复制。" : "剪贴板不可用，配置审计摘要未复制。";
 }
 
-function issueUrl(): string {
+async function openConfigIssue(): Promise<void> {
+  if (!issueBaseline.value) {
+    state.output = "请先加载配置，再生成 Diff Issue。";
+    return;
+  }
+  let diff: string;
+  try {
+    diff = buildUnifiedConfigDiff(issueBaseline.value, state.config.text);
+  } catch (error) {
+    state.output = `无法生成安全 Diff：${error instanceof Error ? error.message : String(error)}`;
+    return;
+  }
+  if (!diff) {
+    state.output = "配置没有可提交的变更。";
+    return;
+  }
+  if (new TextEncoder().encode(diff).length > MAX_CONFIG_ISSUE_DIFF_BYTES) {
+    state.output = "安全 Diff 超过 24 KiB，未复制或打开 Issue；请缩小单次配置变更。";
+    return;
+  }
+  const copied = await copyText(`\`\`\`diff\n${diff}\n\`\`\``);
   const body = [
-    "已尝试过滤 URL、token、secret、password 等敏感字段；创建前仍需人工检查，避免提交私有订阅或密钥。",
+    "## Proposed Change",
     "",
-    "## Target",
-    state.config.target,
+    copied ? "脱敏 unified diff 已复制到剪贴板，请粘贴到此处。" : "剪贴板不可用，请返回 MagicNet 重新复制脱敏 diff。",
     "",
-    "## Sanitized Config",
-    "```",
-    sanitizedConfig.value.slice(0, 12000),
-    "```"
+    `Target: ${state.config.target}`,
+    "",
+    "创建前仍需人工检查，避免提交私有订阅、密钥或节点信息。"
   ].join("\n");
-  return `${REPO}/issues/new?${new URLSearchParams({ title: `配置变更建议：${state.config.target}`, body }).toString()}`;
+  openExternal(`${REPO}/issues/new?${new URLSearchParams({ title: `配置变更建议：${state.config.target}`, body }).toString()}`, "配置 Diff Issue");
 }
 </script>
 
@@ -123,12 +147,12 @@ function issueUrl(): string {
   <div class="grid gap-4">
     <PageHeader overline="Validated Editor" title="配置编辑器" description="高级配置入口：编辑 sing-box config.json；订阅链接请到订阅页填写。">
       <div class="flex flex-wrap items-center gap-2">
-        <Button variant="outline" :loading="isRunning('load-config')" @click="withAction('load-config', () => loadConfig())"><RefreshCw :size="17" />{{ isRunning('load-config') ? '加载中' : '加载配置' }}</Button>
+        <Button variant="outline" :loading="isRunning('load-config')" @click="withAction('load-config', loadConfigForEditing)"><RefreshCw :size="17" />{{ isRunning('load-config') ? '加载中' : '加载配置' }}</Button>
         <Button variant="outline" :loading="isRunning('sync-template')" @click="requestSyncTemplate"><DownloadCloud :size="17" />{{ isRunning('sync-template') ? '同步中' : '同步上游模板' }}</Button>
         <Button variant="outline" :disabled="!state.config.text" @click="formatConfigJson"><Braces :size="17" />格式化 JSON</Button>
         <Button variant="outline" :disabled="!state.config.text" @click="copySanitizedConfig"><Copy :size="17" />{{ sanitizedCopied ? '已复制脱敏' : '复制脱敏' }}</Button>
         <Button :loading="isRunning('save-config')" @click="requestSaveConfig"><Save :size="17" />{{ isRunning('save-config') ? '校验中' : '校验并保存' }}</Button>
-        <Button variant="outline" @click="openExternal(issueUrl(), '配置 Diff Issue')"><Github :size="17" />创建 Diff Issue</Button>
+        <Button variant="outline" @click="openConfigIssue"><Github :size="17" />创建 Diff Issue</Button>
       </div>
     </PageHeader>
 

--- a/webui/src/components/pages/configEditorInsights.ts
+++ b/webui/src/components/pages/configEditorInsights.ts
@@ -58,6 +58,81 @@ export function sanitizeConfigText(text: string): string {
     .replace(SENSITIVE_BARE_FIELD_PATTERN, (_match, prefix: string) => `${prefix}[filtered]`);
 }
 
+const SAFE_INBOUND_TYPES = new Set(["tun", "mixed", "direct"]);
+const SAFE_TUN_STACKS = new Set(["system", "gvisor", "mixed"]);
+const SAFE_BOOLEAN_KEYS = ["auto_route", "auto_redirect", "strict_route"] as const;
+const ISSUE_DIFF_CONTEXT = 3;
+export const MAX_CONFIG_ISSUE_DIFF_BYTES = 24 * 1024;
+
+export function sanitizeConfigForIssue(text: string): string {
+  const parsed = JSON.parse(text) as unknown;
+  if (!isRecord(parsed)) throw new Error("配置根节点不是 JSON object。");
+  const inbounds = arrayRecords(parsed.inbounds).map((inbound, index) => {
+    const type = stringValue(inbound.type);
+    const safe: Record<string, unknown> = {
+      id: `inbound-${index + 1}`,
+      type: SAFE_INBOUND_TYPES.has(type) ? type : "other"
+    };
+    if (type === "tun") {
+      const stack = stringValue(inbound.stack);
+      if (SAFE_TUN_STACKS.has(stack)) safe.stack = stack;
+      if (typeof inbound.mtu === "number" && Number.isSafeInteger(inbound.mtu)) safe.mtu = inbound.mtu;
+      for (const key of SAFE_BOOLEAN_KEYS) if (typeof inbound[key] === "boolean") safe[key] = inbound[key];
+    }
+    return safe;
+  });
+  const safe = {
+    format: "magicnet-config-diff-v1",
+    structure: {
+      inbound_count: inbounds.length,
+      outbound_count: Array.isArray(parsed.outbounds) ? parsed.outbounds.length : 0,
+      route_rule_count: isRecord(parsed.route) && Array.isArray(parsed.route.rules) ? parsed.route.rules.length : 0,
+      dns_server_count: isRecord(parsed.dns) && Array.isArray(parsed.dns.servers) ? parsed.dns.servers.length : 0
+    },
+    inbounds
+  };
+  return `${JSON.stringify(safe, null, 2)}\n`;
+}
+
+export function buildUnifiedConfigDiff(before: string, after: string): string {
+  const beforeRaw = parseIssueConfig(before);
+  const afterRaw = parseIssueConfig(after);
+  const beforeSafe = JSON.parse(sanitizeConfigForIssue(before)) as Record<string, unknown>;
+  const afterSafe = JSON.parse(sanitizeConfigForIssue(after)) as Record<string, unknown>;
+  const changedSections = (["inbounds", "outbounds", "route", "dns"] as const)
+    .filter((key) => JSON.stringify(beforeRaw[key]) !== JSON.stringify(afterRaw[key]));
+  if (changedSections.length) {
+    beforeSafe.change_markers = Object.fromEntries(changedSections.map((key) => [key, "before"]));
+    afterSafe.change_markers = Object.fromEntries(changedSections.map((key) => [key, "after"]));
+  }
+  const oldLines = JSON.stringify(beforeSafe, null, 2).split("\n");
+  const newLines = JSON.stringify(afterSafe, null, 2).split("\n");
+  let prefix = 0;
+  while (prefix < oldLines.length && prefix < newLines.length && oldLines[prefix] === newLines[prefix]) prefix++;
+  if (prefix === oldLines.length && prefix === newLines.length) return "";
+  let suffix = 0;
+  while (suffix < oldLines.length - prefix && suffix < newLines.length - prefix && oldLines[oldLines.length - 1 - suffix] === newLines[newLines.length - 1 - suffix]) suffix++;
+  const oldStart = Math.max(0, prefix - ISSUE_DIFF_CONTEXT);
+  const newStart = Math.max(0, prefix - ISSUE_DIFF_CONTEXT);
+  const oldEnd = Math.min(oldLines.length, oldLines.length - suffix + ISSUE_DIFF_CONTEXT);
+  const newEnd = Math.min(newLines.length, newLines.length - suffix + ISSUE_DIFF_CONTEXT);
+  const contextBefore = oldLines.slice(oldStart, prefix).map((line) => ` ${line}`);
+  const removed = oldLines.slice(prefix, oldLines.length - suffix).map((line) => `-${line}`);
+  const added = newLines.slice(prefix, newLines.length - suffix).map((line) => `+${line}`);
+  const contextAfter = oldLines.slice(oldLines.length - suffix, oldEnd).map((line) => ` ${line}`);
+  return [
+    "--- config.before.json", "+++ config.after.json",
+    `@@ -${oldStart + 1},${oldEnd - oldStart} +${newStart + 1},${newEnd - newStart} @@`,
+    ...contextBefore, ...removed, ...added, ...contextAfter
+  ].join("\n");
+}
+
+function parseIssueConfig(text: string): Record<string, unknown> {
+  const parsed = JSON.parse(text) as unknown;
+  if (!isRecord(parsed)) throw new Error("配置根节点不是 JSON object。");
+  return parsed;
+}
+
 export function buildConfigOutline(text: string): ConfigOutline {
   const trimmed = text.trim();
   if (!trimmed) {


### PR DESCRIPTION
Fixes #27.
- set managed sing-box TUN MTU to 1400
- replace full/truncated config issue payloads with compact unified diffs
- use fail-closed structural redaction for nodes and private config
- cover jq and jq-less paths plus disclosure regressions

## Summary by Sourcery

通过紧凑统一 diff 实现安全配置问题上报，并更新受管 TUN 设置。

New Features:
- 为配置变更问题生成紧凑且大小受限的统一 diff，用以替代在问题草稿中直接嵌入完整配置。

Bug Fixes:
- 确保编排器在透明模式下始终为入站流量配置 MTU 为 1400 的 gVisor TUN，以提升上传性能。
- 通过采用“失败即关闭”的结构化脱敏策略，防止配置问题负载泄露节点端点、凭据或私有配置值。

Enhancements:
- 在 WebUI 中跟踪干净的配置基线，使问题 diff 仅包含有意义的变更。
- 改进 WebUI 的问题创建流程，引导用户粘贴已脱敏的 diff，并手动核查敏感数据。
- 为已脱敏的配置结构添加变更标记，使 diff 能高亮显示哪些主要部分被修改，而不暴露原始值。

Build:
- 将项目版本元数据在发布和更新描述中提升到 v1.1.14。

Tests:
- 添加 WebUI 侧测试，验证配置问题草稿在脱敏后不会泄露“金丝雀”密钥，并确保统一 diff 保持紧凑且正确标记已变更的部分。
- 扩展编排器冒烟测试，覆盖无 jq 时的 awk 回退路径，并验证在生成的配置中新的 TUN MTU 和协议栈设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Secure configuration issue reporting with compact unified diffs and update managed TUN settings.

New Features:
- Add generation of compact, size-bounded unified diffs for configuration change issues to replace embedding full configs in issue drafts.

Bug Fixes:
- Ensure orchestrator transparent mode consistently provisions a gVisor TUN inbound with MTU 1400 for better upload performance.
- Prevent configuration issue payloads from leaking node endpoints, credentials, or private config values by applying fail-closed structural redaction.

Enhancements:
- Track a clean configuration baseline in the WebUI so issue diffs only include meaningful changes.
- Improve WebUI issue creation flow to guide users to paste sanitized diffs and manually verify sensitive data.
- Add change markers to sanitized config structures so diffs highlight which major sections were modified without exposing raw values.

Build:
- Bump project version metadata to v1.1.14 in release and update descriptors.

Tests:
- Add WebUI-side tests to verify sanitized config issue drafts never leak canary secrets and that unified diffs remain compact and correctly mark changed sections.
- Extend orchestrator smoke tests to cover jq-less awk fallback paths and validate the new TUN MTU and stack settings in generated configs.

</details>