### PR TITLE
chore(release): prepare v1.1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Unreleased
 
+## v1.1.17 (2026-07-13)
+
+- Fix #36 by making `ad-allow` inherit the normal `final` policy by default,
+  while preserving explicit Direct and Proxy overrides across bundled, jq,
+  no-jq, and upgrade-generated configurations.
+- Fix #37 by adding a high-priority package rule for Proxy-listed apps and
+  restarting sing-box after app policy changes so the selected policy takes
+  effect immediately.
+- Update Proxy/Bypass lists transactionally during multi-app changes to avoid
+  partially applied policy state.
+
 ## v1.1.16 (2026-07-12)
 
 - Fix #34 with an explicit delete action for ad allowlist chips, and refresh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   <p>
-    <a href="kam.toml"><img alt="MagicNet v1.1.16" src="https://img.shields.io/badge/MagicNet-v1.1.16-31c2f2" /></a>
+    <a href="kam.toml"><img alt="MagicNet v1.1.17" src="https://img.shields.io/badge/MagicNet-v1.1.17-31c2f2" /></a>
     <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-green.svg" /></a>
     <a href="Cargo.toml"><img alt="Rust workspace" src="https://img.shields.io/badge/Rust-workspace-f46623?logo=rust&logoColor=white" /></a>
     <a href="webui/package.json"><img alt="Vue WebUI" src="https://img.shields.io/badge/WebUI-Vue%203-42b883?logo=vue.js&logoColor=white" /></a>
@@ -27,7 +27,7 @@ MagicNet 是一个 Android root 网络编排模块，把设备流量或显式代
 
 当前主线已经收敛为 **sing-box + 用户态编排**。`sing-box` 是唯一代理核心；MagicNet 提供 `proxy`、`external-tun`、`hybrid` 和兼容 `tun` 四种运行模式。下一代设计详见 [docs/next-gen-architecture.md](docs/next-gen-architecture.md)。旧的 TProxy 主路径、多核心切换和抓包代理功能都不再作为主线能力维护。
 
-需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.16`。Release 以发布页为准。
+需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.17`。Release 以发布页为准。
 
 ## 成果
 
@@ -108,9 +108,9 @@ chmod +x kam.sh
 
 ### Release 包
 
-当前 release 下载页：<https://github.com/LIghtJUNction/MagicNet/releases/tag/v1.1.16>
+当前 release 下载页：<https://github.com/LIghtJUNction/MagicNet/releases/tag/v1.1.17>
 
-直接下载当前模块包：<https://github.com/LIghtJUNction/MagicNet/releases/download/v1.1.16/MagicNet.zip>
+直接下载当前模块包：<https://github.com/LIghtJUNction/MagicNet/releases/download/v1.1.17/MagicNet.zip>
 
 ```bash
 kam -S MagicNet

--- a/kam.toml
+++ b/kam.toml
@@ -1,8 +1,8 @@
 [prop]
 id = "MagicNet"
 name = "MagicNet"
-version = "v1.1.16"
-versionCode = 1783870364521
+version = "v1.1.17"
+versionCode = 1783916779259
 author = "LIghtJUNction"
 description = "[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM."
 updateJson = "https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json"

--- a/src/MagicNet/README.md
+++ b/src/MagicNet/README.md
@@ -5,7 +5,7 @@ MagicNet 是一个 Android root TUN 透明代理模块，用 `sing-box` 和 `mag
 > [!IMPORTANT]
 > DNS 防泄露必读：请打开系统设置，搜索 `DNS`，找到“私人 DNS”“私密 DNS”“Private DNS”或类似表述，把私人 DNS 关闭，不要设置为自动加密。必须让 DNS 正常走 53 端口，让 MagicNet 模块接管并代理 DNS；否则 Android 系统或浏览器可能直接使用 DoT/DoH，导致 DNS 泄露检测仍然显示外部解析器。
 
-> 需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.16`。Release 以发布页为准。
+> 需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.17`。Release 以发布页为准。
 
 ## 定位
 

--- a/src/MagicNet/module.prop
+++ b/src/MagicNet/module.prop
@@ -1,7 +1,7 @@
 id=MagicNet
 name=MagicNet
-version=v1.1.16
-versionCode=1783870364521
+version=v1.1.17
+versionCode=1783916779259
 author=LIghtJUNction
 description=[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM.
 updateJson=https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
   "changelog": "https://github.com/LIghtJUNction/MagicNet/blob/main/CHANGELOG.md",
-  "version": "v1.1.16",
-  "versionCode": 1783870364521,
+  "version": "v1.1.17",
+  "versionCode": 1783916779259,
   "zipUrl": "https://github.com/LIghtJUNction/MagicNet/releases/latest/download/MagicNet.zip"
 }


### PR DESCRIPTION
## Release v1.1.17

- fix #36 by letting `ad-allow` inherit the active `final` policy by default across bundled, jq, no-jq, and migration paths
- fix #37 by forcing Proxy-listed apps through the proxy outbound and reloading policy changes immediately
- make multi-app policy list updates transactional

## Validation

- `kam validate`
- `jq empty update.json`
- version consistency across `kam.toml`, `update.json`, README files, packaged `module.prop`, and CHANGELOG
- `pre-commit run --all-files` / `magicnet-validate`
- `git diff --check`

The formal release will be created by the repository's `exec.yml` workflow after this PR merges.