### PR TITLE
fix(routing): honor ad and app proxy policies

### DIFF
--- a/crates/magicnet-cli/src/rules.rs
+++ b/crates/magicnet-cli/src/rules.rs
@@ -1,7 +1,9 @@
 mod block;
 
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::service::restart_current_core;
@@ -72,7 +74,7 @@ pub(crate) fn app_cmd(app: &App, args: &[String]) -> Result<(), String> {
         "add-many" => app_add_many(app, args),
         "remove" => app_remove(app, args),
         "packages" => app_packages(args),
-        "apply" => run_magicnet_function(app, "magicnet_app_policy_apply"),
+        "apply" => app_apply_and_restart(app),
         _ => Err("Usage: cli app {list|packages [query]|mode <blacklist|whitelist>|add <package> [proxy|bypass]|add-many <proxy|bypass> <package...>|remove <package>|apply}".to_string()),
     }
 }
@@ -100,7 +102,7 @@ fn app_mode(app: &App, args: &[String]) -> Result<(), String> {
         conf_dir(app).join("app-mode.conf"),
         &format!("MAGICNET_APP_MODE={mode}\n"),
     )?;
-    run_magicnet_function(app, "magicnet_app_policy_apply")?;
+    app_apply_and_restart(app)?;
     println!("[info] App policy mode set to {mode}");
     Ok(())
 }
@@ -121,7 +123,7 @@ fn app_add(app: &App, args: &[String]) -> Result<(), String> {
     };
     update_line(app_file(app, opposite)?, package, false)?;
     update_line(app_file(app, target)?, package, true)?;
-    run_magicnet_function(app, "magicnet_app_policy_apply")?;
+    app_apply_and_restart(app)?;
     println!("[info] Added {package} to {target} app list");
     Ok(())
 }
@@ -131,8 +133,11 @@ fn app_add_many(app: &App, args: &[String]) -> Result<(), String> {
     if !matches!(target, "proxy" | "bypass") || args.len() < 3 {
         return Err("Usage: cli app add-many <proxy|bypass> <package...>".to_string());
     }
+    let opposite = if target == "proxy" { "bypass" } else { "proxy" };
     let path = app_file(app, target)?;
+    let opposite_path = app_file(app, opposite)?;
     let mut lines = clean_lines(path.clone());
+    let mut opposite_lines = clean_lines(opposite_path.clone());
     let mut added = 0usize;
     for package in args.iter().skip(2).map(String::as_str) {
         if !valid_package_name(package) {
@@ -142,9 +147,15 @@ fn app_add_many(app: &App, args: &[String]) -> Result<(), String> {
             lines.push(package.to_string());
             added += 1;
         }
+        opposite_lines.retain(|line| line != package);
     }
-    write_unique_lines(path, &lines)?;
-    run_magicnet_function(app, "magicnet_app_policy_apply")?;
+    write_two_files_transactional(
+        &opposite_path,
+        &unique_lines_text(&opposite_lines),
+        &path,
+        &unique_lines_text(&lines),
+    )?;
+    app_apply_and_restart(app)?;
     println!("[info] Added {added} packages to {target} app list");
     Ok(())
 }
@@ -168,12 +179,17 @@ fn app_remove(app: &App, args: &[String]) -> Result<(), String> {
             update_line(app_file(app, "bypass")?, package, false)?;
         }
     }
-    run_magicnet_function(app, "magicnet_app_policy_apply")?;
+    app_apply_and_restart(app)?;
     println!(
         "[info] Removed {package} from {} app list",
         target.unwrap_or("both")
     );
     Ok(())
+}
+
+fn app_apply_and_restart(app: &App) -> Result<(), String> {
+    run_magicnet_function(app, "magicnet_app_policy_apply")?;
+    restart_current_core(app)
 }
 
 fn app_packages(args: &[String]) -> Result<(), String> {
@@ -234,6 +250,10 @@ pub(super) fn update_line(path: PathBuf, item: &str, add: bool) -> Result<(), St
 }
 
 fn write_unique_lines(path: PathBuf, lines: &[String]) -> Result<(), String> {
+    write_text_file(path, &unique_lines_text(lines))
+}
+
+fn unique_lines_text(lines: &[String]) -> String {
     let mut seen = HashSet::new();
     let mut out = Vec::new();
     for line in lines
@@ -245,7 +265,153 @@ fn write_unique_lines(path: PathBuf, lines: &[String]) -> Result<(), String> {
             out.push(line.to_string());
         }
     }
-    write_text_file(path, &format!("{}\n", out.join("\n")))
+    format!("{}\n", out.join("\n"))
+}
+
+enum FileSnapshot {
+    Missing,
+    Present(Vec<u8>),
+}
+
+fn write_two_files_transactional(
+    first_path: &Path,
+    first_text: &str,
+    second_path: &Path,
+    second_text: &str,
+) -> Result<(), String> {
+    write_two_files_transactional_with_replace(
+        first_path,
+        first_text,
+        second_path,
+        second_text,
+        |source, destination| fs::rename(source, destination),
+    )
+}
+
+fn write_two_files_transactional_with_replace<F>(
+    first_path: &Path,
+    first_text: &str,
+    second_path: &Path,
+    second_text: &str,
+    mut replace: F,
+) -> Result<(), String>
+where
+    F: FnMut(&Path, &Path) -> io::Result<()>,
+{
+    let targets = [first_path, second_path];
+    let contents = [first_text.as_bytes(), second_text.as_bytes()];
+    let snapshots = [file_snapshot(first_path)?, file_snapshot(second_path)?];
+    let stages = [
+        transaction_temp_path(first_path, 1)?,
+        transaction_temp_path(second_path, 2)?,
+    ];
+
+    for (index, stage) in stages.iter().enumerate() {
+        if let Some(parent) = stage.parent() {
+            if let Err(err) = fs::create_dir_all(parent) {
+                let cleanup_errors = cleanup_transaction_temps(&stages);
+                return Err(transaction_error(
+                    format!("mkdir {}: {err}", parent.display()),
+                    cleanup_errors,
+                ));
+            }
+        }
+        if let Err(err) = fs::write(stage, contents[index]) {
+            let cleanup_errors = cleanup_transaction_temps(&stages);
+            return Err(transaction_error(
+                format!("stage {}: {err}", targets[index].display()),
+                cleanup_errors,
+            ));
+        }
+    }
+
+    for index in 0..targets.len() {
+        if let Err(err) = replace(&stages[index], targets[index]) {
+            let mut recovery_errors = Vec::new();
+            for rollback_index in (0..index).rev() {
+                if let Err(restore_err) = restore_file_snapshot(
+                    targets[rollback_index],
+                    &snapshots[rollback_index],
+                    &stages[rollback_index],
+                    &mut replace,
+                ) {
+                    recovery_errors.push(restore_err);
+                }
+            }
+            recovery_errors.extend(cleanup_transaction_temps(&stages));
+            return Err(transaction_error(
+                format!("replace {}: {err}", targets[index].display()),
+                recovery_errors,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn file_snapshot(path: &Path) -> Result<FileSnapshot, String> {
+    match fs::read(path) {
+        Ok(contents) => Ok(FileSnapshot::Present(contents)),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(FileSnapshot::Missing),
+        Err(err) => Err(format!("snapshot {}: {err}", path.display())),
+    }
+}
+
+fn transaction_temp_path(path: &Path, index: usize) -> Result<PathBuf, String> {
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| format!("invalid app list path: {}", path.display()))?;
+    Ok(path.with_file_name(format!(
+        ".{name}.magicnet-{}-{index}.tmp",
+        std::process::id()
+    )))
+}
+
+fn restore_file_snapshot<F>(
+    path: &Path,
+    snapshot: &FileSnapshot,
+    stage: &Path,
+    replace: &mut F,
+) -> Result<(), String>
+where
+    F: FnMut(&Path, &Path) -> io::Result<()>,
+{
+    match snapshot {
+        FileSnapshot::Missing => match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(format!("remove {} during rollback: {err}", path.display())),
+        },
+        FileSnapshot::Present(contents) => {
+            fs::write(stage, contents)
+                .map_err(|err| format!("stage rollback for {}: {err}", path.display()))?;
+            replace(stage, path)
+                .map_err(|err| format!("restore {} during rollback: {err}", path.display()))
+        }
+    }
+}
+
+fn cleanup_transaction_temps(stages: &[PathBuf]) -> Vec<String> {
+    let mut errors = Vec::new();
+    for stage in stages {
+        match fs::remove_file(stage) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => errors.push(format!("remove temporary {}: {err}", stage.display())),
+        }
+    }
+    errors
+}
+
+fn transaction_error(original: String, recovery_errors: Vec<String>) -> String {
+    if recovery_errors.is_empty() {
+        original
+    } else {
+        format!(
+            "{original}; rollback failed: {}",
+            recovery_errors.join("; ")
+        )
+    }
 }
 
 pub(super) fn conf_dir(app: &App) -> PathBuf {
@@ -272,5 +438,79 @@ pub(super) fn normalize_block_rule(rule: &str) -> String {
         value.to_string()
     } else {
         format!("DOMAIN-SUFFIX,{value}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    fn test_dir(name: &str) -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "magicnet-rules-{name}-{}-{stamp}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn two_file_transaction_replaces_both_destinations() {
+        let dir = test_dir("success");
+        fs::create_dir_all(&dir).unwrap();
+        let first = dir.join("app-bypass.list");
+        let second = dir.join("app-proxy.list");
+        fs::write(&first, "old-bypass\n").unwrap();
+        fs::write(&second, "old-proxy\n").unwrap();
+
+        write_two_files_transactional(&first, "new-bypass\n", &second, "new-proxy\n").unwrap();
+
+        assert_eq!(fs::read_to_string(&first).unwrap(), "new-bypass\n");
+        assert_eq!(fs::read_to_string(&second).unwrap(), "new-proxy\n");
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn two_file_transaction_rolls_back_when_second_replace_fails() {
+        let dir = test_dir("rollback");
+        fs::create_dir_all(&dir).unwrap();
+        let first = dir.join("app-bypass.list");
+        let second = dir.join("app-proxy.list");
+        fs::write(&first, "old-bypass\n").unwrap();
+        fs::write(&second, "old-proxy\n").unwrap();
+        let mut replace_count = 0usize;
+
+        let error = write_two_files_transactional_with_replace(
+            &first,
+            "new-bypass\n",
+            &second,
+            "new-proxy\n",
+            |source, destination| {
+                replace_count += 1;
+                if replace_count == 2 {
+                    Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        "injected second replace failure",
+                    ))
+                } else {
+                    fs::rename(source, destination)
+                }
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.contains("injected second replace failure"));
+        assert_eq!(fs::read_to_string(&first).unwrap(), "old-bypass\n");
+        assert_eq!(fs::read_to_string(&second).unwrap(), "old-proxy\n");
+        assert!(!fs::read_dir(&dir).unwrap().any(|entry| entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains(".tmp")));
+        fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/scripts/test-ad-routing.sh
+++ b/scripts/test-ad-routing.sh
@@ -6,16 +6,64 @@ ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT HUP INT TERM
 
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%s\n' 'jq is required for ad routing regression tests' >&2
+  exit 1
+fi
+
 MODDIR="$WORK/module"
 export MODDIR
 mkdir -p "$MODDIR/.config/magicnet" "$MODDIR/.config/sing-box"
 
 . "$ROOT/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh"
+. "$ROOT/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh"
 . "$ROOT/src/MagicNet/lib/magicnet/blocklist.sh"
+
+assert_subscription_ad_allow() {
+  _fragment="$1"
+  _config="$2"
+  {
+    printf '{\n'
+    cat "$_fragment"
+    printf '\n  "route": {}\n}\n'
+  } >"$_config"
+  jq -e '
+    [.outbounds[] | select(.tag == "ad-allow")] == [{
+      "type": "selector",
+      "tag": "ad-allow",
+      "outbounds": ["final", "direct", "proxy"],
+      "default": "final"
+    }]
+  ' "$_config" >/dev/null
+  unset _fragment _config
+}
+
+mkdir -p "$WORK/subscription-jq" "$WORK/subscription-no-jq/nodes"
+printf '[]' >"$WORK/subscription-jq/nodes.json"
+: >"$WORK/subscription-jq/tags"
+magicnet_singbox_build_outbounds_file_with_jq \
+  "$WORK/subscription-jq/nodes.json" \
+  "$WORK/subscription-jq/tags" \
+  "$WORK/subscription-jq/outbounds"
+assert_subscription_ad_allow \
+  "$WORK/subscription-jq/outbounds" \
+  "$WORK/subscription-jq/config.json"
+
+magicnet_singbox_build_outbounds_file_with_jq() {
+  return 1
+}
+magicnet_singbox_build_outbounds_file \
+  "$WORK/subscription-no-jq/nodes" \
+  "$WORK/subscription-no-jq/outbounds" \
+  "$WORK/subscription-no-jq/tags" >/dev/null
+assert_subscription_ad_allow \
+  "$WORK/subscription-no-jq/outbounds" \
+  "$WORK/subscription-no-jq/config.json"
 
 cat >"$MODDIR/.config/magicnet/block-allow-rules.list" <<'EOF'
 DOMAIN,ads.example.com
 DOMAIN-SUFFIX,example.org
+DOMAIN-SUFFIX,mobilism.org
 DOMAIN-KEYWORD,sponsor
 EOF
 cat >"$MODDIR/.config/magicnet/community-ban-rules.list" <<'EOF'
@@ -47,7 +95,7 @@ cat >"$MODDIR/.config/sing-box/config.json" <<'EOF'
         "action": "sniff"
       },
       {
-        "rule_set": "ads",
+        "rule_set": "hagezi-anti-piracy",
         "outbound": "ad-block"
       }
     ]
@@ -67,6 +115,7 @@ grep -q '"outbound": "ad-allow"' "$CONFIG"
 grep -q '"outbound": "ad-block"' "$CONFIG"
 grep -q '"ads.example.com"' "$CONFIG"
 grep -q '"example.org"' "$CONFIG"
+grep -q '"mobilism.org"' "$CONFIG"
 grep -q '"sponsor"' "$CONFIG"
 if grep -A8 '__magicnet_block__' "$CONFIG" | grep -q 'ads.example.com'; then
   exit 1
@@ -74,9 +123,13 @@ fi
 
 ALLOW_LINE=$(grep -n '__magicnet_ad_allow__' "$CONFIG" | cut -d: -f1)
 BLOCK_LINE=$(grep -n '__magicnet_block__' "$CONFIG" | cut -d: -f1)
-STATIC_LINE=$(grep -n '"rule_set": "ads"' "$CONFIG" | cut -d: -f1)
+STATIC_LINE=$(grep -n '"rule_set": "hagezi-anti-piracy"' "$CONFIG" | cut -d: -f1)
 [ "$ALLOW_LINE" -lt "$BLOCK_LINE" ]
 [ "$BLOCK_LINE" -lt "$STATIC_LINE" ]
+jq -e '
+  any(.route.rules[];
+    .outbound == "ad-allow" and ((.domain_suffix // []) | index("mobilism.org")))
+' "$CONFIG" >/dev/null
 
 : >"$MODDIR/.config/magicnet/block-allow-rules.list"
 magicnet_block_apply_singbox
@@ -84,20 +137,19 @@ if grep -q '__magicnet_ad_allow__' "$CONFIG"; then
   exit 1
 fi
 
-grep -Fq 'selector("ad-block"; ["block", "direct", "proxy"]; "block")' \
-  "$ROOT/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh"
-grep -Fq 'selector("ad-allow"; ["direct", "proxy"]; "direct")' \
-  "$ROOT/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh"
-
-if command -v jq >/dev/null 2>&1; then
-  jq -e '
-    (.outbounds[] | select(.tag == "ad-block") | .outbounds == ["block", "direct", "proxy"] and .default == "block") and
-    (.outbounds[] | select(.tag == "ad-allow") | .outbounds == ["direct", "proxy"] and .default == "direct") and
-    (.outbounds[] | select(.tag == "ad-block") | .outbounds == ["block", "direct", "proxy"]) and
-    (.outbounds[] | select(.tag == "ad-allow") | .outbounds == ["direct", "proxy"])
-  ' "$ROOT/src/MagicNet/.config/sing-box/config.json" >/dev/null
-  jq empty "$CONFIG"
-  [ "$(jq '[.route.rules[] | select(has("domain") and (.domain | index("__magicnet_ad_allow__")))] | length' "$CONFIG")" -eq 0 ]
+SRS="$ROOT/src/MagicNet/.config/sing-box/rules/hagezi-anti-piracy.srs"
+if command -v sing-box >/dev/null 2>&1 && [ -f "$SRS" ]; then
+  MATCH_OUTPUT=$(sing-box rule-set match -f binary "$SRS" forum.mobilism.org 2>&1)
+  [ -n "$MATCH_OUTPUT" ]
 fi
+
+jq -e '
+  (.outbounds[] | select(.tag == "ad-block") | .outbounds == ["block", "direct", "proxy"] and .default == "block") and
+  (.outbounds[] | select(.tag == "ad-allow") | .outbounds == ["final", "direct", "proxy"] and .default == "final") and
+  (.outbounds[] | select(.tag == "ad-block") | .outbounds == ["block", "direct", "proxy"]) and
+  (.outbounds[] | select(.tag == "ad-allow") | .outbounds == ["final", "direct", "proxy"])
+' "$ROOT/src/MagicNet/.config/sing-box/config.json" >/dev/null
+jq empty "$CONFIG"
+[ "$(jq '[.route.rules[] | select(has("domain") and (.domain | index("__magicnet_ad_allow__")))] | length' "$CONFIG")" -eq 0 ]
 
 printf '%s\n' 'ad routing regression tests passed'

--- a/scripts/test-app-routing-policy.sh
+++ b/scripts/test-app-routing-policy.sh
@@ -1,0 +1,154 @@
+#!/bin/sh
+
+set -eu
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT HUP INT TERM
+
+JQ_BIN=$(command -v jq 2>/dev/null || true)
+if [ -z "$JQ_BIN" ]; then
+  printf '%s\n' 'jq is required for app routing policy assertions' >&2
+  exit 1
+fi
+
+. "$ROOT/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh"
+. "$ROOT/src/MagicNet/lib/magicnet/apps.sh"
+
+NO_JQ_BIN="$WORK/no-jq-bin"
+mkdir -p "$NO_JQ_BIN"
+for command_name in awk grep mv rm sed tr wc; do
+  command_path=$(command -v "$command_name")
+  ln -s "$command_path" "$NO_JQ_BIN/$command_name"
+done
+
+write_base_config() {
+  cat >"$MODDIR/.config/sing-box/config.json" <<'EOF'
+{
+  "inbounds": [
+    {
+      "type": "tun",
+      "tag": "tun-in",
+      "include_package": ["stale.include"],
+      "exclude_package": ["stale.exclude"],
+      "stack": "system"
+    }
+  ],
+  "route": {
+    "rules": [
+      {
+        "inbound": ["tun-in"],
+        "action": "sniff"
+      },
+      {
+        "package_name": ["com.example.direct"],
+        "outbound": "direct"
+      },
+      {
+        "protocol": "dns",
+        "action": "hijack-dns"
+      },
+      {
+        "protocol": "icmp",
+        "outbound": "block"
+      },
+      {
+        "domain_suffix": ["example.org"],
+        "outbound": "direct"
+      }
+    ]
+  }
+}
+EOF
+}
+
+assert_proxy_rule_and_order() {
+  # shellcheck disable=SC2016
+  "$JQ_BIN" -e '
+    ([.route.rules | to_entries[]
+       | select((.value.package_name // []) | index("__magicnet_app_proxy__"))] | length) == 1
+    and ([.route.rules[]
+          | select((.package_name // []) | index("__magicnet_app_proxy__"))][0]
+         | .package_name == ["__magicnet_app_proxy__", "com.example.proxy"]
+           and .outbound == "proxy")
+    and (([.route.rules | to_entries[]
+            | select(.value | (has("action") or (.protocol == "icmp" and .outbound == "block")))
+            | .key] | max) as $guard
+         | ([.route.rules | to_entries[]
+              | select((.value.package_name // []) | index("__magicnet_app_proxy__"))
+              | .key][0]) as $proxy
+         | ([.route.rules | to_entries[]
+              | select(.value.outbound == "direct" and ((.value.package_name // .value.domain_suffix // []) | length) > 0)
+              | .key] | min) as $business
+         | $guard < $proxy and $proxy < $business)
+  ' "$MODDIR/.config/sing-box/config.json" >/dev/null
+}
+
+assert_blacklist() {
+  "$JQ_BIN" -e '
+    (.inbounds[] | select(.type == "tun")
+      | .exclude_package == ["com.example.bypass"] and (has("include_package") | not))
+  ' "$MODDIR/.config/sing-box/config.json" >/dev/null
+  assert_proxy_rule_and_order
+}
+
+assert_whitelist() {
+  "$JQ_BIN" -e '
+    (.inbounds[] | select(.type == "tun")
+      | .include_package == ["com.example.proxy"] and (has("exclude_package") | not))
+  ' "$MODDIR/.config/sing-box/config.json" >/dev/null
+  assert_proxy_rule_and_order
+}
+
+apply_policy() {
+  implementation="$1"
+  if [ "$implementation" = "no-jq" ]; then
+    PATH="$NO_JQ_BIN" magicnet_singbox_apply_app_policy
+  else
+    magicnet_singbox_apply_app_policy
+  fi
+}
+
+run_case() {
+  implementation="$1"
+  MODDIR="$WORK/$implementation/module"
+  export MODDIR
+  mkdir -p "$MODDIR/.config/magicnet" "$MODDIR/.config/sing-box"
+  write_base_config
+
+  printf '%s\n' 'MAGICNET_APP_MODE=blacklist' >"$MODDIR/.config/magicnet/app-mode.conf"
+  cat >"$MODDIR/.config/magicnet/app-proxy.list" <<'EOF'
+com.example.proxy
+com.example.proxy
+EOF
+  cat >"$MODDIR/.config/magicnet/app-bypass.list" <<'EOF'
+com.example.bypass
+com.example.bypass
+EOF
+  apply_policy "$implementation"
+  apply_policy "$implementation"
+  if ! "$JQ_BIN" empty "$MODDIR/.config/sing-box/config.json" >/dev/null 2>&1; then
+    printf '%s\n' "$implementation generated invalid JSON" >&2
+    awk '{ printf "%4d %s\n", NR, $0 }' "$MODDIR/.config/sing-box/config.json" >&2
+    exit 1
+  fi
+  assert_blacklist
+
+  : >"$MODDIR/.config/magicnet/app-proxy.list"
+  apply_policy "$implementation"
+  apply_policy "$implementation"
+  "$JQ_BIN" -e '
+    [.route.rules[] | select((.package_name // []) | index("__magicnet_app_proxy__"))] | length == 0
+  ' "$MODDIR/.config/sing-box/config.json" >/dev/null
+
+  printf '%s\n' 'MAGICNET_APP_MODE=whitelist' >"$MODDIR/.config/magicnet/app-mode.conf"
+  printf '%s\n' 'com.example.proxy' 'com.example.proxy' >"$MODDIR/.config/magicnet/app-proxy.list"
+  apply_policy "$implementation"
+  apply_policy "$implementation"
+  assert_whitelist
+}
+
+run_case jq
+run_case no-jq
+
+printf '%s\n' 'app routing policy regression tests passed'

--- a/src/MagicNet/lib/magicnet/apps.sh
+++ b/src/MagicNet/lib/magicnet/apps.sh
@@ -26,7 +26,8 @@ magicnet_package_array_block() {
         return 0
     fi
 
-    _items=$(sed '/^[[:space:]]*$/d; /^[[:space:]]*#/d' "$_file" 2>/dev/null | awk '!seen[$0]++')
+    _items=$(sed '/^[[:space:]]*$/d; /^[[:space:]]*#/d' "$_file" 2>/dev/null |
+        awk '{ gsub(/^[[:space:]]+|[[:space:]]+$/, ""); if (!seen[$0]++) print }')
     if [ -z "$_items" ]; then
         [ "$_force_empty" = "1" ] || return 0
         printf '      "%s": []%s\n' "$_key" "$_comma"
@@ -46,6 +47,41 @@ magicnet_package_array_block() {
     done
     printf '      ]%s\n' "$_comma"
     unset _key _file _comma _force_empty _items _count _idx _line_comma _pkg
+}
+
+magicnet_app_proxy_packages() {
+    _proxy_packages_file="$1"
+    if [ ! -f "$_proxy_packages_file" ]; then
+        unset _proxy_packages_file
+        return 0
+    fi
+    sed '/^[[:space:]]*$/d; /^[[:space:]]*#/d' "$_proxy_packages_file" 2>/dev/null |
+        awk '{ gsub(/^[[:space:]]+|[[:space:]]+$/, ""); if (!seen[$0]++) print }'
+    unset _proxy_packages_file
+}
+
+magicnet_app_proxy_rule() {
+    _proxy_rule_packages="$(magicnet_app_proxy_packages "$1")"
+    if [ -z "$_proxy_rule_packages" ]; then
+        unset _proxy_rule_packages
+        return 0
+    fi
+    printf '      {\n'
+    printf '        "package_name": [\n'
+    printf '          "__magicnet_app_proxy__",\n'
+    _proxy_rule_count=$(printf '%s\n' "$_proxy_rule_packages" | wc -l | tr -d ' ')
+    _proxy_rule_idx=0
+    printf '%s\n' "$_proxy_rule_packages" | while IFS= read -r _proxy_rule_package; do
+        [ -n "$_proxy_rule_package" ] || continue
+        _proxy_rule_idx=$((_proxy_rule_idx + 1))
+        _proxy_rule_comma=","
+        [ "$_proxy_rule_idx" -eq "$_proxy_rule_count" ] && _proxy_rule_comma=""
+        printf '          "%s"%s\n' "$(magicnet_json_escape "$_proxy_rule_package")" "$_proxy_rule_comma"
+    done
+    printf '        ],\n'
+    printf '        "outbound": "proxy"\n'
+    printf '      }\n'
+    unset _proxy_rule_packages _proxy_rule_count _proxy_rule_idx _proxy_rule_package _proxy_rule_comma
 }
 
 magicnet_singbox_apply_app_policy() {
@@ -68,6 +104,7 @@ magicnet_singbox_apply_app_policy() {
     _tmp="${_config}.app-policy.new"
     _include_tmp="${_config}.include-package.tmp"
     _exclude_tmp="${_config}.exclude-package.tmp"
+    _proxy_rule_tmp="${_config}.app-proxy-rule.tmp"
     _jq="${MODDIR}/bin/jq"
     if [ ! -x "$_jq" ]; then
         _jq="$(command -v jq 2>/dev/null || true)"
@@ -100,8 +137,26 @@ magicnet_singbox_apply_app_policy() {
                   end
                 )
               )
+            | .route.rules = (
+                ((.route.rules // [])
+                  | map(select(((.package_name // []) | index("__magicnet_app_proxy__")) == null))) as $rules
+                | if ($proxy_packages | length) == 0 then
+                    $rules
+                  else
+                    ($rules
+                      | map(select(has("action") or (((.protocol // "") == "icmp") and ((.outbound // "") == "block"))))) as $protocol_guards
+                    | ($rules
+                      | map(select((has("action") or (((.protocol // "") == "icmp") and ((.outbound // "") == "block"))) | not))) as $business_rules
+                    | $protocol_guards
+                      + [{
+                          "package_name": (["__magicnet_app_proxy__"] + $proxy_packages),
+                          "outbound": "proxy"
+                        }]
+                      + $business_rules
+                  end
+              )
         ' "$_config" >"$_tmp" && mv -f "$_tmp" "$_config"; then
-            unset _config _dir _mode _proxy_file _bypass_file _include_block _exclude_block _tmp _include_tmp _exclude_tmp _jq
+            unset _config _dir _mode _proxy_file _bypass_file _include_block _exclude_block _tmp _include_tmp _exclude_tmp _proxy_rule_tmp _jq
             return 0
         fi
         rm -f "$_tmp" 2>/dev/null || true
@@ -120,8 +175,14 @@ magicnet_singbox_apply_app_policy() {
         rm -f "$_exclude_tmp" 2>/dev/null || true
         _exclude_tmp=""
     fi
+    if magicnet_app_proxy_packages "$_proxy_file" | grep -q .; then
+        magicnet_app_proxy_rule "$_proxy_file" >"$_proxy_rule_tmp"
+    else
+        rm -f "$_proxy_rule_tmp" 2>/dev/null || true
+        _proxy_rule_tmp=""
+    fi
 
-    if awk -v include_file="$_include_tmp" -v exclude_file="$_exclude_tmp" '
+    if awk -v include_file="$_include_tmp" -v exclude_file="$_exclude_tmp" -v proxy_rule_file="$_proxy_rule_tmp" '
         function emit_file(path, line) {
             if (path == "") {
                 return
@@ -131,9 +192,88 @@ magicnet_singbox_apply_app_policy() {
             }
             close(path)
         }
+        function emit_proxy_rule(comma, line, previous) {
+            if (proxy_rule_file == "") {
+                return
+            }
+            previous = ""
+            while ((getline line < proxy_rule_file) > 0) {
+                if (previous != "") {
+                    print previous
+                }
+                previous = line
+            }
+            close(proxy_rule_file)
+            if (previous != "") {
+                print previous comma
+            }
+            proxy_inserted = 1
+        }
+        function route_rule_is_guard(rule) {
+            return rule ~ /"action"[[:space:]]*:/ ||
+                (rule ~ /"protocol"[[:space:]]*:[[:space:]]*"icmp"/ &&
+                 rule ~ /"outbound"[[:space:]]*:[[:space:]]*"block"/)
+        }
+        function flush_route_rule() {
+            if (route_buffer !~ /"__magicnet_app_proxy__"/) {
+                route_rule_count++
+                route_rules[route_rule_count] = route_buffer
+            }
+            route_buffer = ""
+            route_buffering = 0
+        }
+        function emit_route_rule(rule, comma) {
+            sub(/},\n$/, "}\n", rule)
+            if (comma != "") {
+                sub(/}\n$/, "},\n", rule)
+            }
+            printf "%s", rule
+        }
+        function emit_route_rules(i, guard_count, business_count, output_count, emitted) {
+            guard_count = 0
+            business_count = 0
+            for (i = 1; i <= route_rule_count; i++) {
+                if (route_rule_is_guard(route_rules[i])) {
+                    guard_count++
+                } else {
+                    business_count++
+                }
+            }
+            output_count = guard_count + business_count + (proxy_rule_file != "" ? 1 : 0)
+            emitted = 0
+            for (i = 1; i <= route_rule_count; i++) {
+                if (route_rule_is_guard(route_rules[i])) {
+                    emitted++
+                    emit_route_rule(route_rules[i], emitted < output_count ? "," : "")
+                }
+            }
+            if (proxy_rule_file != "") {
+                emitted++
+                emit_proxy_rule(emitted < output_count ? "," : "")
+            }
+            for (i = 1; i <= route_rule_count; i++) {
+                if (!route_rule_is_guard(route_rules[i])) {
+                    emitted++
+                    emit_route_rule(route_rules[i], emitted < output_count ? "," : "")
+                }
+            }
+        }
         BEGIN {
             in_tun = 0
             skip_package_array = 0
+            in_route = 0
+            in_route_rules = 0
+            route_buffering = 0
+            route_buffer = ""
+            route_rule_count = 0
+            proxy_inserted = 0
+        }
+        route_buffering {
+            route_buffer = route_buffer $0 "\n"
+            if ($0 ~ /^      }[,]?[[:space:]]*$/) {
+                flush_route_rule()
+            }
+            next
         }
         skip_package_array {
             if ($0 ~ /^[[:space:]]*][[:space:]]*,?[[:space:]]*$/) {
@@ -142,11 +282,35 @@ magicnet_singbox_apply_app_policy() {
             next
         }
         {
+            if ($0 ~ /^  "route"[[:space:]]*:[[:space:]]*\{[[:space:]]*$/) {
+                in_route = 1
+            }
+            if (in_route && $0 ~ /^    "rules"[[:space:]]*:[[:space:]]*\[[[:space:]]*$/) {
+                in_route_rules = 1
+                print
+                next
+            }
+            if (in_route_rules && $0 ~ /^      \{[[:space:]]*$/) {
+                route_buffering = 1
+                route_buffer = $0 "\n"
+                next
+            }
+            if (in_route_rules && $0 ~ /^    ][,]?[[:space:]]*$/) {
+                emit_route_rules()
+                in_route_rules = 0
+                print
+                next
+            }
+            if (in_route && $0 ~ /^  }[,]?[[:space:]]*$/) {
+                in_route = 0
+            }
             if ($0 ~ /"type"[[:space:]]*:[[:space:]]*"tun"/) {
                 in_tun = 1
             }
             if (in_tun && $0 ~ /^[[:space:]]*"(include_package|exclude_package)"[[:space:]]*:/) {
-                skip_package_array = 1
+                if ($0 !~ /\[[^]]*][[:space:]]*,?[[:space:]]*$/) {
+                    skip_package_array = 1
+                }
                 next
             }
             if (in_tun && $0 ~ /^[[:space:]]*"stack"[[:space:]]*:/) {
@@ -162,10 +326,10 @@ magicnet_singbox_apply_app_policy() {
         :
     else
         rm -f "$_tmp" 2>/dev/null || true
-        rm -f "$_include_tmp" "$_exclude_tmp" 2>/dev/null || true
+        rm -f "$_include_tmp" "$_exclude_tmp" "$_proxy_rule_tmp" 2>/dev/null || true
         return 1
     fi
-    rm -f "$_include_tmp" "$_exclude_tmp" 2>/dev/null || true
+    rm -f "$_include_tmp" "$_exclude_tmp" "$_proxy_rule_tmp" 2>/dev/null || true
 }
 
 magicnet_app_policy_apply_unlocked() {

--- a/src/MagicNet/lib/magicnet/blocklist.sh
+++ b/src/MagicNet/lib/magicnet/blocklist.sh
@@ -187,8 +187,8 @@ magicnet_block_ensure_ad_selectors() {
             print "    {"
             print "      \"type\": \"selector\","
             print "      \"tag\": \"ad-allow\","
-            print "      \"outbounds\": [\"direct\", \"proxy\"],"
-            print "      \"default\": \"direct\""
+            print "      \"outbounds\": [\"final\", \"direct\", \"proxy\"],"
+            print "      \"default\": \"final\""
             print "    }" comma
         }
         function brace_delta(s, i, c, d) {
@@ -272,16 +272,22 @@ magicnet_block_apply_singbox() {
             buffering = 0
             skip_custom = 0
         }
+        function route_rule_precedes_ads(rule) {
+            return rule ~ /"action"[[:space:]]*:/ ||
+                (rule ~ /"protocol"[[:space:]]*:[[:space:]]*"icmp"/ &&
+                 rule ~ /"outbound"[[:space:]]*:[[:space:]]*"block"/) ||
+                rule ~ /"__magicnet_app_proxy__"/
+        }
         function flush_rule() {
             if (!skip_custom) {
-                printf "%s", buffer
-                if (!inserted && buffer ~ /"action"[[:space:]]*:[[:space:]]*"sniff"/) {
+                if (!inserted && !route_rule_precedes_ads(buffer)) {
                     while ((getline rule_line < rules_file) > 0) {
                         print rule_line
                     }
                     close(rules_file)
                     inserted = 1
                 }
+                printf "%s", buffer
             }
             reset_buffer()
         }
@@ -312,6 +318,13 @@ magicnet_block_apply_singbox() {
                 next
             }
             if (in_rules && $0 ~ /^    ][,]?[[:space:]]*$/) {
+                if (!inserted) {
+                    while ((getline rule_line < rules_file) > 0) {
+                        print rule_line
+                    }
+                    close(rules_file)
+                    inserted = 1
+                }
                 in_rules = 0
                 print
                 next

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh
@@ -70,6 +70,30 @@ magicnet_emit_selector_json() {
     printf '    }'
 }
 
+magicnet_emit_selector_json_exact() {
+    _exact_tag="$1"
+    _exact_tags="$2"
+    _exact_fallback="$3"
+    _exact_items=$(printf '%s\n%s\n' "$_exact_fallback" "$_exact_tags" | awk 'NF && !seen[$0]++')
+    _exact_first=1
+    printf '    {\n'
+    printf '      "type": "selector",\n'
+    printf '      "tag": "%s",\n' "$(magicnet_json_escape "$_exact_tag")"
+    printf '      "outbounds": ['
+    while IFS= read -r _exact_item; do
+        [ -n "$_exact_item" ] || continue
+        [ "$_exact_first" -eq 1 ] || printf ', '
+        printf '"%s"' "$(magicnet_json_escape "$_exact_item")"
+        _exact_first=0
+    done <<EOF
+$_exact_items
+EOF
+    printf '],\n'
+    printf '      "default": "%s"\n' "$(magicnet_json_escape "$_exact_fallback")"
+    printf '    }'
+    unset _exact_tag _exact_tags _exact_fallback _exact_items _exact_first _exact_item
+}
+
 magicnet_uri_query_value() {
     _key="$1"
     _query="$2"

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
@@ -70,6 +70,10 @@ magicnet_singbox_build_outbounds_file_with_jq() {
     def selector($tag; $outs; $fallback):
       (with_base($outs; $fallback)) as $items
       | {"type": "selector", "tag": $tag, "outbounds": $items, "default": $items[0]};
+    def selector_exact($tag; $outs; $fallback):
+      (reduce ([$fallback] + $outs)[] as $item
+        ([]; if ($item == "" or index($item)) then . else . + [$item] end)) as $items
+      | {"type": "selector", "tag": $tag, "outbounds": $items, "default": $fallback};
     def mainland_node_tag:
       test("中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:China|Mainland|Hong[ _-]?Kong|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
     def pinned_ai_selector($tag; $tags):
@@ -106,7 +110,7 @@ magicnet_singbox_build_outbounds_file_with_jq() {
           selector("select"; ["proxy", "direct"]; "proxy"),
           selector("lan"; ["direct"]; "direct"),
           selector("ad-block"; ["block", "direct", "proxy"]; "block"),
-          selector("ad-allow"; ["direct", "proxy"]; "direct"),
+          selector_exact("ad-allow"; ["final", "direct", "proxy"]; "final"),
           selector("cn-direct"; ["direct"]; "direct"),
           selector("apple-cn"; ["direct", "proxy"]; "direct"),
           selector("microsoft-cn"; ["direct", "proxy"]; "direct"),
@@ -215,7 +219,7 @@ magicnet_singbox_emit_static_selectors() {
     printf ',\n'
     magicnet_emit_selector_json "ad-block" "$(printf '%s\n%s\n%s\n' "block" "direct" "proxy")" "block"
     printf ',\n'
-    magicnet_emit_selector_json "ad-allow" "$(printf '%s\n%s\n' "direct" "proxy")" "direct"
+    magicnet_emit_selector_json_exact "ad-allow" "$(printf '%s\n%s\n%s\n' "final" "direct" "proxy")" "final"
     printf ',\n'
     magicnet_emit_selector_json "bing" "$(printf '%s\n%s\n' "proxy" "direct")" "proxy"
     printf ',\n'

--- a/webui/src/components/pages/AppsPage.vue
+++ b/webui/src/components/pages/AppsPage.vue
@@ -126,8 +126,8 @@ function requestAddPackage(pkg: string, target: "proxy" | "bypass", key = `add-$
     key,
     command: `app add ${pkg} ${target}`,
     message: target === "proxy"
-      ? `确认把 ${pkg} 加入 Proxy 名单？实际接管效果取决于当前黑/白名单模式。`
-      : `确认把 ${pkg} 加入 Bypass 名单？实际绕过效果取决于当前黑/白名单模式。`,
+      ? `确认把 ${pkg} 加入 Proxy 名单？该应用将强制走 MagicNet proxy。`
+      : `确认把 ${pkg} 加入 Bypass 名单？该应用将绕过 MagicNet TUN。`,
     plan: actionPlan({ type: "add", target, packages: [pkg] }),
     run: () => addPackage(pkg, target, key)
   };
@@ -185,7 +185,7 @@ function requestSetMode(mode: "blacklist" | "whitelist"): void {
   pendingAppAction.value = {
     key: `mode-${mode}`,
     command: `app mode ${mode}`,
-    message: mode === "blacklist" ? "确认切换到黑名单模式？应用分流语义会立即改变。" : "确认切换到白名单模式？只有 Proxy 名单应用会进入 TUN。",
+    message: mode === "blacklist" ? "确认切换到黑名单模式？未列出应用将正常进入 TUN。" : "确认切换到白名单模式？未列出应用将绕过 TUN。",
     plan: actionPlan({ type: "mode", mode }),
     run: () => setMode(mode)
   };
@@ -291,7 +291,7 @@ onMounted(() => {
 
 <template>
   <div class="grid gap-4">
-    <PageHeader overline="Per App Policy" title="应用名单" description="只管理应用进入或绕过 MagicNet TUN 的名单，不做节点和代理模式控制。">
+    <PageHeader overline="Per App Policy" title="应用名单" description="Proxy 强制应用走 MagicNet proxy；Bypass 让应用绕过 TUN；模式控制未列出应用是否进入 TUN。">
       <div class="flex flex-wrap gap-2">
         <Button variant="outline" :loading="isRunning('refresh-apps')" @click="withAction('refresh-apps', () => refreshApps())"><RefreshCw :size="17" />读取名单</Button>
         <Button variant="outline" :loading="isRunning('search-packages')" @click="searchPackages"><ListFilter :size="17" />重新读取应用</Button>
@@ -339,7 +339,7 @@ onMounted(() => {
           <button class="min-h-12 rounded px-3 text-sm text-zinc-400 disabled:cursor-progress disabled:opacity-60" :disabled="isRunning('mode-blacklist') || state.appPolicy.mode === 'blacklist'" :class="{ 'bg-zinc-800 text-zinc-50': state.appPolicy.mode === 'blacklist' }" @click="requestSetMode('blacklist')">黑名单</button>
           <button class="min-h-12 rounded px-3 text-sm text-zinc-400 disabled:cursor-progress disabled:opacity-60" :disabled="isRunning('mode-whitelist') || state.appPolicy.mode === 'whitelist'" :class="{ 'bg-zinc-800 text-zinc-50': state.appPolicy.mode === 'whitelist' }" @click="requestSetMode('whitelist')">白名单</button>
         </div>
-        <span class="text-sm text-zinc-500">黑名单模式下 Bypass 应用绕过 TUN；白名单模式下 Proxy 应用进入 TUN。</span>
+        <span class="text-sm text-zinc-500">Proxy 始终强制走 MagicNet proxy；Bypass 始终绕过 TUN；黑/白名单模式只控制未列出应用。</span>
       </div>
       <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
         <Input v-model="state.packageInput" placeholder="com.android.chrome" spellcheck="false" />
@@ -361,7 +361,7 @@ onMounted(() => {
           {{ policySummary.conflicts.length ? `${policySummary.conflicts.length} 个冲突` : '无冲突' }}
         </span>
       </div>
-      <div class="grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-5">
+      <div class="grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-6">
         <span
           v-for="item in policySummary.items"
           :key="item.label"

--- a/webui/src/components/pages/BlocklistPage.vue
+++ b/webui/src/components/pages/BlocklistPage.vue
@@ -130,7 +130,7 @@ function requestAddAllowRule(): void {
   pendingBlockAction.value = {
     key: `allow-${rule}`,
     command: `block allow-rule ${rule}`,
-    message: `确认把 ${rule} 加入广告放行白名单？它会优先于所有广告阻断规则，并通过 ad-allow 组选择 Direct 或 Proxy。`,
+    message: `确认把 ${rule} 加入广告放行白名单？它会优先于所有广告阻断规则，并默认继承主策略；也可在 ad-allow 组手动选择 Direct 或 Proxy。`,
     run: () => allowRule(rule)
   };
 }
@@ -139,7 +139,7 @@ function requestAllowRule(rule: string): void {
   pendingBlockAction.value = {
     key: `allow-${rule}`,
     command: `block allow-rule ${rule}`,
-    message: `确认把社区规则 ${rule} 加入广告放行白名单？流量将由 ad-allow 组选择 Direct 或 Proxy。`,
+    message: `确认把社区规则 ${rule} 加入广告放行白名单？流量默认继承主策略，也可在 ad-allow 组手动选择 Direct 或 Proxy。`,
     run: () => allowRule(rule)
   };
 }
@@ -261,7 +261,7 @@ async function confirmBlockAction(): Promise<void> {
 
 <template>
   <div class="grid gap-4">
-    <PageHeader overline="Community Banlist" title="联 ban 黑名单" description="广告放行白名单优先于所有广告阻断规则；ad-allow 组可选择 Direct 或 Proxy。">
+    <PageHeader overline="Community Banlist" title="联 ban 黑名单" description="广告放行白名单优先于所有广告阻断规则；ad-allow 默认继承主策略，也可手动选择 Direct 或 Proxy。">
       <div class="flex flex-wrap items-center gap-2">
         <Button variant="outline" :loading="isRunning('refresh-block')" @click="withAction('refresh-block', () => refreshBlock())"><RefreshCw :size="17" />读取</Button>
         <Button :loading="isRunning('update-block')" @click="requestUpdateCommunityBlocklist"><DownloadCloud :size="17" />更新社区库</Button>
@@ -360,7 +360,7 @@ async function confirmBlockAction(): Promise<void> {
 
       <Card>
         <h3 class="mb-1 text-base font-semibold">广告放行白名单</h3>
-        <p class="mb-3 text-sm leading-6 text-zinc-500">优先于内置、规则集和社区广告规则；放行方式由 ad-allow 组选择 Direct 或 Proxy。</p>
+        <p class="mb-3 text-sm leading-6 text-zinc-500">优先于内置、规则集和社区广告规则；ad-allow 默认继承主策略，也可手动选择 Direct 或 Proxy。</p>
         <div class="mb-3 grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
           <Input v-model="allowRuleInput" placeholder="example.com 或 DOMAIN-SUFFIX,example.com" spellcheck="false" @keyup.enter="requestAddAllowRule" />
           <Button variant="secondary" :loading="isRunning(`allow-${allowRuleInput.trim()}`)" @click="requestAddAllowRule"><Plus :size="16" />加入白名单</Button>

--- a/webui/src/components/pages/appPolicyChangePlan.ts
+++ b/webui/src/components/pages/appPolicyChangePlan.ts
@@ -80,7 +80,7 @@ function changedPackages(
 
 function modeWarnings(beforeMode: AppPolicyMode, after: { mode: AppPolicyMode; proxy: string[]; bypass: string[] }): string[] {
   if (beforeMode === after.mode) return [];
-  if (after.mode === "whitelist" && !after.proxy.length) return ["白名单模式下 Proxy 为空，普通应用将不会进入 TUN。"];
+  if (after.mode === "whitelist" && !after.proxy.length) return ["白名单模式下 Proxy 为空，未列出应用将绕过 TUN。"];
   if (after.mode === "blacklist" && !after.bypass.length) return ["黑名单模式下 Bypass 为空，除系统排除外应用会默认进入 TUN。"];
   return [];
 }
@@ -91,12 +91,13 @@ function effectiveRoutingChanges(
   installedPackages: Set<string>
 ): number | null {
   if (!installedPackages.size) return null;
-  return Array.from(installedPackages).filter((pkg) => entersTun(before, pkg) !== entersTun(after, pkg)).length;
+  return Array.from(installedPackages).filter((pkg) => effectiveRoute(before, pkg) !== effectiveRoute(after, pkg)).length;
 }
 
-function entersTun(state: { mode: AppPolicyMode; proxy: string[]; bypass: string[] }, pkg: string): boolean {
-  if (state.mode === "whitelist") return state.proxy.includes(pkg);
-  return !state.bypass.includes(pkg);
+function effectiveRoute(state: { mode: AppPolicyMode; proxy: string[]; bypass: string[] }, pkg: string): "proxy" | "tun" | "bypass" {
+  if (state.proxy.includes(pkg)) return "proxy";
+  if (state.bypass.includes(pkg) || state.mode === "whitelist") return "bypass";
+  return "tun";
 }
 
 function movedPackageWarnings(before: { proxy: string[]; bypass: string[] }, after: { proxy: string[]; bypass: string[] }): string[] {

--- a/webui/src/components/pages/appPolicyInsights.ts
+++ b/webui/src/components/pages/appPolicyInsights.ts
@@ -111,16 +111,18 @@ export function buildAppPolicySummary(
   const installedProxy = installedPackages.size ? proxy.filter((pkg) => installedPackages.has(pkg)) : [];
   const installedBypass = installedPackages.size ? bypass.filter((pkg) => installedPackages.has(pkg)) : [];
   const installedKnown = installedPackages.size > 0;
-  const captured = mode === "whitelist" ? `${proxy.length} 个 Proxy 名单应用` : "除 Bypass 外的应用";
-  const bypassed = mode === "whitelist" ? "非 Proxy 名单应用" : `${bypass.length} 个 Bypass 名单应用`;
+  const unlisted = mode === "whitelist" ? "绕过 TUN" : "进入 TUN";
   return {
-    summary: mode === "whitelist" ? "白名单模式只让 Proxy 名单进入 TUN。" : "黑名单模式默认接管应用，Bypass 名单绕过 TUN。",
+    summary: mode === "whitelist"
+      ? "Proxy 名单强制走 MagicNet proxy；未列出应用绕过 TUN。"
+      : "Proxy 名单强制走 MagicNet proxy；Bypass 名单绕过 TUN，未列出应用正常进入 TUN。",
     conflicts,
     installedProxy,
     installedBypass,
     items: [
-      insight("接管范围", captured, proxy.length || mode === "blacklist" ? "success" : "warning"),
-      insight("绕过范围", bypassed, bypass.length || mode === "whitelist" ? "success" : "neutral"),
+      insight("Proxy 强制", `${proxy.length} 个`, proxy.length ? "success" : "neutral"),
+      insight("Bypass 绕过", `${bypass.length} 个`, bypass.length ? "success" : "neutral"),
+      insight("未列出应用", unlisted, mode === "blacklist" ? "success" : "neutral"),
       insight("名单冲突", conflicts.length ? `${conflicts.length} 个` : "无", conflicts.length ? "danger" : "success"),
       insight("当前列表命中", installedKnown ? `Proxy ${installedProxy.length} / Bypass ${installedBypass.length}` : "未读取应用", installedKnown ? "success" : "warning"),
       insight("可应用推荐", `${availableRecommendedCount} 个`, availableRecommendedCount ? "neutral" : "success")


### PR DESCRIPTION
## What changed

- make `ad-allow` inherit the normal `final` policy while keeping Direct/Proxy overrides
- generate the same exact selector in jq, no-jq, migration, and bundled config paths
- add a high-priority package rule so Proxy-listed apps really use the `proxy` outbound
- reload sing-box after app policy changes
- update multi-app writes transactionally and keep Proxy/Bypass lists mutually exclusive
- align WebUI wording with the effective behavior

## Root cause

`ad-allow` defaulted to Direct, so an allowed domain could still ignore the active Proxy/final policy. Per-app settings only changed TUN include/exclude fields and did not reload the running core; the Proxy list also lacked a package-to-proxy route rule.

## Validation

- `sh scripts/test-ad-routing.sh`
- `sh scripts/test-app-routing-policy.sh`
- `cargo test -p magicnet-cli` (44 passed)
- `cargo fmt --all -- --check`
- `npm run typecheck` in `webui/`
- `npm run build` in `webui/`
- `pre-commit run --all-files` (`magicnet-validate` passed)
- parent and nested `git diff --check`
- `sing-box check` on bundled and generated configurations

Fixes #36
Fixes #37

Dependency: LIghtJUNction/MagicSingBox#3 (merged)