### PR TITLE
fix(webui): expose ad allowlist removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## v1.1.16 (2026-07-12)
+
+- Fix #34 with an explicit delete action for ad allowlist chips, and refresh
+  blocklist state after removal so community rules return to the community list
+  while manually added entries do not.
+
 ## v1.1.15 (2026-07-11)
 
 - Add a prioritized ad allowlist routed through selectable `direct` or `proxy`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   <p>
-    <a href="kam.toml"><img alt="MagicNet v1.1.15" src="https://img.shields.io/badge/MagicNet-v1.1.15-31c2f2" /></a>
+    <a href="kam.toml"><img alt="MagicNet v1.1.16" src="https://img.shields.io/badge/MagicNet-v1.1.16-31c2f2" /></a>
     <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-green.svg" /></a>
     <a href="Cargo.toml"><img alt="Rust workspace" src="https://img.shields.io/badge/Rust-workspace-f46623?logo=rust&logoColor=white" /></a>
     <a href="webui/package.json"><img alt="Vue WebUI" src="https://img.shields.io/badge/WebUI-Vue%203-42b883?logo=vue.js&logoColor=white" /></a>
@@ -27,7 +27,7 @@ MagicNet 是一个 Android root 网络编排模块，把设备流量或显式代
 
 当前主线已经收敛为 **sing-box + 用户态编排**。`sing-box` 是唯一代理核心；MagicNet 提供 `proxy`、`external-tun`、`hybrid` 和兼容 `tun` 四种运行模式。下一代设计详见 [docs/next-gen-architecture.md](docs/next-gen-architecture.md)。旧的 TProxy 主路径、多核心切换和抓包代理功能都不再作为主线能力维护。
 
-需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.15`。Release 以发布页为准。
+需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.16`。Release 以发布页为准。
 
 ## 成果
 
@@ -108,9 +108,9 @@ chmod +x kam.sh
 
 ### Release 包
 
-当前 release 下载页：<https://github.com/LIghtJUNction/MagicNet/releases/tag/v1.1.15>
+当前 release 下载页：<https://github.com/LIghtJUNction/MagicNet/releases/tag/v1.1.16>
 
-直接下载当前模块包：<https://github.com/LIghtJUNction/MagicNet/releases/download/v1.1.15/MagicNet.zip>
+直接下载当前模块包：<https://github.com/LIghtJUNction/MagicNet/releases/download/v1.1.16/MagicNet.zip>
 
 ```bash
 kam -S MagicNet

--- a/kam.toml
+++ b/kam.toml
@@ -1,8 +1,8 @@
 [prop]
 id = "MagicNet"
 name = "MagicNet"
-version = "v1.1.15"
-versionCode = 1783751366708
+version = "v1.1.16"
+versionCode = 1783870364521
 author = "LIghtJUNction"
 description = "[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM."
 updateJson = "https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json"

--- a/src/MagicNet/README.md
+++ b/src/MagicNet/README.md
@@ -5,7 +5,7 @@ MagicNet 是一个 Android root TUN 透明代理模块，用 `sing-box` 和 `mag
 > [!IMPORTANT]
 > DNS 防泄露必读：请打开系统设置，搜索 `DNS`，找到“私人 DNS”“私密 DNS”“Private DNS”或类似表述，把私人 DNS 关闭，不要设置为自动加密。必须让 DNS 正常走 53 端口，让 MagicNet 模块接管并代理 DNS；否则 Android 系统或浏览器可能直接使用 DoT/DoH，导致 DNS 泄露检测仍然显示外部解析器。
 
-> 需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.15`。Release 以发布页为准。
+> 需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.16`。Release 以发布页为准。
 
 ## 定位
 

--- a/src/MagicNet/module.prop
+++ b/src/MagicNet/module.prop
@@ -1,7 +1,7 @@
 id=MagicNet
 name=MagicNet
-version=v1.1.15
-versionCode=1783751366708
+version=v1.1.16
+versionCode=1783870364521
 author=LIghtJUNction
 description=[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM.
 updateJson=https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
   "changelog": "https://github.com/LIghtJUNction/MagicNet/blob/main/CHANGELOG.md",
-  "version": "v1.1.15",
-  "versionCode": 1783751366708,
+  "version": "v1.1.16",
+  "versionCode": 1783870364521,
   "zipUrl": "https://github.com/LIghtJUNction/MagicNet/releases/latest/download/MagicNet.zip"
 }

--- a/webui/src/components/pages/BlocklistPage.vue
+++ b/webui/src/components/pages/BlocklistPage.vue
@@ -144,28 +144,26 @@ function requestAllowRule(rule: string): void {
   };
 }
 
-async function unallowRule(rule: string): Promise<void> {
+async function removeAllowRule(rule: string): Promise<void> {
   await withAction(`unallow-${rule}`, async () => {
     state.blocklist.allowRules = state.blocklist.allowRules.filter((item) => item !== rule);
-    if (!state.blocklist.communityRules.includes(rule)) state.blocklist.communityRules.unshift(rule);
-    state.output = `正在恢复阻断：${rule}`;
-    const text = await runCli(`block unallow-rule ${shellQuote(rule)}`, `恢复阻断 ${rule}`, true);
+    state.output = `正在从广告放行白名单删除：${rule}`;
+    const text = await runCli(`block unallow-rule ${shellQuote(rule)}`, `从广告放行白名单删除 ${rule}`, true);
     if (text.includes("[error]")) {
       state.output = text;
-      state.blocklist.communityRules = state.blocklist.communityRules.filter((item) => item !== rule);
       if (!state.blocklist.allowRules.includes(rule)) state.blocklist.allowRules.push(rule);
       return;
     }
-    state.output = `已恢复阻断：${rule}`;
+    if (await refreshBlock(true)) state.output = `已从广告放行白名单删除：${rule}`;
   });
 }
 
-function requestUnallowRule(rule: string): void {
+function requestRemoveAllowRule(rule: string): void {
   pendingBlockAction.value = {
     key: `unallow-${rule}`,
     command: `block unallow-rule ${rule}`,
-    message: `确认恢复阻断 ${rule}？`,
-    run: () => unallowRule(rule)
+    message: `确认从广告放行白名单删除 ${rule}？若规则来自社区库，删除后会回到社区库并恢复阻断；手工添加项则会从白名单消失。`,
+    run: () => removeAllowRule(rule)
   };
 }
 
@@ -370,7 +368,7 @@ async function confirmBlockAction(): Promise<void> {
         <div class="flex max-h-[26rem] flex-wrap gap-2 overflow-auto">
           <span v-for="rule in visibleAllowRules" :key="rule" class="inline-flex max-w-full items-center gap-1 rounded-full border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs break-all">
             {{ rule }}
-            <button class="grid size-6 place-items-center rounded-full bg-zinc-800 text-zinc-50 disabled:cursor-progress disabled:opacity-60" :disabled="isRunning(`unallow-${rule}`)" type="button" title="恢复阻断" @click="requestUnallowRule(rule)"><Plus :size="14" /></button>
+            <button class="grid size-6 place-items-center rounded-full bg-red-500/15 text-red-200 hover:bg-red-500/25 disabled:cursor-progress disabled:opacity-60" :disabled="isRunning(`unallow-${rule}`)" type="button" :title="`从广告放行白名单删除 ${rule}`" :aria-label="`从广告放行白名单删除 ${rule}`" @click="requestRemoveAllowRule(rule)"><X :size="14" /></button>
           </span>
           <em v-if="!visibleAllowRules.length" class="text-sm not-italic text-zinc-500">{{ state.blocklist.allowRules.length ? '没有匹配项' : '暂无白名单规则' }}</em>
         </div>


### PR DESCRIPTION
## Summary

- replace the ambiguous `+` action on ad allowlist chips with an explicit red delete action
- refresh blocklist state from the CLI after removal so community rules return to the community list while manual entries disappear
- prepare the synchronized `v1.1.16` patch release metadata

## Verification

- `bun run typecheck`
- `bun run build`
- `scripts/test-ad-routing.sh`
- `kam validate`
- `kam build`
- `scripts/pre-commit.sh`
- packaged `module.prop` reports `v1.1.16` / `1783870364521`
- packaged WebUI contains the explicit removal label

## Related issue

Refs #34
