### PR TITLE
fix(routing): repair legacy AI selectors

### DIFF
--- a/.agents/skills/magicnet-device-debugging/SKILL.md
+++ b/.agents/skills/magicnet-device-debugging/SKILL.md
@@ -80,6 +80,20 @@ Interpret status conservatively:
 - `missing` or `permission denied` can be kernel, bpffs, SELinux, or vendor netd behavior.
 - netd `ALLOW_MULTI` is only evidence of netd capability. Do not treat it as permission to force eBPF redirect.
 
+## AI Website Routing Acceptance
+
+Do not accept an AI routing fix from config inspection alone. On the installed device, verify all four public websites through MagicNet's local HTTP proxy at `127.0.0.1:7892`:
+
+```sh
+adb shell 'su -M -c '\''for url in https://chatgpt.com/ https://gemini.google.com/ https://grok.com/ https://claude.ai/; do curl -sS -o /dev/null -w "%{http_code} $url\n" --max-time 30 -x http://127.0.0.1:7892 "$url"; done'\'''
+```
+
+- Require an HTTP response from every site. A redirect, authentication response, or application response proves reachability; timeout, DNS failure, TLS failure, or proxy failure does not.
+- For each request, collect sing-box logs proving traffic selected its dedicated outbound: `ai-chatgpt`, `ai-gemini`, `ai-grok`, or `ai-claude`. Reject any `missing outbound`, `outbound not found`, or equivalent error.
+- Follow command-line probes with a real browser visit when the user's acceptance criterion is website usability. Confirm the page loads through MagicNet rather than only proving TCP/TLS reachability.
+- If testing temporarily changes a selector through the Clash API or WebUI, record its original selection and restore it before finishing.
+- Redact subscription URLs, node credentials, tokens, cookies, authorization headers, and private browsing data from commands, logs, screenshots, and reports.
+
 ## Certificate-Less Packet Capture
 
 Use these methods when the user wants packet evidence without installing a CA certificate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+## v1.1.19 (2026-07-14)
+
+- Repair legacy sing-box subscription configurations that are missing the
+  fail-closed ChatGPT, Gemini, Grok, and Claude outbound selectors.
+- Validate cached AI selectors across jq and no-jq paths, rejecting malformed,
+  duplicate, or stale outbound references before rebuilding the subscription.
+
 ## v1.1.18 (2026-07-13)
 
 - Fix #40 by normalizing pasted HTTP(S) URLs in the WebUI to canonical hostnames

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   <p>
-    <a href="kam.toml"><img alt="MagicNet v1.1.18" src="https://img.shields.io/badge/MagicNet-v1.1.18-31c2f2" /></a>
+    <a href="kam.toml"><img alt="MagicNet v1.1.19" src="https://img.shields.io/badge/MagicNet-v1.1.19-31c2f2" /></a>
     <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-green.svg" /></a>
     <a href="Cargo.toml"><img alt="Rust workspace" src="https://img.shields.io/badge/Rust-workspace-f46623?logo=rust&logoColor=white" /></a>
     <a href="webui/package.json"><img alt="Vue WebUI" src="https://img.shields.io/badge/WebUI-Vue%203-42b883?logo=vue.js&logoColor=white" /></a>
@@ -27,7 +27,7 @@ MagicNet 是一个 Android root 网络编排模块，把设备流量或显式代
 
 当前主线已经收敛为 **sing-box + 用户态编排**。`sing-box` 是唯一代理核心；MagicNet 提供 `proxy`、`external-tun`、`hybrid` 和兼容 `tun` 四种运行模式。下一代设计详见 [docs/next-gen-architecture.md](docs/next-gen-architecture.md)。旧的 TProxy 主路径、多核心切换和抓包代理功能都不再作为主线能力维护。
 
-需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.18`。Release 以发布页为准。
+需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.19`。Release 以发布页为准。
 
 ## 成果
 
@@ -108,9 +108,9 @@ chmod +x kam.sh
 
 ### Release 包
 
-当前 release 下载页：<https://github.com/LIghtJUNction/MagicNet/releases/tag/v1.1.18>
+当前 release 下载页：<https://github.com/LIghtJUNction/MagicNet/releases/tag/v1.1.19>
 
-直接下载当前模块包：<https://github.com/LIghtJUNction/MagicNet/releases/download/v1.1.18/MagicNet.zip>
+直接下载当前模块包：<https://github.com/LIghtJUNction/MagicNet/releases/download/v1.1.19/MagicNet.zip>
 
 ```bash
 kam -S MagicNet

--- a/kam.toml
+++ b/kam.toml
@@ -1,8 +1,8 @@
 [prop]
 id = "MagicNet"
 name = "MagicNet"
-version = "v1.1.18"
-versionCode = 1783938405765
+version = "v1.1.19"
+versionCode = 1783965200465
 author = "LIghtJUNction"
 description = "[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM."
 updateJson = "https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json"

--- a/scripts/fake-magisk-smoke.sh
+++ b/scripts/fake-magisk-smoke.sh
@@ -617,6 +617,8 @@ mkdir -p "$MODDIR/.config/sing-box/.subscription-work"
          or .type == "shadowsocks"
          or .type == "hysteria2") | not
     ))
+    | .outbounds |= map(select(.tag != "ai-chatgpt" and .tag != "ai-gemini" and .tag != "ai-grok" and .tag != "ai-claude"))
+    | .outbounds += [{"type":"vmess","tag":"stale-device-node","server":"127.0.0.2","server_port":443,"uuid":"00000000-0000-0000-0000-000000000002","security":"auto"}]
 ' "$MODDIR/.config/sing-box/config.json" >"$TMP/base-sing-box-config.json"
 mv "$TMP/base-sing-box-config.json" "$MODDIR/.config/sing-box/config.json"
 "$HOST_JQ" -e '[.outbounds[] | select(.type == "selector")] | length > 0' \
@@ -640,6 +642,16 @@ sleep 1
 run env MODDIR="$MODDIR" MODPATH="$MODDIR" "$MODDIR/cli" service status >"$TMP/singbox-service-status.log"
 rg -q '^  sing-box: [0-9][0-9,]*$' "$TMP/singbox-service-status.log"
 "$HOST_JQ" -e '.outbounds[] | select(.tag == "old-cached-node")' "$MODDIR/.config/sing-box/config.json" >/dev/null
+if "$HOST_JQ" -e '.outbounds[] | select(.tag == "stale-device-node")' "$MODDIR/.config/sing-box/config.json" >/dev/null; then
+    echo "sing-box startup accepted a legacy config with missing AI selectors" >&2
+    exit 1
+fi
+# shellcheck disable=SC2016
+"$HOST_JQ" -e '
+    ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] as $names
+    | [.outbounds[] | select(.tag as $tag | $names | index($tag))]
+    | length == 4 and all(.type == "selector" and .default == "block" and .outbounds[0] == "block")
+' "$MODDIR/.config/sing-box/config.json" >/dev/null
 if "$HOST_JQ" -e '.outbounds[] | select(.tag == "fresh-sub-node")' "$MODDIR/.config/sing-box/config.json" >/dev/null; then
     echo "sing-box startup refreshed subscription instead of using cached config" >&2
     exit 1

--- a/scripts/test-anthropic-routing.sh
+++ b/scripts/test-anthropic-routing.sh
@@ -65,6 +65,40 @@ done
 for tag in 'HKT edge' 'CHK edge' 'hk01 edge' 'myhk edge'; do
   grep -Fxq "$tag" "$tmp_dir/pinned-ai-tags" || fail "Hong Kong boundary false positive: $tag"
 done
+jq 'del(.outbounds[] | select(.tag == "ai-chatgpt" or .tag == "ai-gemini" or .tag == "ai-grok" or .tag == "ai-claude"))' \
+  "$tmp_dir/generated.json" >"$tmp_dir/legacy-cached.json"
+cp "$tmp_dir/legacy-cached.json" "$tmp_dir/legacy-cached.before.json"
+magicnet_singbox_sanitize_generated_config "$tmp_dir/legacy-cached.json"
+jq -e '
+  ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] as $names
+  | [.outbounds[] | select(.tag as $tag | $names | index($tag))] as $groups
+  | ($groups | length) == 4
+    and ($groups | all(.type == "selector" and .default == "block" and .outbounds == ["block", "US stable", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "hk01 edge", "myhk edge"]))
+' "$tmp_dir/legacy-cached.json" >/dev/null || fail "legacy cached config AI selector repair mismatch"
+jq '.outbounds += [
+      {"type":"direct","tag":"ai-chatgpt"},
+      {"type":"selector","tag":"ai-gemini","outbounds":["direct"],"default":"direct"}
+    ]
+    | (.outbounds[] | select(.tag == "ai-grok") | .default) = "direct"' \
+  "$tmp_dir/generated.json" >"$tmp_dir/malformed-cached.json"
+cp "$tmp_dir/malformed-cached.json" "$tmp_dir/malformed-cached.before.json"
+magicnet_singbox_sanitize_generated_config "$tmp_dir/malformed-cached.json"
+jq -e '
+  ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] as $names
+  | [.outbounds[] | select(.tag as $tag | $names | index($tag))] as $groups
+  | ($groups | length) == 4
+    and ($groups | all(.type == "selector" and .default == "block" and .outbounds == ["block", "US stable", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "hk01 edge", "myhk edge"]))
+' "$tmp_dir/malformed-cached.json" >/dev/null || fail "malformed or duplicate AI selectors not canonicalized"
+mkdir "$tmp_dir/no-jq-bin"
+ln -s "$(command -v awk)" "$tmp_dir/no-jq-bin/awk"
+base_config="$MODULE_ROOT/.config/sing-box/config.json"
+jq 'del(.outbounds[] | select(.tag == "ai-chatgpt"))' "$base_config" >"$tmp_dir/no-jq-legacy.json"
+jq '(.outbounds[] | select(.tag == "ai-grok") | .default) = "direct"' "$base_config" >"$tmp_dir/no-jq-malformed.json"
+jq '(.outbounds[] | select(.tag == "ai-chatgpt") | .outbounds) += ["stale-missing-node"]' "$base_config" >"$tmp_dir/no-jq-stale-member.json"
+PATH="$tmp_dir/no-jq-bin" magicnet_singbox_ai_selectors_canonical "$base_config" || fail "pure-shell canonical validator rejected fresh config"
+! PATH="$tmp_dir/no-jq-bin" magicnet_singbox_ai_selectors_canonical "$tmp_dir/no-jq-legacy.json" 2>/dev/null || fail "pure-shell canonical validator accepted missing selectors"
+! PATH="$tmp_dir/no-jq-bin" magicnet_singbox_ai_selectors_canonical "$tmp_dir/no-jq-malformed.json" 2>/dev/null || fail "pure-shell canonical validator accepted malformed selectors"
+! PATH="$tmp_dir/no-jq-bin" magicnet_singbox_ai_selectors_canonical "$tmp_dir/no-jq-stale-member.json" 2>/dev/null || fail "pure-shell canonical validator accepted undefined selector member"
 jq -e '
   ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] as $names
   | [.outbounds[] | select(.tag as $tag | $names | index($tag))]

--- a/src/MagicNet/README.md
+++ b/src/MagicNet/README.md
@@ -5,7 +5,7 @@ MagicNet 是一个 Android root TUN 透明代理模块，用 `sing-box` 和 `mag
 > [!IMPORTANT]
 > DNS 防泄露必读：请打开系统设置，搜索 `DNS`，找到“私人 DNS”“私密 DNS”“Private DNS”或类似表述，把私人 DNS 关闭，不要设置为自动加密。必须让 DNS 正常走 53 端口，让 MagicNet 模块接管并代理 DNS；否则 Android 系统或浏览器可能直接使用 DoT/DoH，导致 DNS 泄露检测仍然显示外部解析器。
 
-> 需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.18`。Release 以发布页为准。
+> 需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.19`。Release 以发布页为准。
 
 ## 定位
 

--- a/src/MagicNet/lib/magicnet/common.sh
+++ b/src/MagicNet/lib/magicnet/common.sh
@@ -86,7 +86,10 @@ magicnet_singbox_config_has_nodes() {
         unset _config
         return 1
     }
-    grep -Eq '"type"[[:space:]]*:[[:space:]]*"(vless|hysteria2|trojan|vmess|shadowsocks|wireguard|tuic|anytls)"' "$_config"
+    [ "$(command -v magicnet_singbox_ai_selectors_canonical 2>/dev/null)" ] ||
+        . "${MODDIR}/lib/magicnet/singbox_subscribe/common.sh"
+    grep -Eq '"type"[[:space:]]*:[[:space:]]*"(vless|hysteria2|trojan|vmess|shadowsocks|wireguard|tuic|anytls)"' "$_config" &&
+        magicnet_singbox_ai_selectors_canonical "$_config"
     _rc=$?
     unset _config
     return "$_rc"

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh
@@ -8,6 +8,72 @@ magicnet_json_escape() {
         sed 's/[[:cntrl:]]//g; s/\\/\\\\/g; s/"/\\"/g'
 }
 
+magicnet_singbox_ai_selectors_canonical() {
+    _ai_config="$1"
+    if command -v jq >/dev/null 2>&1; then
+        jq -e '
+          ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] as $names
+          | [.outbounds[]? | select(.tag as $tag | $names | index($tag))] as $groups
+          | ([.outbounds[]?.tag] | unique) as $tags
+          | ($groups | length) == 4
+            and ($groups | all(
+              .type == "selector" and .default == "block"
+              and (.outbounds | type == "array" and length > 0 and .[0] == "block")
+              and (.outbounds | index("direct") == null and index("proxy") == null)
+              and (.outbounds | all(. as $member | $tags | index($member) != null))))
+        ' "$_ai_config" >/dev/null 2>&1
+        _ai_rc=$?
+    else
+        awk '
+          BEGIN {
+            split("ai-chatgpt ai-gemini ai-grok ai-claude", names)
+            for (i in names) wanted[names[i]] = 1
+          }
+          /^[[:space:]]*\{/ { object = $0 "\n"; next }
+          object != "" { object = object $0 "\n" }
+          object != "" && /^[[:space:]]*\}[,]?[[:space:]]*$/ {
+            objects[++object_count] = object
+            object = ""
+          }
+          END {
+            for (i = 1; i <= object_count; i++) {
+              tag = objects[i]
+              if (tag !~ /"tag"[[:space:]]*:/) continue
+              sub(/^.*"tag"[[:space:]]*:[[:space:]]*"/, "", tag)
+              sub(/".*/, "", tag)
+              tags[tag] = 1
+            }
+            for (i = 1; i <= object_count; i++) {
+              object = objects[i]
+              tag = object
+              if (tag !~ /"tag"[[:space:]]*:/) continue
+              sub(/^.*"tag"[[:space:]]*:[[:space:]]*"/, "", tag)
+              sub(/".*/, "", tag)
+              if (!(tag in wanted)) continue
+              count[tag]++
+              if (object !~ /"type"[[:space:]]*:[[:space:]]*"selector"/ ||
+                  object !~ /"default"[[:space:]]*:[[:space:]]*"block"/ ||
+                  object !~ /"outbounds"[[:space:]]*:[[:space:]]*\[[[:space:]]*"block"/ ||
+                  object ~ /"outbounds"[[:space:]]*:[^]]*"(direct|proxy)"/) bad = 1
+              members = object
+              sub(/^.*"outbounds"[[:space:]]*:[[:space:]]*\[/, "", members)
+              sub(/\].*/, "", members)
+              member_count = split(members, member, ",")
+              for (j = 1; j <= member_count; j++) {
+                gsub(/^[[:space:]]*"|"[[:space:]]*$/, "", member[j])
+                if (!(member[j] in tags)) bad = 1
+              }
+            }
+            for (name in wanted) if (count[name] != 1) bad = 1
+            exit bad ? 1 : 0
+          }
+        ' "$_ai_config"
+        _ai_rc=$?
+    fi
+    unset _ai_config
+    return "$_ai_rc"
+}
+
 magicnet_json_array_csv() {
     _values="$1"
     _first=1

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
@@ -281,12 +281,18 @@ magicnet_singbox_sanitize_generated_config() {
     _sanitize_config_file="$1"
     _sanitize_jq="$(command -v jq 2>/dev/null || true)"
     [ -n "$_sanitize_jq" ] || {
+        magicnet_singbox_ai_selectors_canonical "$_sanitize_config_file"
+        _sanitize_rc=$?
         unset _sanitize_config_file _sanitize_jq
-        return 0
+        return "$_sanitize_rc"
     }
 
     _sanitize_tmp_file="${_sanitize_config_file}.sanitized"
     "$_sanitize_jq" '
+      def mainland_node_tag:
+        test("中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:China|Mainland|Hong[ _-]?Kong|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
+      def pinned_ai_selector($tag; $tags):
+        {"type": "selector", "tag": $tag, "outbounds": (["block"] + $tags), "default": "block"};
       def has_match($rule):
         [
           "inbound",
@@ -307,10 +313,17 @@ magicnet_singbox_sanitize_generated_config() {
           "user",
           "user_id"
         ] | any(. as $key | $rule | has($key));
-      .outbounds = ((.outbounds // [])
-        | if any(.tag == "dns-guard") then .
-          else . + [{"type": "selector", "tag": "dns-guard", "outbounds": ["proxy", "block", "direct"], "default": "proxy"}]
-          end)
+      (.outbounds // []) as $outbounds
+      | ([$outbounds[]
+          | select(.type == "shadowsocks" or .type == "vmess" or .type == "vless" or .type == "trojan" or .type == "hysteria2" or .type == "anytls" or .type == "tuic")
+          | .tag // empty
+          | select(mainland_node_tag | not)]) as $ai_tags
+      | .outbounds = ($outbounds
+          | map(select(.tag as $tag | ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] | index($tag) == null))
+          | if any(.tag == "dns-guard") then .
+            else . + [{"type": "selector", "tag": "dns-guard", "outbounds": ["proxy", "block", "direct"], "default": "proxy"}]
+            end
+          | . + (["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] | map(pinned_ai_selector(.; $ai_tags))))
       | .route.rules = ((.route.rules // [])
         | map(select(((has("outbound") and (has_match(.) | not) and (has("action") | not)) | not))))
     ' "$_sanitize_config_file" >"$_sanitize_tmp_file" && mv -f "$_sanitize_tmp_file" "$_sanitize_config_file"

--- a/src/MagicNet/module.prop
+++ b/src/MagicNet/module.prop
@@ -1,7 +1,7 @@
 id=MagicNet
 name=MagicNet
-version=v1.1.18
-versionCode=1783938405765
+version=v1.1.19
+versionCode=1783965200465
 author=LIghtJUNction
 description=[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM.
 updateJson=https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
   "changelog": "https://github.com/LIghtJUNction/MagicNet/blob/main/CHANGELOG.md",
-  "version": "v1.1.18",
-  "versionCode": 1783938405765,
+  "version": "v1.1.19",
+  "versionCode": 1783965200465,
   "zipUrl": "https://github.com/LIghtJUNction/MagicNet/releases/latest/download/MagicNet.zip"
 }


### PR DESCRIPTION
Fix upgraded sing-box configurations that retain proxy nodes but lack the fail-closed ai-chatgpt, ai-gemini, ai-grok, and ai-claude selectors. Canonicalizes jq output, rejects malformed no-jq caches and stale members, and forces subscription refresh for legacy runtime configs.\n\nIncludes v1.1.19 release metadata and an updated real-device AI website acceptance gate.\n\nValidation: bash scripts/pre-commit.sh (exit 0).\n\nLive device/site testing was skipped at the user's explicit request.