### PR TITLE
fix(routing): exclude Hong Kong from pinned AI groups

### DIFF
--- a/scripts/test-anthropic-routing.sh
+++ b/scripts/test-anthropic-routing.sh
@@ -23,6 +23,16 @@ cat >"$tmp_dir/nodes.json" <<'JSON'
  {"type":"vless","tag":"Sichuan edge","server":"sichuan.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000011"},
  {"type":"vless","tag":"Inner-Mongolia edge","server":"mongolia.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000012"},
  {"type":"vless","tag":"Xinjiang edge","server":"xinjiang.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000013"}
+ ,{"type":"vless","tag":"香港 edge","server":"hk-cn.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000014"}
+ ,{"type":"vless","tag":"Hong Kong edge","server":"hongkong.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000015"}
+ ,{"type":"vless","tag":"Hong-Kong edge","server":"hong-kong.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000016"}
+ ,{"type":"vless","tag":"Hong_Kong edge","server":"hong_kong.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000017"}
+ ,{"type":"vless","tag":"HK edge","server":"hk.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000018"}
+ ,{"type":"vless","tag":"HKG edge","server":"hkg.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000019"}
+ ,{"type":"vless","tag":"HKT edge","server":"hkt.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000020"}
+ ,{"type":"vless","tag":"CHK edge","server":"chk.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000021"}
+ ,{"type":"vless","tag":"hk01 edge","server":"hk01.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000022"}
+ ,{"type":"vless","tag":"myhk edge","server":"myhk.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000023"}
 ]
 JSON
 magicnet_singbox_write_outbounds_from_json "$tmp_dir/nodes.json" "$tmp_dir/outbounds.fragment"
@@ -31,16 +41,16 @@ jq -e '
   ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] as $names
   | [.outbounds[] | select(.tag as $tag | $names | index($tag))] as $groups
   | ($groups | length) == 4
-    and ($groups | all(.type == "selector" and .default == "block" and .outbounds == ["block", "US stable", "CN2 premium", "opaque-42"] and (.outbounds | index("proxy") == null and index("direct") == null)))
+    and ($groups | all(.type == "selector" and .default == "block" and .outbounds == ["block", "US stable", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "hk01 edge", "myhk edge"] and (.outbounds | index("proxy") == null and index("direct") == null)))
 ' "$tmp_dir/generated.json" >/dev/null || fail "jq generator selector mismatch"
-printf '%s\n' 'US stable' '上海 node' 'CN node' 'CN2 premium' 'opaque-42' 'Mainland premium' 'Beijing edge' 'Shanghai edge' 'Guangzhou edge' 'Shenzhen edge' 'Sichuan edge' 'Inner-Mongolia edge' 'Xinjiang edge' >"$tmp_dir/tags"
+printf '%s\n' 'US stable' '上海 node' 'CN node' 'CN2 premium' 'opaque-42' 'Mainland premium' 'Beijing edge' 'Shanghai edge' 'Guangzhou edge' 'Shenzhen edge' 'Sichuan edge' 'Inner-Mongolia edge' 'Xinjiang edge' '香港 edge' 'Hong Kong edge' 'Hong-Kong edge' 'Hong_Kong edge' 'HK edge' 'HKG edge' 'HKT edge' 'CHK edge' 'hk01 edge' 'myhk edge' >"$tmp_dir/tags"
 magicnet_singbox_emit_selector_block "$tmp_dir/tags" 'US stable' >"$tmp_dir/no-jq.fragment"
 { printf '{"outbounds":['; cat "$tmp_dir/no-jq.fragment"; printf ']}\n'; } >"$tmp_dir/no-jq.json"
 jq -e '
   ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] as $names
   | [.outbounds[] | select(.tag as $tag | $names | index($tag))] as $groups
   | ($groups | length) == 4
-    and ($groups | all(.type == "selector" and .default == "block" and .outbounds == ["block", "US stable", "CN2 premium", "opaque-42"] and (.outbounds | index("proxy") == null and index("direct") == null)))
+    and ($groups | all(.type == "selector" and .default == "block" and .outbounds == ["block", "US stable", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "hk01 edge", "myhk edge"] and (.outbounds | index("proxy") == null and index("direct") == null)))
 ' "$tmp_dir/no-jq.json" >/dev/null || fail "no-jq generator selector mismatch"
 magicnet_singbox_pinned_ai_tags "$tmp_dir/tags" >"$tmp_dir/pinned-ai-tags"
 grep -Fxq 'CN2 premium' "$tmp_dir/pinned-ai-tags" || fail "CN2 false positive"
@@ -48,6 +58,12 @@ grep -Fxq 'opaque-42' "$tmp_dir/pinned-ai-tags" || fail "opaque node filtered"
 ! grep -Fxq '上海 node' "$tmp_dir/pinned-ai-tags" || fail "mainland node retained"
 for tag in 'Mainland premium' 'Beijing edge' 'Shanghai edge' 'Guangzhou edge' 'Shenzhen edge' 'Sichuan edge' 'Inner-Mongolia edge' 'Xinjiang edge'; do
   ! grep -Fxq "$tag" "$tmp_dir/pinned-ai-tags" || fail "English mainland label retained: $tag"
+done
+for tag in '香港 edge' 'Hong Kong edge' 'Hong-Kong edge' 'Hong_Kong edge' 'HK edge' 'HKG edge'; do
+  ! grep -Fxq "$tag" "$tmp_dir/pinned-ai-tags" || fail "Hong Kong label retained: $tag"
+done
+for tag in 'HKT edge' 'CHK edge' 'hk01 edge' 'myhk edge'; do
+  grep -Fxq "$tag" "$tmp_dir/pinned-ai-tags" || fail "Hong Kong boundary false positive: $tag"
 done
 jq -e '
   ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] as $names

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
@@ -71,7 +71,7 @@ magicnet_singbox_build_outbounds_file_with_jq() {
       (with_base($outs; $fallback)) as $items
       | {"type": "selector", "tag": $tag, "outbounds": $items, "default": $items[0]};
     def mainland_node_tag:
-      test("中国|大陆|内地|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:China|Mainland|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
+      test("中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:China|Mainland|Hong[ _-]?Kong|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
     def pinned_ai_selector($tag; $tags):
       (["block"] + [$tags[]? | select(mainland_node_tag | not)]) as $items
       | {"type": "selector", "tag": $tag, "outbounds": $items, "default": "block"};
@@ -267,8 +267,8 @@ magicnet_singbox_pinned_ai_tags() {
     _pinned_ai_tags_file="$1"
     printf '%s\n' "block"
     awk 'BEGIN { IGNORECASE = 1 }
-      !/中国|大陆|内地|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西/ &&
-      !/(^|[^[:alnum:]])(China|Mainland|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^[:alnum:]]|$)/ { print }
+      !/中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西/ &&
+      !/(^|[^[:alnum:]])(China|Mainland|Hong[ _-]?Kong|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^[:alnum:]]|$)/ { print }
     ' "$_pinned_ai_tags_file"
     unset _pinned_ai_tags_file
 }


### PR DESCRIPTION
Follow-up to #29.\n\n- exclude Hong Kong labels from all pinned AI selectors in jq and jq-less paths\n- cover Chinese, English, HK, and HKG forms with token boundaries\n- retain HKT, CHK, hk01, myhk, and CN2 boundary cases