### PR TITLE
fix(routing): normalize ad allow URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+## v1.1.18 (2026-07-13)
+
+- Fix #40 by normalizing pasted HTTP(S) URLs in the WebUI to canonical hostnames
+  and canonicalizing valid CLI allow-rule inputs while rejecting invalid or unsupported values.
+- Migrate legacy scheme-bearing `ad-allow` rules atomically and idempotently,
+  validated with real-device A/B tests of the allow and block paths.
+
 ## v1.1.17 (2026-07-13)
 
 - Fix #36 by making `ad-allow` inherit the normal `final` policy by default,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   <p>
-    <a href="kam.toml"><img alt="MagicNet v1.1.17" src="https://img.shields.io/badge/MagicNet-v1.1.17-31c2f2" /></a>
+    <a href="kam.toml"><img alt="MagicNet v1.1.18" src="https://img.shields.io/badge/MagicNet-v1.1.18-31c2f2" /></a>
     <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-green.svg" /></a>
     <a href="Cargo.toml"><img alt="Rust workspace" src="https://img.shields.io/badge/Rust-workspace-f46623?logo=rust&logoColor=white" /></a>
     <a href="webui/package.json"><img alt="Vue WebUI" src="https://img.shields.io/badge/WebUI-Vue%203-42b883?logo=vue.js&logoColor=white" /></a>
@@ -27,7 +27,7 @@ MagicNet 是一个 Android root 网络编排模块，把设备流量或显式代
 
 当前主线已经收敛为 **sing-box + 用户态编排**。`sing-box` 是唯一代理核心；MagicNet 提供 `proxy`、`external-tun`、`hybrid` 和兼容 `tun` 四种运行模式。下一代设计详见 [docs/next-gen-architecture.md](docs/next-gen-architecture.md)。旧的 TProxy 主路径、多核心切换和抓包代理功能都不再作为主线能力维护。
 
-需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.17`。Release 以发布页为准。
+需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.18`。Release 以发布页为准。
 
 ## 成果
 
@@ -108,9 +108,9 @@ chmod +x kam.sh
 
 ### Release 包
 
-当前 release 下载页：<https://github.com/LIghtJUNction/MagicNet/releases/tag/v1.1.17>
+当前 release 下载页：<https://github.com/LIghtJUNction/MagicNet/releases/tag/v1.1.18>
 
-直接下载当前模块包：<https://github.com/LIghtJUNction/MagicNet/releases/download/v1.1.17/MagicNet.zip>
+直接下载当前模块包：<https://github.com/LIghtJUNction/MagicNet/releases/download/v1.1.18/MagicNet.zip>
 
 ```bash
 kam -S MagicNet

--- a/crates/magicnet-cli/src/rules.rs
+++ b/crates/magicnet-cli/src/rules.rs
@@ -441,6 +441,86 @@ pub(super) fn normalize_block_rule(rule: &str) -> String {
     }
 }
 
+pub(super) fn normalize_allow_rule(rule: &str) -> Result<String, String> {
+    let value = rule.trim();
+    let (kind, payload) = match value.split_once(',') {
+        Some((kind, payload)) => (kind.trim().to_ascii_uppercase(), payload.trim()),
+        None => ("DOMAIN-SUFFIX".to_string(), value),
+    };
+    if payload.is_empty() {
+        return Err("invalid allow rule: missing domain or keyword".to_string());
+    }
+
+    match kind.as_str() {
+        "DOMAIN" | "DOMAIN-SUFFIX" => {
+            let host = normalize_allow_host(payload)?;
+            Ok(format!("{kind},{host}"))
+        }
+        "DOMAIN-KEYWORD" => {
+            if payload.chars().any(char::is_whitespace) {
+                return Err("invalid allow rule: keyword must not contain whitespace".to_string());
+            }
+            Ok(format!("{kind},{}", payload.to_ascii_lowercase()))
+        }
+        _ => Err(format!(
+            "invalid allow rule type: {kind}; expected DOMAIN, DOMAIN-SUFFIX, or DOMAIN-KEYWORD"
+        )),
+    }
+}
+
+fn normalize_allow_host(value: &str) -> Result<String, String> {
+    let mut authority = value;
+    if let Some(scheme_end) = value.find("://") {
+        let scheme = &value[..scheme_end];
+        if !scheme.eq_ignore_ascii_case("http") && !scheme.eq_ignore_ascii_case("https") {
+            return Err(format!(
+                "unsupported allow rule URL scheme: {scheme}; expected http or https"
+            ));
+        }
+        authority = &value[scheme_end + 3..];
+    }
+    authority = authority.split(['/', '?', '#']).next().unwrap_or_default();
+    authority = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    if authority.is_empty() {
+        return Err("invalid allow rule URL: missing host".to_string());
+    }
+
+    let host = if let Some(bracketed) = authority.strip_prefix('[') {
+        let Some(end) = bracketed.find(']') else {
+            return Err("invalid allow rule host".to_string());
+        };
+        let suffix = &bracketed[end + 1..];
+        if !suffix.is_empty() && (!suffix.starts_with(':') || !valid_allow_port(&suffix[1..])) {
+            return Err("invalid allow rule URL port".to_string());
+        }
+        &bracketed[..end]
+    } else if let Some((host, port)) = authority.rsplit_once(':') {
+        if host.contains(':') || !valid_allow_port(port) {
+            return Err("invalid allow rule URL port".to_string());
+        }
+        host
+    } else {
+        authority
+    };
+
+    let host = host.trim_end_matches('.').to_ascii_lowercase();
+    if host.is_empty()
+        || host.chars().any(|character| {
+            character.is_whitespace() || matches!(character, '/' | '?' | '#' | ',' | '@' | ':')
+        })
+    {
+        return Err("invalid allow rule host".to_string());
+    }
+    Ok(host)
+}
+
+fn valid_allow_port(port: &str) -> bool {
+    port.is_empty()
+        || (port.bytes().all(|byte| byte.is_ascii_digit()) && port.parse::<u16>().is_ok())
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -512,5 +592,36 @@ mod tests {
             .to_string_lossy()
             .contains(".tmp")));
         fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn allow_rule_normalization_extracts_url_hosts() {
+        assert_eq!(
+            normalize_allow_rule("https://Forum.Mobilism.org.:443/path?q=1#topic").unwrap(),
+            "DOMAIN-SUFFIX,forum.mobilism.org"
+        );
+        assert_eq!(
+            normalize_allow_rule("domain,HTTP://Ads.Example.COM:8080/banner").unwrap(),
+            "DOMAIN,ads.example.com"
+        );
+    }
+
+    #[test]
+    fn allow_rule_normalization_canonicalizes_domains_and_keywords() {
+        assert_eq!(
+            normalize_allow_rule("Example.COM.").unwrap(),
+            "DOMAIN-SUFFIX,example.com"
+        );
+        assert_eq!(
+            normalize_allow_rule("domain-keyword,Sponsor").unwrap(),
+            "DOMAIN-KEYWORD,sponsor"
+        );
+    }
+
+    #[test]
+    fn allow_rule_normalization_rejects_invalid_urls() {
+        assert!(normalize_allow_rule("DOMAIN-SUFFIX,ftp://example.com").is_err());
+        assert!(normalize_allow_rule("DOMAIN,https://").is_err());
+        assert!(normalize_allow_rule("DOMAIN-SUFFIX,https:///missing-host").is_err());
     }
 }

--- a/crates/magicnet-cli/src/rules/block.rs
+++ b/crates/magicnet-cli/src/rules/block.rs
@@ -7,7 +7,7 @@ use crate::service::restart_current_core;
 use crate::subscriptions::validate_subscription_url;
 use crate::{clean_lines, read_kv, run_magicnet_function, write_kv, App};
 
-use super::{conf_dir, normalize_block_rule, print_lines, update_line};
+use super::{conf_dir, normalize_allow_rule, normalize_block_rule, print_lines, update_line};
 
 pub(crate) fn block_cmd(app: &App, args: &[String]) -> Result<(), String> {
     let dir = conf_dir(app);
@@ -136,11 +136,16 @@ fn block_allow(app: &App, args: &[String]) -> Result<(), String> {
     if rule.is_empty() {
         return Err("Usage: cli block {allow-rule|unallow-rule} <rule>".to_string());
     }
-    update_line(
-        conf_dir(app).join("block-allow-rules.list"),
-        &normalize_block_rule(rule),
-        args[0] == "allow-rule",
-    )?;
+    let normalized = normalize_allow_rule(rule)?;
+    let path = conf_dir(app).join("block-allow-rules.list");
+    let add = args[0] == "allow-rule";
+    if !add {
+        let legacy = normalize_block_rule(rule);
+        if legacy != normalized {
+            update_line(path.clone(), &legacy, false)?;
+        }
+    }
+    update_line(path, &normalized, add)?;
     apply_and_restart(app)?;
     println!("[info] Local allow rule updated");
     Ok(())

--- a/kam.toml
+++ b/kam.toml
@@ -1,8 +1,8 @@
 [prop]
 id = "MagicNet"
 name = "MagicNet"
-version = "v1.1.17"
-versionCode = 1783916779259
+version = "v1.1.18"
+versionCode = 1783938405765
 author = "LIghtJUNction"
 description = "[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM."
 updateJson = "https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json"

--- a/scripts/test-ad-routing.sh
+++ b/scripts/test-ad-routing.sh
@@ -63,8 +63,11 @@ assert_subscription_ad_allow \
 cat >"$MODDIR/.config/magicnet/block-allow-rules.list" <<'EOF'
 DOMAIN,ads.example.com
 DOMAIN-SUFFIX,example.org
-DOMAIN-SUFFIX,mobilism.org
+DOMAIN-SUFFIX,https://Forum.Mobilism.org.:443/path?from=legacy#post
+DOMAIN-SUFFIX,forum.mobilism.org
+DOMAIN-SUFFIX,https://forum.mobilism.org/duplicate
 DOMAIN-KEYWORD,sponsor
+PROCESS-NAME,KeepThis
 EOF
 cat >"$MODDIR/.config/magicnet/community-ban-rules.list" <<'EOF'
 DOMAIN,ads.example.com
@@ -104,7 +107,9 @@ cat >"$MODDIR/.config/sing-box/config.json" <<'EOF'
 EOF
 
 magicnet_block_apply_singbox
+ALLOW_RULES_AFTER_FIRST_APPLY=$(cat "$MODDIR/.config/magicnet/block-allow-rules.list")
 magicnet_block_apply_singbox
+[ "$ALLOW_RULES_AFTER_FIRST_APPLY" = "$(cat "$MODDIR/.config/magicnet/block-allow-rules.list")" ]
 
 CONFIG="$MODDIR/.config/sing-box/config.json"
 [ "$(grep -c '__magicnet_ad_allow__' "$CONFIG")" -eq 1 ]
@@ -115,8 +120,14 @@ grep -q '"outbound": "ad-allow"' "$CONFIG"
 grep -q '"outbound": "ad-block"' "$CONFIG"
 grep -q '"ads.example.com"' "$CONFIG"
 grep -q '"example.org"' "$CONFIG"
-grep -q '"mobilism.org"' "$CONFIG"
+grep -q '"forum.mobilism.org"' "$CONFIG"
 grep -q '"sponsor"' "$CONFIG"
+grep -qx 'DOMAIN-SUFFIX,forum.mobilism.org' "$MODDIR/.config/magicnet/block-allow-rules.list"
+grep -qx 'PROCESS-NAME,KeepThis' "$MODDIR/.config/magicnet/block-allow-rules.list"
+[ "$(grep -c '^DOMAIN-SUFFIX,forum\.mobilism\.org$' "$MODDIR/.config/magicnet/block-allow-rules.list")" -eq 1 ]
+if grep -Eiq 'DOMAIN(-SUFFIX)?,https?://' "$MODDIR/.config/magicnet/block-allow-rules.list"; then
+  exit 1
+fi
 if grep -A8 '__magicnet_block__' "$CONFIG" | grep -q 'ads.example.com'; then
   exit 1
 fi
@@ -128,7 +139,7 @@ STATIC_LINE=$(grep -n '"rule_set": "hagezi-anti-piracy"' "$CONFIG" | cut -d: -f1
 [ "$BLOCK_LINE" -lt "$STATIC_LINE" ]
 jq -e '
   any(.route.rules[];
-    .outbound == "ad-allow" and ((.domain_suffix // []) | index("mobilism.org")))
+    .outbound == "ad-allow" and ((.domain_suffix // []) | index("forum.mobilism.org")))
 ' "$CONFIG" >/dev/null
 
 : >"$MODDIR/.config/magicnet/block-allow-rules.list"

--- a/src/MagicNet/README.md
+++ b/src/MagicNet/README.md
@@ -5,7 +5,7 @@ MagicNet 是一个 Android root TUN 透明代理模块，用 `sing-box` 和 `mag
 > [!IMPORTANT]
 > DNS 防泄露必读：请打开系统设置，搜索 `DNS`，找到“私人 DNS”“私密 DNS”“Private DNS”或类似表述，把私人 DNS 关闭，不要设置为自动加密。必须让 DNS 正常走 53 端口，让 MagicNet 模块接管并代理 DNS；否则 Android 系统或浏览器可能直接使用 DoT/DoH，导致 DNS 泄露检测仍然显示外部解析器。
 
-> 需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.17`。Release 以发布页为准。
+> 需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.18`。Release 以发布页为准。
 
 ## 定位
 

--- a/src/MagicNet/lib/magicnet/blocklist.sh
+++ b/src/MagicNet/lib/magicnet/blocklist.sh
@@ -39,6 +39,65 @@ magicnet_block_list_values() {
     sed '/^[[:space:]]*$/d; /^[[:space:]]*#/d' "$_file" 2>/dev/null | awk '!seen[$0]++'
 }
 
+magicnet_block_normalize_allow_rules() {
+    _allow_file="$(magicnet_block_allow_file)"
+    [ -f "$_allow_file" ] || {
+        unset _allow_file
+        return 0
+    }
+    _allow_tmp="${_allow_file}.magicnet-normalize.$$"
+    if ! awk '
+        function trim(value) {
+            sub(/^[[:space:]]+/, "", value)
+            sub(/[[:space:]]+$/, "", value)
+            return value
+        }
+        function normalize(line,    value, comma, kind, payload, lower, scheme_end, authority, slash, host) {
+            value = trim(line)
+            comma = index(value, ",")
+            if (!comma) return line
+            kind = toupper(trim(substr(value, 1, comma - 1)))
+            if (kind != "DOMAIN" && kind != "DOMAIN-SUFFIX") return line
+            payload = trim(substr(value, comma + 1))
+            lower = tolower(payload)
+            if (index(lower, "http://") == 1) {
+                scheme_end = 8
+            } else if (index(lower, "https://") == 1) {
+                scheme_end = 9
+            } else {
+                return line
+            }
+            authority = substr(payload, scheme_end)
+            slash = match(authority, /[\/?#]/)
+            if (slash) authority = substr(authority, 1, slash - 1)
+            sub(/^.*@/, "", authority)
+            if (authority ~ /:[0-9]+$/) sub(/:[0-9]+$/, "", authority)
+            host = tolower(authority)
+            sub(/[.]+$/, "", host)
+            if (host == "" || host ~ /[[:space:]\/:,@]/) return line
+            return kind "," host
+        }
+        {
+            output = normalize($0)
+            key = trim(output)
+            if (key != "" && key !~ /^#/ && seen[key]++) next
+            print output
+        }
+    ' "$_allow_file" >"$_allow_tmp"; then
+        rm -f "$_allow_tmp"
+        unset _allow_file _allow_tmp
+        return 1
+    fi
+    if cmp -s "$_allow_file" "$_allow_tmp"; then
+        rm -f "$_allow_tmp"
+    elif ! mv -f "$_allow_tmp" "$_allow_file"; then
+        rm -f "$_allow_tmp"
+        unset _allow_file _allow_tmp
+        return 1
+    fi
+    unset _allow_file _allow_tmp
+}
+
 magicnet_block_manual_suffixes() {
     magicnet_block_list_values "$(magicnet_block_manual_file)" | awk '{ print "DOMAIN-SUFFIX," $0 }'
 }
@@ -248,6 +307,7 @@ magicnet_block_ensure_ad_selectors() {
 }
 
 magicnet_block_apply_singbox() {
+    magicnet_block_normalize_allow_rules || return 1
     _config="${MODDIR}/.config/sing-box/config.json"
     [ -f "$_config" ] || return 0
     magicnet_block_ensure_ad_selectors "$_config" || return 1

--- a/src/MagicNet/module.prop
+++ b/src/MagicNet/module.prop
@@ -1,7 +1,7 @@
 id=MagicNet
 name=MagicNet
-version=v1.1.17
-versionCode=1783916779259
+version=v1.1.18
+versionCode=1783938405765
 author=LIghtJUNction
 description=[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM.
 updateJson=https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
   "changelog": "https://github.com/LIghtJUNction/MagicNet/blob/main/CHANGELOG.md",
-  "version": "v1.1.17",
-  "versionCode": 1783916779259,
+  "version": "v1.1.18",
+  "versionCode": 1783938405765,
   "zipUrl": "https://github.com/LIghtJUNction/MagicNet/releases/latest/download/MagicNet.zip"
 }

--- a/webui/src/components/pages/BlocklistPage.vue
+++ b/webui/src/components/pages/BlocklistPage.vue
@@ -110,13 +110,44 @@ async function allowRule(rule: string): Promise<void> {
 
 function normalizeAllowRule(input: string): string | null {
   const raw = input.trim();
-  const candidate = raw.includes(",") ? raw : `DOMAIN-SUFFIX,${raw}`;
-  const match = candidate.match(/^(DOMAIN|DOMAIN-SUFFIX|DOMAIN-KEYWORD),(.+)$/i);
-  if (!match || !match[2].trim() || /\s/.test(match[2])) {
-    state.output = "白名单格式不对。支持 example.com、DOMAIN,example.com、DOMAIN-SUFFIX,example.com 或 DOMAIN-KEYWORD,example。";
+  const match = raw.match(/^([^,]+),(.*)$/);
+  const kind = (match?.[1] ?? "DOMAIN-SUFFIX").trim().toUpperCase();
+  const value = (match?.[2] ?? raw).trim();
+  if (!(["DOMAIN", "DOMAIN-SUFFIX", "DOMAIN-KEYWORD"] as string[]).includes(kind) || !value) {
+    state.output = "白名单格式不对。支持 example.com、http(s) URL、DOMAIN,example.com、DOMAIN-SUFFIX,example.com 或 DOMAIN-KEYWORD,example。";
     return null;
   }
-  const rule = `${match[1].toUpperCase()},${match[2].trim().toLowerCase()}`;
+
+  let normalizedValue = value.toLowerCase();
+  if (kind === "DOMAIN-KEYWORD") {
+    if (/\s/.test(value)) {
+      state.output = "白名单格式不对：DOMAIN-KEYWORD 需要非空且不含空格的关键词。";
+      return null;
+    }
+  } else {
+    const scheme = value.match(/^([a-z][a-z0-9+.-]*):\/\//i);
+    if (scheme && !/^https?$/i.test(scheme[1])) {
+      state.output = `白名单格式不对：DOMAIN 和 DOMAIN-SUFFIX 仅支持 http/https URL，不能使用 ${scheme[1]}。`;
+      return null;
+    }
+    if (scheme && !value.slice(scheme[0].length).split(/[/?#]/, 1)[0]) {
+      state.output = "白名单格式不对：URL 缺少有效主机名。示例：https://forum.mobilism.org";
+      return null;
+    }
+    try {
+      const url = new URL(scheme ? value : `http://${value}`);
+      normalizedValue = url.hostname.toLowerCase().replace(/\.+$/, "");
+    } catch {
+      state.output = "白名单格式不对：DOMAIN 和 DOMAIN-SUFFIX 需要有效域名或 http/https URL。示例：https://forum.mobilism.org";
+      return null;
+    }
+    if (!normalizedValue) {
+      state.output = "白名单格式不对：URL 缺少有效主机名。示例：https://forum.mobilism.org";
+      return null;
+    }
+  }
+
+  const rule = `${kind},${normalizedValue}`;
   if (state.blocklist.allowRules.includes(rule)) {
     state.output = `${rule} 已在广告放行白名单中。`;
     return null;


### PR DESCRIPTION
## Summary

- normalize pasted HTTP(S) URLs to canonical hosts in the WebUI and CLI
- migrate legacy scheme-bearing ad-allow rules atomically and idempotently
- add focused regression coverage and prepare v1.1.18 metadata

Related to #40.

## Validation

- 47 Rust tests and focused ad-routing regression
- WebUI typecheck and production build
- full MagicNet pre-commit validation, including fake-Magisk smoke
- PHK110 real-device A/B: allow path HTTP 200, blocked path HTTP 000
- independent code and device review approved