### PR TITLE
feat(adblock): add prioritized whitelist routing

### DIFF
--- a/scripts/test-ad-routing.sh
+++ b/scripts/test-ad-routing.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+
+set -eu
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT HUP INT TERM
+
+MODDIR="$WORK/module"
+export MODDIR
+mkdir -p "$MODDIR/.config/magicnet" "$MODDIR/.config/sing-box"
+
+. "$ROOT/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh"
+. "$ROOT/src/MagicNet/lib/magicnet/blocklist.sh"
+
+cat >"$MODDIR/.config/magicnet/block-allow-rules.list" <<'EOF'
+DOMAIN,ads.example.com
+DOMAIN-SUFFIX,example.org
+DOMAIN-KEYWORD,sponsor
+EOF
+cat >"$MODDIR/.config/magicnet/community-ban-rules.list" <<'EOF'
+DOMAIN,ads.example.com
+DOMAIN-SUFFIX,blocked.example
+EOF
+cat >"$MODDIR/.config/sing-box/config.json" <<'EOF'
+{
+  "outbounds": [
+    {
+      "type": "selector",
+      "tag": "ad-block",
+      "outbounds": ["block", "direct"],
+      "default": "direct"
+    },
+    {
+      "type": "direct",
+      "tag": "direct"
+    },
+    {
+      "type": "block",
+      "tag": "block"
+    }
+  ],
+  "route": {
+    "rules": [
+      {
+        "inbound": ["tun-in"],
+        "action": "sniff"
+      },
+      {
+        "rule_set": "ads",
+        "outbound": "ad-block"
+      }
+    ]
+  }
+}
+EOF
+
+magicnet_block_apply_singbox
+magicnet_block_apply_singbox
+
+CONFIG="$MODDIR/.config/sing-box/config.json"
+[ "$(grep -c '__magicnet_ad_allow__' "$CONFIG")" -eq 1 ]
+[ "$(grep -c '__magicnet_block__' "$CONFIG")" -eq 1 ]
+[ "$(grep -c '"tag": "ad-block"' "$CONFIG")" -eq 1 ]
+[ "$(grep -c '"tag": "ad-allow"' "$CONFIG")" -eq 1 ]
+grep -q '"outbound": "ad-allow"' "$CONFIG"
+grep -q '"outbound": "ad-block"' "$CONFIG"
+grep -q '"ads.example.com"' "$CONFIG"
+grep -q '"example.org"' "$CONFIG"
+grep -q '"sponsor"' "$CONFIG"
+if grep -A8 '__magicnet_block__' "$CONFIG" | grep -q 'ads.example.com'; then
+  exit 1
+fi
+
+ALLOW_LINE=$(grep -n '__magicnet_ad_allow__' "$CONFIG" | cut -d: -f1)
+BLOCK_LINE=$(grep -n '__magicnet_block__' "$CONFIG" | cut -d: -f1)
+STATIC_LINE=$(grep -n '"rule_set": "ads"' "$CONFIG" | cut -d: -f1)
+[ "$ALLOW_LINE" -lt "$BLOCK_LINE" ]
+[ "$BLOCK_LINE" -lt "$STATIC_LINE" ]
+
+: >"$MODDIR/.config/magicnet/block-allow-rules.list"
+magicnet_block_apply_singbox
+if grep -q '__magicnet_ad_allow__' "$CONFIG"; then
+  exit 1
+fi
+
+grep -Fq 'selector("ad-block"; ["block", "direct", "proxy"]; "block")' \
+  "$ROOT/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh"
+grep -Fq 'selector("ad-allow"; ["direct", "proxy"]; "direct")' \
+  "$ROOT/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh"
+
+if command -v jq >/dev/null 2>&1; then
+  jq -e '
+    (.outbounds[] | select(.tag == "ad-block") | .outbounds == ["block", "direct", "proxy"] and .default == "block") and
+    (.outbounds[] | select(.tag == "ad-allow") | .outbounds == ["direct", "proxy"] and .default == "direct") and
+    (.outbounds[] | select(.tag == "ad-block") | .outbounds == ["block", "direct", "proxy"]) and
+    (.outbounds[] | select(.tag == "ad-allow") | .outbounds == ["direct", "proxy"])
+  ' "$ROOT/src/MagicNet/.config/sing-box/config.json" >/dev/null
+  jq empty "$CONFIG"
+  [ "$(jq '[.route.rules[] | select(has("domain") and (.domain | index("__magicnet_ad_allow__")))] | length' "$CONFIG")" -eq 0 ]
+fi
+
+printf '%s\n' 'ad routing regression tests passed'

--- a/src/MagicNet/lib/magicnet/blocklist.sh
+++ b/src/MagicNet/lib/magicnet/blocklist.sh
@@ -74,6 +74,45 @@ magicnet_block_has_domains() {
     magicnet_block_all_rules | grep -q .
 }
 
+magicnet_block_emit_match_array() {
+    _emit_key="$1"
+    _emit_values="$2"
+    [ -n "$_emit_values" ] || return 0
+    printf ',\n        "%s": [\n' "$_emit_key"
+    _emit_count=$(printf '%s\n' "$_emit_values" | awk 'NF' | wc -l | tr -d ' ')
+    _emit_idx=0
+    printf '%s\n' "$_emit_values" | while read -r _emit_value; do
+        [ -n "$_emit_value" ] || continue
+        _emit_idx=$((_emit_idx + 1))
+        _emit_comma=","; [ "$_emit_idx" -eq "$_emit_count" ] && _emit_comma=""
+        printf '          "%s"%s\n' "$(magicnet_json_escape "$_emit_value")" "$_emit_comma"
+    done
+    printf '        ]'
+    unset _emit_key _emit_values _emit_count _emit_idx _emit_value _emit_comma
+}
+
+magicnet_block_allow_singbox_rules() {
+    _rules="$(magicnet_block_list_values "$(magicnet_block_allow_file)")"
+    [ -n "$_rules" ] || return 0
+    _domains="$(printf '%s\n' "$_rules" | awk -F, '$1 == "DOMAIN" { print $2 }' | awk 'NF && !seen[$0]++')"
+    _suffixes="$(printf '%s\n' "$_rules" | awk -F, '$1 == "DOMAIN-SUFFIX" { print $2 }' | awk 'NF && !seen[$0]++')"
+    _keywords="$(printf '%s\n' "$_rules" | awk -F, '$1 == "DOMAIN-KEYWORD" { print $2 }' | awk 'NF && !seen[$0]++')"
+    printf '      {\n'
+    printf '        "domain": ["__magicnet_ad_allow__"'
+    if [ -n "$_domains" ]; then
+        printf '%s\n' "$_domains" | while read -r _domain; do
+            [ -n "$_domain" ] || continue
+            printf ', "%s"' "$(magicnet_json_escape "$_domain")"
+        done
+    fi
+    printf ']'
+    magicnet_block_emit_match_array "domain_suffix" "$_suffixes"
+    magicnet_block_emit_match_array "domain_keyword" "$_keywords"
+    printf ',\n        "outbound": "ad-allow"\n'
+    printf '      },\n'
+    unset _rules _domains _suffixes _keywords _domain
+}
+
 magicnet_block_singbox_rules() {
     _rules="$(magicnet_block_all_rules)"
     [ -n "$_rules" ] || return 0
@@ -125,18 +164,100 @@ magicnet_block_singbox_rules() {
         printf '        ]'
     fi
     printf ',\n'
-    printf '        "outbound": "block"\n'
+    printf '        "outbound": "ad-block"\n'
     printf '      },\n'
     unset _rules _domains _suffixes _keywords _count _idx _comma _domain
+}
+
+magicnet_block_ensure_ad_selectors() {
+    _selector_config="$1"
+    _selector_tmp="${_selector_config}.magicnet-selectors.new"
+    _selector_has_allow=0
+    grep -q '"tag"[[:space:]]*:[[:space:]]*"ad-allow"' "$_selector_config" && _selector_has_allow=1
+    awk -v has_allow="$_selector_has_allow" '
+        function emit_block(comma) {
+            print "    {"
+            print "      \"type\": \"selector\","
+            print "      \"tag\": \"ad-block\","
+            print "      \"outbounds\": [\"block\", \"direct\", \"proxy\"],"
+            print "      \"default\": \"block\""
+            print "    }" comma
+        }
+        function emit_allow(comma) {
+            print "    {"
+            print "      \"type\": \"selector\","
+            print "      \"tag\": \"ad-allow\","
+            print "      \"outbounds\": [\"direct\", \"proxy\"],"
+            print "      \"default\": \"direct\""
+            print "    }" comma
+        }
+        function brace_delta(s, i, c, d) {
+            d = 0
+            for (i = 1; i <= length(s); i++) {
+                c = substr(s, i, 1)
+                if (c == "{") d++
+                if (c == "}") d--
+            }
+            return d
+        }
+        BEGIN { in_outbounds = 0; buffering = 0; depth = 0; buffer = ""; found_block = 0 }
+        {
+            if (buffering) {
+                buffer = buffer $0 "\n"
+                depth += brace_delta($0)
+                if ($0 ~ /"tag"[[:space:]]*:[[:space:]]*"ad-block"/) tag = "block"
+                if ($0 ~ /"tag"[[:space:]]*:[[:space:]]*"ad-allow"/) tag = "allow"
+                if (depth <= 0) {
+                    comma = ($0 ~ /},[[:space:]]*$/) ? "," : ""
+                    if (tag == "block") {
+                        emit_block(has_allow ? comma : ",")
+                        found_block = 1
+                        if (!has_allow) emit_allow(comma)
+                    } else if (tag == "allow") {
+                        emit_allow(comma)
+                    } else {
+                        printf "%s", buffer
+                    }
+                    buffering = 0; buffer = ""; tag = ""
+                }
+                next
+            }
+            if ($0 ~ /^  "outbounds"[[:space:]]*:[[:space:]]*\[[[:space:]]*$/) {
+                in_outbounds = 1
+                print
+                next
+            }
+            if (in_outbounds && $0 ~ /^    \{[[:space:]]*$/) {
+                buffering = 1; buffer = $0 "\n"; depth = 1; tag = ""
+                next
+            }
+            if (in_outbounds && $0 ~ /^  ][,]?[[:space:]]*$/) {
+                if (!found_block) exit 42
+                in_outbounds = 0
+            }
+            print
+        }
+    ' "$_selector_config" >"$_selector_tmp" || {
+        _selector_rc=$?
+        rm -f "$_selector_tmp"
+        unset _selector_config _selector_tmp _selector_has_allow _selector_rc
+        return 1
+    }
+    mv -f "$_selector_tmp" "$_selector_config"
+    unset _selector_config _selector_tmp _selector_has_allow
 }
 
 magicnet_block_apply_singbox() {
     _config="${MODDIR}/.config/sing-box/config.json"
     [ -f "$_config" ] || return 0
+    magicnet_block_ensure_ad_selectors "$_config" || return 1
     _tmp="${_config}.magicnet-block.new"
     _rules_file="${MODDIR}/.tmp/magicnet-block-singbox.rules"
     mkdir -p "${_rules_file%/*}"
-    magicnet_block_singbox_rules >"$_rules_file"
+    {
+        magicnet_block_allow_singbox_rules
+        magicnet_block_singbox_rules
+    } >"$_rules_file"
     if awk -v rules_file="$_rules_file" '
         BEGIN {
             in_route = 0
@@ -167,7 +288,7 @@ magicnet_block_apply_singbox() {
         {
             if (buffering) {
                 buffer = buffer $0 "\n"
-                if ($0 ~ /"__magicnet_block__"/) {
+                if ($0 ~ /"__magicnet_(ad_allow|block)__"/) {
                     skip_custom = 1
                 }
                 if ($0 ~ /^      }[,]?[[:space:]]*$/) {

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
@@ -100,7 +100,8 @@ magicnet_singbox_build_outbounds_file_with_jq() {
           selector("proxy"; $tags; preferred_proxy_tag($tags)),
           selector("select"; ["proxy", "direct"]; "proxy"),
           selector("lan"; ["direct"]; "direct"),
-          selector("ad-block"; ["block", "direct"]; "block"),
+          selector("ad-block"; ["block", "direct", "proxy"]; "block"),
+          selector("ad-allow"; ["direct", "proxy"]; "direct"),
           selector("cn-direct"; ["direct"]; "direct"),
           selector("apple-cn"; ["direct", "proxy"]; "direct"),
           selector("microsoft-cn"; ["direct", "proxy"]; "direct"),
@@ -195,13 +196,17 @@ magicnet_singbox_pick_default_proxy_tag() {
 
 magicnet_singbox_emit_static_selectors() {
     for _pair in \
-        "lan::direct" "ad-block::block" "cn-direct::direct" \
+        "lan::direct" "cn-direct::direct" \
         "apple-cn::direct" "microsoft-cn::direct" "google-cn::proxy" "icloud::direct"; do
         _name=${_pair%%:*}
         _default=${_pair##*:}
         printf ',\n'
         magicnet_emit_selector_json "$_name" "" "$_default"
     done
+    printf ',\n'
+    magicnet_emit_selector_json "ad-block" "$(printf '%s\n%s\n%s\n' "block" "direct" "proxy")" "block"
+    printf ',\n'
+    magicnet_emit_selector_json "ad-allow" "$(printf '%s\n%s\n' "direct" "proxy")" "direct"
     printf ',\n'
     magicnet_emit_selector_json "bing" "$(printf '%s\n%s\n' "proxy" "direct")" "proxy"
     printf ',\n'

--- a/webui/src/components/pages/BlocklistPage.vue
+++ b/webui/src/components/pages/BlocklistPage.vue
@@ -15,6 +15,7 @@ const { isRunning, withAction } = useActionLock();
 const pendingBlockAction = ref<PendingBlockAction | null>(null);
 const snapshotCopied = ref(false);
 const blockQuery = ref("");
+const allowRuleInput = ref("");
 const COMMUNITY_SNAPSHOT_LIMIT = 40;
 
 type PendingBlockAction = {
@@ -92,8 +93,8 @@ async function allowRule(rule: string): Promise<void> {
     const suffix = rule.replace(/^DOMAIN-SUFFIX,/, "");
     if (suffix !== rule) state.blocklist.communityDomains = state.blocklist.communityDomains.filter((item) => item !== suffix);
     if (!state.blocklist.allowRules.includes(rule)) state.blocklist.allowRules.push(rule);
-    state.output = `正在加入本地排除：${rule}`;
-    const text = await runCli(`block allow-rule ${shellQuote(rule)}`, `本地排除 ${rule}`, true);
+    state.output = `正在加入广告放行白名单：${rule}`;
+    const text = await runCli(`block allow-rule ${shellQuote(rule)}`, `广告放行 ${rule}`, true);
     if (text.includes("[error]")) {
       state.output = text;
       state.blocklist.allowRules = state.blocklist.allowRules.filter((item) => item !== rule);
@@ -102,15 +103,43 @@ async function allowRule(rule: string): Promise<void> {
       } else if (!state.blocklist.communityRules.includes(rule)) state.blocklist.communityRules.unshift(rule);
       return;
     }
-    state.output = `已加入本地排除：${rule}`;
+    allowRuleInput.value = "";
+    state.output = `已加入广告放行白名单：${rule}`;
   });
+}
+
+function normalizeAllowRule(input: string): string | null {
+  const raw = input.trim();
+  const candidate = raw.includes(",") ? raw : `DOMAIN-SUFFIX,${raw}`;
+  const match = candidate.match(/^(DOMAIN|DOMAIN-SUFFIX|DOMAIN-KEYWORD),(.+)$/i);
+  if (!match || !match[2].trim() || /\s/.test(match[2])) {
+    state.output = "白名单格式不对。支持 example.com、DOMAIN,example.com、DOMAIN-SUFFIX,example.com 或 DOMAIN-KEYWORD,example。";
+    return null;
+  }
+  const rule = `${match[1].toUpperCase()},${match[2].trim().toLowerCase()}`;
+  if (state.blocklist.allowRules.includes(rule)) {
+    state.output = `${rule} 已在广告放行白名单中。`;
+    return null;
+  }
+  return rule;
+}
+
+function requestAddAllowRule(): void {
+  const rule = normalizeAllowRule(allowRuleInput.value);
+  if (!rule) return;
+  pendingBlockAction.value = {
+    key: `allow-${rule}`,
+    command: `block allow-rule ${rule}`,
+    message: `确认把 ${rule} 加入广告放行白名单？它会优先于所有广告阻断规则，并通过 ad-allow 组选择 Direct 或 Proxy。`,
+    run: () => allowRule(rule)
+  };
 }
 
 function requestAllowRule(rule: string): void {
   pendingBlockAction.value = {
     key: `allow-${rule}`,
     command: `block allow-rule ${rule}`,
-    message: `确认把社区规则 ${rule} 加入本地排除？`,
+    message: `确认把社区规则 ${rule} 加入广告放行白名单？流量将由 ad-allow 组选择 Direct 或 Proxy。`,
     run: () => allowRule(rule)
   };
 }
@@ -234,7 +263,7 @@ async function confirmBlockAction(): Promise<void> {
 
 <template>
   <div class="grid gap-4">
-    <PageHeader overline="Community Banlist" title="联 ban 黑名单" description="本地规则和社区库排除都在这里。X 是排除社区规则，+ 是恢复阻断。">
+    <PageHeader overline="Community Banlist" title="联 ban 黑名单" description="广告放行白名单优先于所有广告阻断规则；ad-allow 组可选择 Direct 或 Proxy。">
       <div class="flex flex-wrap items-center gap-2">
         <Button variant="outline" :loading="isRunning('refresh-block')" @click="withAction('refresh-block', () => refreshBlock())"><RefreshCw :size="17" />读取</Button>
         <Button :loading="isRunning('update-block')" @click="requestUpdateCommunityBlocklist"><DownloadCloud :size="17" />更新社区库</Button>
@@ -304,7 +333,7 @@ async function confirmBlockAction(): Promise<void> {
       </div>
       <div class="relative">
         <Search class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-zinc-600" :size="16" />
-        <Input v-model="blockQuery" class="pl-9" placeholder="过滤本地阻断、社区规则和排除规则" spellcheck="false" />
+        <Input v-model="blockQuery" class="pl-9" placeholder="过滤本地阻断、社区规则和广告放行白名单" spellcheck="false" />
       </div>
     </Card>
 
@@ -332,13 +361,18 @@ async function confirmBlockAction(): Promise<void> {
       </Card>
 
       <Card>
-        <h3 class="mb-2 text-base font-semibold">本地排除</h3>
+        <h3 class="mb-1 text-base font-semibold">广告放行白名单</h3>
+        <p class="mb-3 text-sm leading-6 text-zinc-500">优先于内置、规则集和社区广告规则；放行方式由 ad-allow 组选择 Direct 或 Proxy。</p>
+        <div class="mb-3 grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+          <Input v-model="allowRuleInput" placeholder="example.com 或 DOMAIN-SUFFIX,example.com" spellcheck="false" @keyup.enter="requestAddAllowRule" />
+          <Button variant="secondary" :loading="isRunning(`allow-${allowRuleInput.trim()}`)" @click="requestAddAllowRule"><Plus :size="16" />加入白名单</Button>
+        </div>
         <div class="flex max-h-[26rem] flex-wrap gap-2 overflow-auto">
           <span v-for="rule in visibleAllowRules" :key="rule" class="inline-flex max-w-full items-center gap-1 rounded-full border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs break-all">
             {{ rule }}
             <button class="grid size-6 place-items-center rounded-full bg-zinc-800 text-zinc-50 disabled:cursor-progress disabled:opacity-60" :disabled="isRunning(`unallow-${rule}`)" type="button" title="恢复阻断" @click="requestUnallowRule(rule)"><Plus :size="14" /></button>
           </span>
-          <em v-if="!visibleAllowRules.length" class="text-sm not-italic text-zinc-500">{{ state.blocklist.allowRules.length ? '没有匹配项' : '暂无排除规则' }}</em>
+          <em v-if="!visibleAllowRules.length" class="text-sm not-italic text-zinc-500">{{ state.blocklist.allowRules.length ? '没有匹配项' : '暂无白名单规则' }}</em>
         </div>
       </Card>
     </div>

--- a/webui/src/components/pages/blocklistInsights.ts
+++ b/webui/src/components/pages/blocklistInsights.ts
@@ -46,7 +46,7 @@ export function buildBlocklistSummary(blocklist: BlocklistState): BlocklistSumma
       insight("社区库", blocklist.community ? "启用" : "关闭", blocklist.community ? "success" : "neutral"),
       insight("本地阻断", `${blocklist.manual.length} 条`, blocklist.manual.length ? "success" : "neutral"),
       insight("社区有效", `${communityEntries.length} 条`, communityEntries.length ? "success" : "warning"),
-      insight("本地排除", `${blocklist.allowRules.length} 条`, blocklist.allowRules.length ? "warning" : "neutral")
+      insight("广告放行", `${blocklist.allowRules.length} 条`, blocklist.allowRules.length ? "warning" : "neutral")
     ]
   };
 }


### PR DESCRIPTION
Fixes #26.
- route all advertising blocks through ad-block (block/direct/proxy)
- add higher-priority ad-allow (direct/proxy) whitelist routing
- support arbitrary DOMAIN, DOMAIN-SUFFIX and DOMAIN-KEYWORD whitelist entries in WebUI
- migrate preserved legacy selectors idempotently
- add routing precedence and upgrade regression coverage
- Dependency: LIghtJUNction/MagicSingBox#1