### PR TITLE
feat(routing): pin AI services to explicit nodes

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -34,6 +34,7 @@ mapfile -t posix_shell_files < <(
 shellcheck -s sh -e SC1091,SC1090,SC2329,SC2059 "${posix_shell_files[@]}"
 
 jq empty src/MagicNet/.config/sing-box/config.json
+bash scripts/test-anthropic-routing.sh
 bash scripts/singbox-subscription-protocol-smoke.sh
 
 KAM_HOOKS_ROOT=hooks KAM_MODULE_ROOT=src/MagicNet bash hooks/pre-build/6000.check_config.sh

--- a/scripts/test-anthropic-routing.sh
+++ b/scripts/test-anthropic-routing.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODULE_ROOT="$ROOT/src/MagicNet"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+fail() { printf 'pinned AI routing test failed: %s\n' "$*" >&2; exit 1; }
+# shellcheck disable=SC2034
+MODDIR="$MODULE_ROOT"
+. "$MODULE_ROOT/lib/magicnet_singbox_subscribe.sh"
+cat >"$tmp_dir/nodes.json" <<'JSON'
+[
+ {"type":"vless","tag":"US stable","server":"us.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000001"},
+ {"type":"vless","tag":"上海 node","server":"cn.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000002"},
+ {"type":"vless","tag":"CN node","server":"cn2.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000003"},
+ {"type":"vless","tag":"CN2 premium","server":"opaque.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000004"},
+ {"type":"vless","tag":"opaque-42","server":"opaque2.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000005"},
+ {"type":"vless","tag":"Mainland premium","server":"mainland.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000006"},
+ {"type":"vless","tag":"Beijing edge","server":"beijing.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000007"},
+ {"type":"vless","tag":"Shanghai edge","server":"shanghai.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000008"},
+ {"type":"vless","tag":"Guangzhou edge","server":"guangzhou.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000009"},
+ {"type":"vless","tag":"Shenzhen edge","server":"shenzhen.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000010"},
+ {"type":"vless","tag":"Sichuan edge","server":"sichuan.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000011"},
+ {"type":"vless","tag":"Inner-Mongolia edge","server":"mongolia.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000012"},
+ {"type":"vless","tag":"Xinjiang edge","server":"xinjiang.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000013"}
+]
+JSON
+magicnet_singbox_write_outbounds_from_json "$tmp_dir/nodes.json" "$tmp_dir/outbounds.fragment"
+{ printf '{\n'; sed 's/,$//' "$tmp_dir/outbounds.fragment"; printf '\n}\n'; } >"$tmp_dir/generated.json"
+jq -e '
+  ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] as $names
+  | [.outbounds[] | select(.tag as $tag | $names | index($tag))] as $groups
+  | ($groups | length) == 4
+    and ($groups | all(.type == "selector" and .default == "block" and .outbounds == ["block", "US stable", "CN2 premium", "opaque-42"] and (.outbounds | index("proxy") == null and index("direct") == null)))
+' "$tmp_dir/generated.json" >/dev/null || fail "jq generator selector mismatch"
+printf '%s\n' 'US stable' '上海 node' 'CN node' 'CN2 premium' 'opaque-42' 'Mainland premium' 'Beijing edge' 'Shanghai edge' 'Guangzhou edge' 'Shenzhen edge' 'Sichuan edge' 'Inner-Mongolia edge' 'Xinjiang edge' >"$tmp_dir/tags"
+magicnet_singbox_emit_selector_block "$tmp_dir/tags" 'US stable' >"$tmp_dir/no-jq.fragment"
+{ printf '{"outbounds":['; cat "$tmp_dir/no-jq.fragment"; printf ']}\n'; } >"$tmp_dir/no-jq.json"
+jq -e '
+  ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] as $names
+  | [.outbounds[] | select(.tag as $tag | $names | index($tag))] as $groups
+  | ($groups | length) == 4
+    and ($groups | all(.type == "selector" and .default == "block" and .outbounds == ["block", "US stable", "CN2 premium", "opaque-42"] and (.outbounds | index("proxy") == null and index("direct") == null)))
+' "$tmp_dir/no-jq.json" >/dev/null || fail "no-jq generator selector mismatch"
+magicnet_singbox_pinned_ai_tags "$tmp_dir/tags" >"$tmp_dir/pinned-ai-tags"
+grep -Fxq 'CN2 premium' "$tmp_dir/pinned-ai-tags" || fail "CN2 false positive"
+grep -Fxq 'opaque-42' "$tmp_dir/pinned-ai-tags" || fail "opaque node filtered"
+! grep -Fxq '上海 node' "$tmp_dir/pinned-ai-tags" || fail "mainland node retained"
+for tag in 'Mainland premium' 'Beijing edge' 'Shanghai edge' 'Guangzhou edge' 'Shenzhen edge' 'Sichuan edge' 'Inner-Mongolia edge' 'Xinjiang edge'; do
+  ! grep -Fxq "$tag" "$tmp_dir/pinned-ai-tags" || fail "English mainland label retained: $tag"
+done
+jq -e '
+  ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] as $names
+  | [.outbounds[] | select(.tag as $tag | $names | index($tag))]
+  | length == 4 and all(.default == "block" and .outbounds == ["block"])
+' "$MODULE_ROOT/.config/sing-box/config.json" >/dev/null || fail "base config not fail closed"
+python3 - "$MODULE_ROOT/.config/sing-box/config.json" <<'PY'
+import json, sys
+c = json.load(open(sys.argv[1], encoding="utf-8")); rules = c["route"]["rules"]
+groups = {"ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"}
+generic = next(i for i, r in enumerate(rules) if r.get("outbound") == "ai-proxy" and "rule_set" in r)
+assert all(any(i < generic and r.get("outbound") == group for i, r in enumerate(rules)) for group in groups)
+domains = {}
+for rule in rules:
+    if rule.get("outbound") in groups:
+        for domain in rule.get("domain_suffix", []):
+            assert domain not in domains, (domain, domains[domain], rule["outbound"])
+            domains[domain] = rule["outbound"]
+for rule in rules:
+    if rule.get("outbound") == "ai-proxy":
+        assert not (set(rule.get("domain_suffix", [])) & set(domains))
+packages = {r["outbound"]: set(r.get("package_name", [])) for r in rules if r.get("outbound") in groups and "package_name" in r}
+assert {"com.openai.chatgpt", "com.openai.chat", "ai.openai.chatgpt"} <= packages["ai-chatgpt"]
+assert "com.google.android.apps.bard" in packages["ai-gemini"]
+assert "ai.x.grok" in packages["ai-grok"]
+assert "com.anthropic.claude" in packages["ai-claude"]
+PY
+printf 'pinned AI routing test passed\n'

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
@@ -70,6 +70,11 @@ magicnet_singbox_build_outbounds_file_with_jq() {
     def selector($tag; $outs; $fallback):
       (with_base($outs; $fallback)) as $items
       | {"type": "selector", "tag": $tag, "outbounds": $items, "default": $items[0]};
+    def mainland_node_tag:
+      test("中国|大陆|内地|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:China|Mainland|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
+    def pinned_ai_selector($tag; $tags):
+      (["block"] + [$tags[]? | select(mainland_node_tag | not)]) as $items
+      | {"type": "selector", "tag": $tag, "outbounds": $items, "default": "block"};
     def proxy_tag_score($tag):
       if ($tag | test("免费|Free|free|公益|试用|下载专用|剩余|到期|过期|套餐|官网|订阅|Traffic|traffic|Expire|expire|Expired|expired|Subscription|subscription|官方网站|更新订阅")) then 0
       elif ($tag | test("IEPL|IPLC|专线|S[0-9]+|倍率|x1|x2|香港|日本|新加坡|美国|台湾|韩国")) then 2
@@ -110,6 +115,10 @@ magicnet_singbox_build_outbounds_file_with_jq() {
           selector("bing"; ["proxy", "direct"]; "proxy"),
           selector("dns-guard"; ["proxy", "block", "direct"]; "proxy"),
           selector("network-test"; ["proxy", "direct"]; "proxy"),
+          pinned_ai_selector("ai-chatgpt"; $tags),
+          pinned_ai_selector("ai-gemini"; $tags),
+          pinned_ai_selector("ai-grok"; $tags),
+          pinned_ai_selector("ai-claude"; $tags),
           selector("ai-proxy"; ["proxy", "direct"]; "proxy"),
           selector("proxy-rule"; ["proxy", "direct"]; "proxy"),
           selector("dev-proxy"; ["proxy", "direct"]; "proxy"),
@@ -213,6 +222,14 @@ magicnet_singbox_emit_static_selectors() {
     magicnet_emit_selector_json "dns-guard" "$(printf '%s\n%s\n%s\n' "proxy" "block" "direct")" "proxy"
     printf ',\n'
     magicnet_emit_selector_json "network-test" "$(printf '%s\n%s\n' "proxy" "direct")" "proxy"
+    printf ',\n'
+    _pinned_ai_tags=$(magicnet_singbox_pinned_ai_tags "$_tags_file")
+    _pinned_ai_first=1
+    for _name in ai-chatgpt ai-gemini ai-grok ai-claude; do
+        [ "$_pinned_ai_first" -eq 1 ] || printf ',\n'
+        magicnet_singbox_emit_pinned_ai_selector "$_name" "$_pinned_ai_tags"
+        _pinned_ai_first=0
+    done
     for _name in ai-proxy proxy-rule dev-proxy social-proxy media-proxy game-proxy telegram-proxy; do
         printf ',\n'
         magicnet_emit_selector_json "$_name" "$(printf '%s\n%s\n' "proxy" "direct")" "proxy"
@@ -221,7 +238,39 @@ magicnet_singbox_emit_static_selectors() {
     magicnet_emit_selector_json "download-direct" "$(printf '%s\n%s\n' "direct" "proxy")" "direct"
     printf ',\n'
     magicnet_emit_selector_json "final" "$(printf '%s\n%s\n%s\n' "proxy" "direct" "block")" "proxy"
-    unset _pair _name _default
+    unset _pair _name _default _pinned_ai_tags _pinned_ai_first
+}
+
+magicnet_singbox_emit_pinned_ai_selector() {
+    _pinned_ai_name="$1"
+    _pinned_ai_members="$2"
+    printf '    {\n'
+    printf '      "type": "selector",\n'
+    printf '      "tag": "%s",\n' "$(magicnet_json_escape "$_pinned_ai_name")"
+    printf '      "outbounds": ['
+    _pinned_ai_member_first=1
+    while IFS= read -r _pinned_ai_member; do
+        [ -n "$_pinned_ai_member" ] || continue
+        [ "$_pinned_ai_member_first" -eq 1 ] || printf ', '
+        printf '"%s"' "$(magicnet_json_escape "$_pinned_ai_member")"
+        _pinned_ai_member_first=0
+    done <<EOF
+$_pinned_ai_members
+EOF
+    printf '],\n'
+    printf '      "default": "block"\n'
+    printf '    }'
+    unset _pinned_ai_name _pinned_ai_members _pinned_ai_member _pinned_ai_member_first
+}
+
+magicnet_singbox_pinned_ai_tags() {
+    _pinned_ai_tags_file="$1"
+    printf '%s\n' "block"
+    awk 'BEGIN { IGNORECASE = 1 }
+      !/中国|大陆|内地|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西/ &&
+      !/(^|[^[:alnum:]])(China|Mainland|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^[:alnum:]]|$)/ { print }
+    ' "$_pinned_ai_tags_file"
+    unset _pinned_ai_tags_file
 }
 
 magicnet_singbox_sanitize_generated_config() {


### PR DESCRIPTION
Fixes #29.\n\n- add separate fail-closed groups for ChatGPT, Gemini, Grok, and Claude\n- allow only block plus concrete non-mainland-labelled nodes\n- default every group to block with no proxy/direct/urltest fallback\n- add scoped product domain and verified Android package routes before generic AI routing\n- keep jq and jq-less subscription generation equivalent\n- add adversarial routing and filter regressions\n\nDependency: LIghtJUNction/MagicSingBox#2