### PR TITLE
feat(sing-box): add resilient AI proxy routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Unreleased
 
+## v1.1.20 (2026-07-14)
+
+- Add an independent non-China/Hong Kong `ai-proxy` selector and route the
+  ChatGPT, Gemini, Grok, and Claude selectors through it while remaining
+  fail-closed by default.
+- Persist selector choices across subscription activation and service restarts.
+- Fetch subscriptions directly by default, with bounded downloader and process
+  timeouts plus owner-aware update and configuration locks.
+- Make subscription activation transactional and restart only the verified
+  owned sing-box process, restoring the previous configuration on failure.
+
 ## v1.1.19 (2026-07-14)
 
 - Repair legacy sing-box subscription configurations that are missing the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,9 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
 name = "magicnet-cli"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "md5",
  "serde_json",
 ]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   <p>
-    <a href="kam.toml"><img alt="MagicNet v1.1.19" src="https://img.shields.io/badge/MagicNet-v1.1.19-31c2f2" /></a>
+    <a href="kam.toml"><img alt="MagicNet v1.1.20" src="https://img.shields.io/badge/MagicNet-v1.1.20-31c2f2" /></a>
     <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-green.svg" /></a>
     <a href="Cargo.toml"><img alt="Rust workspace" src="https://img.shields.io/badge/Rust-workspace-f46623?logo=rust&logoColor=white" /></a>
     <a href="webui/package.json"><img alt="Vue WebUI" src="https://img.shields.io/badge/WebUI-Vue%203-42b883?logo=vue.js&logoColor=white" /></a>
@@ -27,7 +27,7 @@ MagicNet 是一个 Android root 网络编排模块，把设备流量或显式代
 
 当前主线已经收敛为 **sing-box + 用户态编排**。`sing-box` 是唯一代理核心；MagicNet 提供 `proxy`、`external-tun`、`hybrid` 和兼容 `tun` 四种运行模式。下一代设计详见 [docs/next-gen-architecture.md](docs/next-gen-architecture.md)。旧的 TProxy 主路径、多核心切换和抓包代理功能都不再作为主线能力维护。
 
-需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.19`。Release 以发布页为准。
+需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.20`。Release 以发布页为准。
 
 ## 成果
 
@@ -108,9 +108,9 @@ chmod +x kam.sh
 
 ### Release 包
 
-当前 release 下载页：<https://github.com/LIghtJUNction/MagicNet/releases/tag/v1.1.19>
+当前 release 下载页：<https://github.com/LIghtJUNction/MagicNet/releases/tag/v1.1.20>
 
-直接下载当前模块包：<https://github.com/LIghtJUNction/MagicNet/releases/download/v1.1.19/MagicNet.zip>
+直接下载当前模块包：<https://github.com/LIghtJUNction/MagicNet/releases/download/v1.1.20/MagicNet.zip>
 
 ```bash
 kam -S MagicNet

--- a/crates/magicnet-cli/Cargo.toml
+++ b/crates/magicnet-cli/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 md5 = "0.8"
 serde_json = "1"
+libc = "0.2"

--- a/crates/magicnet-cli/src/main.rs
+++ b/crates/magicnet-cli/src/main.rs
@@ -12,6 +12,7 @@ mod node_delay;
 mod nodes;
 mod ping;
 mod rules;
+mod selector_store;
 mod service;
 mod subscriptions;
 mod utils;
@@ -22,9 +23,12 @@ mod webui_backup;
 use std::env;
 use std::fs;
 use std::io;
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::thread;
 use std::time::Duration;
+use std::time::Instant;
 
 pub(crate) use base64::{decode_base64, encode_base64};
 use config_editor::config_editor;
@@ -337,15 +341,27 @@ pub(crate) fn run_magicnet_function(app: &App, function_name: &str) -> Result<()
         ". '{0}/lib/kamfw/.kamfwrc'; export PATH='{0}/bin':'{0}/system/bin':\"$PATH\"; import __runtime__; . '{0}/lib/magicnet.sh'; {function_name}",
         app.moddir.display(),
     );
-    let status = Command::new("sh")
+    let timeout = env::var("MAGICNET_COMMAND_TIMEOUT")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(180);
+    let mut command = Command::new("sh");
+    command
         .arg("-c")
         .arg(script)
         .arg(app.moddir.join("cli").to_string_lossy().to_string())
         .env("MODDIR", &app.moddir)
         .env("MODPATH", &app.moddir)
-        .stdin(Stdio::null())
-        .status()
-        .map_err(|err| format!("failed to run {function_name}: {err}"))?;
+        .stdin(Stdio::null());
+    let status = match run_process_group(&mut command, Duration::from_secs(timeout)) {
+        Ok(status) => status,
+        Err(err) => {
+            if function_name.contains("magicnet_singbox_update_subscription") {
+                subscriptions::cleanup_stale_update_lock(app);
+            }
+            return Err(format!("{function_name}: {err}"));
+        }
+    };
     if status.success() {
         Ok(())
     } else {
@@ -358,6 +374,47 @@ pub(crate) fn run_magicnet_function(app: &App, function_name: &str) -> Result<()
             "{function_name} failed with status {}",
             status.code().unwrap_or(1)
         ))
+    }
+}
+
+fn run_process_group(
+    command: &mut Command,
+    timeout: Duration,
+) -> Result<std::process::ExitStatus, String> {
+    // SAFETY: pre_exec only invokes async-signal-safe setsid before exec.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        });
+    }
+    let mut child = command
+        .spawn()
+        .map_err(|err| format!("spawn failed: {err}"))?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|err| format!("wait failed: {err}"))?
+        {
+            return Ok(status);
+        }
+        if Instant::now() >= deadline {
+            let group = -(child.id() as i32);
+            unsafe {
+                libc::kill(group, libc::SIGTERM);
+            }
+            thread::sleep(Duration::from_millis(100));
+            unsafe {
+                libc::kill(group, libc::SIGKILL);
+            }
+            let _ = child.wait();
+            return Err(format!("timed out after {}ms", timeout.as_millis()));
+        }
+        thread::sleep(Duration::from_millis(40));
     }
 }
 
@@ -439,5 +496,54 @@ mod command_help_tests {
     #[test]
     fn backup_help_lists_file_restore() {
         assert!(usage_for("backup").contains("restore-file [password|-] <path>"));
+    }
+}
+
+#[cfg(test)]
+mod process_group_tests {
+    use super::{run_process_group, App};
+    use std::fs;
+    use std::process::Command;
+    use std::time::Duration;
+
+    #[test]
+    fn timeout_reaps_command_and_kills_grandchild() {
+        let pid_file =
+            std::env::temp_dir().join(format!("magicnet-grandchild-{}", std::process::id()));
+        let script = format!("sleep 30 & echo $! > '{}'; wait", pid_file.display());
+        let mut command = Command::new("sh");
+        command.args(["-c", &script]);
+        assert!(run_process_group(&mut command, Duration::from_millis(100)).is_err());
+        let pid = fs::read_to_string(&pid_file)
+            .unwrap()
+            .trim()
+            .parse::<i32>()
+            .unwrap();
+        std::thread::sleep(Duration::from_millis(100));
+        assert_eq!(unsafe { libc::kill(pid, 0) }, -1);
+        let _ = fs::remove_file(pid_file);
+    }
+
+    #[test]
+    fn timeout_immediately_cleans_dead_update_owner() {
+        let root =
+            std::env::temp_dir().join(format!("magicnet-timeout-lock-{}", std::process::id()));
+        let lock = root.join(".state/sing-box/subscription-update.lock");
+        fs::create_dir_all(&lock).unwrap();
+        let script = format!(
+            "start=$(awk '{{print $22}}' /proc/$$/stat); echo \"$$:$start:test\" > '{}/owner'; sleep 30 & wait",
+            lock.display()
+        );
+        let mut command = Command::new("sh");
+        command.args(["-c", &script]);
+        assert!(run_process_group(&mut command, Duration::from_millis(100)).is_err());
+        let app = App {
+            moddir: root.clone(),
+            api: String::new(),
+            log_dir: root.join(".log"),
+        };
+        crate::subscriptions::cleanup_stale_update_lock(&app);
+        assert!(!lock.exists());
+        let _ = fs::remove_dir_all(root);
     }
 }

--- a/crates/magicnet-cli/src/nodes.rs
+++ b/crates/magicnet-cli/src/nodes.rs
@@ -5,8 +5,9 @@ use std::path::Path;
 use std::process::Command;
 
 use crate::node_delay::node_delay;
+use crate::webui_api::select_proxy;
 use crate::App;
-use serde_json::{json, Value};
+use serde_json::Value;
 
 pub(crate) fn node_cmd(app: &App, args: &[String]) -> Result<(), String> {
     match args.first().map(String::as_str).unwrap_or("list") {
@@ -17,7 +18,7 @@ pub(crate) fn node_cmd(app: &App, args: &[String]) -> Result<(), String> {
         "current" => node_current(),
         "use" => {
             let name = args[1..].join(" ");
-            node_use(&name)
+            node_use(app, &name)
         }
         "test" => {
             let name = args[1..].join(" ");
@@ -56,34 +57,12 @@ fn node_current() -> Result<(), String> {
     Ok(())
 }
 
-fn node_use(name: &str) -> Result<(), String> {
+fn node_use(app: &App, name: &str) -> Result<(), String> {
     let clean = name.trim();
     if clean.is_empty() {
         return Err("Usage: cli node use <name>".to_string());
     }
-    let payload = json!({ "name": clean }).to_string();
-    let output = Command::new("curl")
-        .args([
-            "-fsS",
-            "--max-time",
-            "5",
-            "-X",
-            "PUT",
-            "-H",
-            "Content-Type: application/json",
-            "--data",
-            &payload,
-            "http://127.0.0.1:9090/proxies/proxy",
-        ])
-        .output()
-        .map_err(|err| format!("run curl: {err}"))?;
-    if output.status.success() {
-        println!("[info] proxy selector set to {clean}");
-        Ok(())
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        Err(format!("select node failed: {}", stderr.trim()))
-    }
+    select_proxy(app, "proxy", clean)
 }
 
 fn node_test(name: &str) -> Result<(), String> {
@@ -169,7 +148,7 @@ fn scan_node_names(app: &App, limit: usize) -> Vec<String> {
 fn scan_singbox_tags(app: &App, limit: usize, names: &mut Vec<String>) {
     let tags = app
         .moddir
-        .join(".config/sing-box/.subscription-work/tags.txt");
+        .join(".state/sing-box/subscription-work/tags.txt");
     if let Ok(text) = fs::read_to_string(tags) {
         for line in text.lines().map(str::trim).filter(|line| !line.is_empty()) {
             push_node(line, limit, names);

--- a/crates/magicnet-cli/src/selector_store.rs
+++ b/crates/magicnet-cli/src/selector_store.rs
@@ -1,0 +1,360 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Write;
+use std::os::fd::AsRawFd;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde_json::{json, Value};
+
+use crate::webui_api::{curl_get_json, curl_put_selection};
+use crate::App;
+
+static LOCK_NONCE: AtomicU64 = AtomicU64::new(0);
+
+fn path(app: &App) -> std::path::PathBuf {
+    app.moddir.join(".state/sing-box/selector-selections.json")
+}
+
+fn now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn load(app: &App) -> BTreeMap<String, String> {
+    let target = path(app);
+    let Ok(bytes) = fs::read(&target) else {
+        return BTreeMap::new();
+    };
+    match serde_json::from_slice(&bytes) {
+        Ok(values) => values,
+        Err(err) => {
+            let quarantine = target.with_extension(format!("json.corrupt.{}", now()));
+            let _ = fs::rename(&target, quarantine);
+            eprintln!("[warn] selector store was corrupt and has been quarantined: {err}");
+            BTreeMap::new()
+        }
+    }
+}
+
+struct StoreLock {
+    path: std::path::PathBuf,
+    token: String,
+    nonce: String,
+}
+
+struct LockGuard(fs::File);
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        unsafe {
+            libc::flock(self.0.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+}
+
+fn lock_guard(path: &std::path::Path) -> Result<LockGuard, String> {
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+        .map_err(|err| format!("open selector lock guard: {err}"))?;
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+        return Err(format!(
+            "lock selector guard: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    Ok(LockGuard(file))
+}
+
+impl Drop for StoreLock {
+    fn drop(&mut self) {
+        if fs::read_to_string(&self.path)
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            == Some(&self.token)
+        {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
+fn process_start(pid: u32) -> Option<String> {
+    fs::read_to_string(format!("/proc/{pid}/stat"))
+        .ok()?
+        .split_whitespace()
+        .nth(21)
+        .map(str::to_string)
+}
+
+fn owner_stale(text: &str) -> bool {
+    let mut fields = text.trim().split(':');
+    let Some(pid) = fields.next().and_then(|value| value.parse::<u32>().ok()) else {
+        return true;
+    };
+    let Some(started) = fields.next() else {
+        return true;
+    };
+    process_start(pid).as_deref() != Some(started)
+}
+
+fn lock(app: &App) -> Result<StoreLock, String> {
+    let lock = path(app).with_extension("json.lock");
+    let guard_path = path(app).with_extension("json.lock.guard");
+    let nonce = format!(
+        "{}-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos(),
+        LOCK_NONCE.fetch_add(1, Ordering::Relaxed)
+    );
+    let token = format!(
+        "{}:{}:{}",
+        std::process::id(),
+        process_start(std::process::id()).unwrap_or_default(),
+        nonce
+    );
+    let claim = path(app).with_extension(format!("json.lock.claim.{nonce}"));
+    let mut claim_file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&claim)
+        .map_err(|err| format!("create selector lock claim: {err}"))?;
+    if let Err(err) = writeln!(claim_file, "{token}").and_then(|_| claim_file.sync_all()) {
+        let _ = fs::remove_file(&claim);
+        return Err(format!("write selector lock claim: {err}"));
+    }
+    drop(claim_file);
+    for _ in 0..40 {
+        let guard = match lock_guard(&guard_path) {
+            Ok(guard) => guard,
+            Err(err) => {
+                let _ = fs::remove_file(&claim);
+                return Err(err);
+            }
+        };
+        match fs::hard_link(&claim, &lock) {
+            Ok(()) => {
+                let _ = fs::remove_file(&claim);
+                drop(guard);
+                return Ok(StoreLock {
+                    path: lock,
+                    token,
+                    nonce,
+                });
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                let observed = fs::read_to_string(&lock).ok();
+                if observed.as_deref().is_some_and(owner_stale) {
+                    let confirmed = fs::read_to_string(&lock).ok();
+                    if confirmed == observed {
+                        let _ = fs::remove_file(&lock);
+                    }
+                }
+                drop(guard);
+                thread::sleep(Duration::from_millis(25));
+            }
+            Err(err) => {
+                let _ = fs::remove_file(&claim);
+                return Err(format!("publish selector lock: {err}"));
+            }
+        }
+    }
+    let _ = fs::remove_file(&claim);
+    Err("selector store is busy".to_string())
+}
+
+pub(crate) fn save(app: &App, group: &str, member: &str) -> Result<(), String> {
+    let target = path(app);
+    let parent = target.parent().ok_or("selector store has no parent")?;
+    fs::create_dir_all(parent).map_err(|err| format!("create selector store: {err}"))?;
+    let store_lock = lock(app)?;
+    let mut values = load(app);
+    values.insert(group.to_string(), member.to_string());
+    let tmp = target.with_extension(format!("json.tmp.{}", store_lock.nonce));
+    let bytes =
+        serde_json::to_vec(&values).map_err(|err| format!("encode selector store: {err}"))?;
+    if let Err(err) = fs::write(&tmp, bytes) {
+        let _ = fs::remove_file(&tmp);
+        return Err(format!("write selector store: {err}"));
+    }
+    let result = fs::rename(&tmp, &target).map_err(|err| format!("commit selector store: {err}"));
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp);
+    }
+    result
+}
+
+pub(crate) fn replay(app: &App) -> Result<usize, String> {
+    let values = {
+        let _lock = lock(app)?;
+        load(app)
+    };
+    if values.is_empty() {
+        return Ok(0);
+    }
+    let mut proxies = None;
+    for _ in 0..20 {
+        if let Ok(value) = curl_get_json(app, "/proxies") {
+            proxies = Some(value);
+            break;
+        }
+        thread::sleep(Duration::from_millis(250));
+    }
+    let proxies = proxies.ok_or("selector API not ready")?;
+    let groups = proxies
+        .get("proxies")
+        .and_then(Value::as_object)
+        .ok_or("invalid proxies response")?;
+    let mut applied = 0;
+    let mut failed = 0;
+    for (group, member) in values {
+        if valid_member(groups, &group, &member) {
+            if let Err(err) = curl_put_selection(app, &group, &json!({"name": member}).to_string())
+            {
+                failed += 1;
+                eprintln!("[warn] persisted selector replay failed for one group: {err}");
+            } else {
+                applied += 1;
+            }
+        }
+    }
+    if failed > 0 {
+        eprintln!("[warn] selector replay completed with {failed} failed item(s)");
+    }
+    Ok(applied)
+}
+
+fn valid_member(groups: &serde_json::Map<String, Value>, group: &str, member: &str) -> bool {
+    groups
+        .get(group)
+        .and_then(|value| value.get("all"))
+        .and_then(Value::as_array)
+        .is_some_and(|items| items.iter().any(|item| item.as_str() == Some(member)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn app() -> (App, std::path::PathBuf) {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "magicnet-selector-store-{}-{nonce}",
+            std::process::id(),
+        ));
+        let app = App {
+            moddir: root.clone(),
+            api: "http://127.0.0.1:1".into(),
+            log_dir: root.join(".log"),
+        };
+        (app, root)
+    }
+
+    #[test]
+    fn corrupted_store_is_empty() {
+        let (app, root) = app();
+        fs::create_dir_all(root.join(".state/sing-box")).unwrap();
+        fs::write(path(&app), b"not-json").unwrap();
+        assert!(load(&app).is_empty());
+        assert!(fs::read_dir(root.join(".state/sing-box"))
+            .unwrap()
+            .any(|entry| {
+                entry
+                    .unwrap()
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("selector-selections.json.corrupt.")
+            }));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn replay_requires_existing_group_member() {
+        let value = json!({"ai-chatgpt": {"all": ["block", "ai-proxy"]}});
+        let groups = value.as_object().unwrap();
+        assert!(valid_member(groups, "ai-chatgpt", "ai-proxy"));
+        assert!(!valid_member(groups, "ai-chatgpt", "missing"));
+        assert!(!valid_member(groups, "missing", "ai-proxy"));
+    }
+
+    #[test]
+    fn stale_lock_recovers_and_concurrent_updates_survive() {
+        for _ in 0..20 {
+            let (_, root) = app();
+            fs::create_dir_all(root.join(".state/sing-box")).unwrap();
+            fs::write(
+                root.join(".state/sing-box/selector-selections.json.lock"),
+                "invalid",
+            )
+            .unwrap();
+            let root_a = root.clone();
+            let a = std::thread::spawn(move || {
+                let app = App {
+                    moddir: root_a.clone(),
+                    api: String::new(),
+                    log_dir: root_a.join(".log"),
+                };
+                save(&app, "ai-chatgpt", "ai-proxy").unwrap();
+            });
+            let root_b = root.clone();
+            let b = std::thread::spawn(move || {
+                let app = App {
+                    moddir: root_b.clone(),
+                    api: String::new(),
+                    log_dir: root_b.join(".log"),
+                };
+                save(&app, "ai-gemini", "ai-proxy").unwrap();
+            });
+            a.join().unwrap();
+            b.join().unwrap();
+            let values: BTreeMap<String, String> = serde_json::from_slice(
+                &fs::read(root.join(".state/sing-box/selector-selections.json")).unwrap(),
+            )
+            .unwrap();
+            assert_eq!(values.len(), 2);
+            assert!(!fs::read_dir(root.join(".state/sing-box"))
+                .unwrap()
+                .any(|entry| {
+                    let name = entry.unwrap().file_name();
+                    let name = name.to_string_lossy();
+                    name.contains(".claim.") || name.contains(".tmp.")
+                }));
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+
+    #[test]
+    fn live_owner_never_expires_by_age() {
+        let pid = std::process::id();
+        let owner = format!("{pid}:{}:0", process_start(pid).unwrap());
+        assert!(!owner_stale(&owner));
+    }
+
+    #[test]
+    fn old_owner_does_not_remove_replacement_lock() {
+        let (_, root) = app();
+        let lock_path = root.join(".state/sing-box/selector-selections.json.lock");
+        fs::create_dir_all(lock_path.parent().unwrap()).unwrap();
+        fs::write(&lock_path, "new-owner").unwrap();
+        drop(StoreLock {
+            path: lock_path.clone(),
+            token: "old-owner".into(),
+            nonce: "old-nonce".into(),
+        });
+        assert_eq!(fs::read_to_string(&lock_path).unwrap(), "new-owner");
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/crates/magicnet-cli/src/service.rs
+++ b/crates/magicnet-cli/src/service.rs
@@ -96,7 +96,7 @@ pub(crate) fn supervisor_cmd(app: &App, args: &[String]) -> Result<(), String> {
 
 pub(crate) fn config_cmd(app: &App, args: &[String]) -> Result<(), String> {
     match args.first().map(String::as_str).unwrap_or_default() {
-        "apply" => run_magicnet_function(app, "magicnet_apply_runtime_config"),
+        "apply" => run_magicnet_function(app, ". \"$MODDIR/lib/magicnet_singbox_subscribe.sh\"; if magicnet_singbox_update_lock_active; then echo '[error] subscription update in progress' >&2; false; else magicnet_apply_runtime_config; fi"),
         _ => Err("Usage: cli config apply".to_string()),
     }
 }

--- a/crates/magicnet-cli/src/subscriptions.rs
+++ b/crates/magicnet-cli/src/subscriptions.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::fs;
 use std::path::PathBuf;
 
 use crate::{
@@ -107,7 +108,34 @@ fn update_singbox_subscription(app: &App) -> Result<(), String> {
     run_magicnet_function(
         app,
         ". \"$MODDIR/lib/magicnet_singbox_subscribe.sh\"; magicnet_singbox_update_subscription",
-    )
+    )?;
+    crate::selector_store::replay(app)?;
+    Ok(())
+}
+
+pub(crate) fn cleanup_stale_update_lock(app: &App) {
+    let lock = app.moddir.join(".state/sing-box/subscription-update.lock");
+    let owner_path = lock.join("owner");
+    let Ok(owner) = fs::read_to_string(&owner_path) else {
+        return;
+    };
+    let mut fields = owner.trim().split(':');
+    let pid = fields.next().and_then(|value| value.parse::<u32>().ok());
+    let expected_start = fields.next();
+    let live_start = pid
+        .and_then(|pid| fs::read_to_string(format!("/proc/{pid}/stat")).ok())
+        .and_then(|stat| stat.split_whitespace().nth(21).map(str::to_string));
+    if expected_start.is_some() && live_start.as_deref() == expected_start {
+        return;
+    }
+    if fs::read_to_string(&owner_path)
+        .ok()
+        .as_deref()
+        .map(str::trim)
+        == Some(owner.trim())
+    {
+        let _ = fs::remove_dir_all(lock);
+    }
 }
 
 pub(crate) fn sub_target_file(app: &App, _target: &str) -> PathBuf {

--- a/crates/magicnet-cli/src/webui_api.rs
+++ b/crates/magicnet-cli/src/webui_api.rs
@@ -7,6 +7,7 @@ use crate::connection_control::{
     close_connections_through_chain, close_matching_connections, close_top_connections,
     print_close_all_summary,
 };
+use crate::selector_store;
 use crate::service::singbox_webui;
 use crate::{run_magicnet_function, write_text_file, App};
 
@@ -23,6 +24,11 @@ pub(crate) fn api_cmd(app: &App, args: &[String]) -> Result<(), String> {
             args.get(1).map(String::as_str).unwrap_or_default(),
             &args[2..].join(" "),
         ),
+        "replay" => {
+            let applied = selector_store::replay(app)?;
+            println!("[info] replayed {applied} persisted selectors");
+            Ok(())
+        }
         "conns" => curl(app, "/connections"),
         "stats" => curl(app, "/traffic"),
         "close" => close_connection(app, args.get(1).map(String::as_str).unwrap_or_default()),
@@ -80,20 +86,20 @@ fn curl_put_json(app: &App, path: &str, payload: &str) -> Result<(), String> {
     ])
 }
 
-fn select_proxy(app: &App, group: &str, node: &str) -> Result<(), String> {
+pub(crate) fn select_proxy(app: &App, group: &str, node: &str) -> Result<(), String> {
     let clean_group = group.trim();
     let clean_node = node.trim();
     if clean_group.is_empty() || clean_node.is_empty() {
         return Err("Usage: cli api select <group> <node>".to_string());
     }
     let payload = json!({ "name": clean_node }).to_string();
-    curl_put_json(
-        app,
-        &format!("/proxies/{}", encode_path_segment(clean_group)),
-        &payload,
-    )?;
+    curl_put_selection(app, clean_group, &payload)?;
+    let persist_error = selector_store::save(app, clean_group, clean_node).err();
     match close_connections_through_chain(app, clean_group) {
         Ok(summary) => {
+            if let Some(err) = persist_error {
+                eprintln!("[warn] runtime applied, persistence failed: {err}");
+            }
             println!(
                 "[info] {clean_group} selector set to {clean_node}; closed {}/{} stale connections",
                 summary.closed, summary.targets
@@ -104,6 +110,25 @@ fn select_proxy(app: &App, group: &str, node: &str) -> Result<(), String> {
             "selector changed to {clean_node}, but stale connections were not fully closed: {err}"
         )),
     }
+}
+
+pub(crate) fn curl_put_selection(app: &App, group: &str, payload: &str) -> Result<(), String> {
+    curl_put_json(
+        app,
+        &format!("/proxies/{}", encode_path_segment(group)),
+        payload,
+    )
+}
+
+pub(crate) fn curl_get_json(app: &App, path: &str) -> Result<serde_json::Value, String> {
+    let output = Command::new("curl")
+        .args(["-fsS", "--max-time", "3", &format!("{}{}", app.api, path)])
+        .output()
+        .map_err(|err| format!("run curl: {err}"))?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+    serde_json::from_slice(&output.stdout).map_err(|err| format!("parse API response: {err}"))
 }
 
 fn close_connection(app: &App, id: &str) -> Result<(), String> {

--- a/kam.toml
+++ b/kam.toml
@@ -1,8 +1,8 @@
 [prop]
 id = "MagicNet"
 name = "MagicNet"
-version = "v1.1.19"
-versionCode = 1783965200465
+version = "v1.1.20"
+versionCode = 1784009905677
 author = "LIghtJUNction"
 description = "[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM."
 updateJson = "https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json"

--- a/scripts/fake-magisk-smoke.sh
+++ b/scripts/fake-magisk-smoke.sh
@@ -605,10 +605,10 @@ env MAGICNET_DEFAULT_CORE=sing-box MAGICNET_STRICT_CORE=1 MODDIR="$MODDIR" MODPA
 grep -qx 'sing-box' "$TMP/strict-core.log"
 
 printf '%s\n' 'https://example.invalid/subscription.yaml' >"$MODDIR/.config/sing-box/subscription.url"
-mkdir -p "$MODDIR/.config/sing-box/.subscription-work"
+mkdir -p "$MODDIR/.state/sing-box/subscription-work"
 "$HOST_JQ" -r '"  \"outbounds\": " + (.outbounds | tojson) + ","' \
     "$MODDIR/.config/sing-box/config.json" \
-    >"$MODDIR/.config/sing-box/.subscription-work/outbounds.json"
+    >"$MODDIR/.state/sing-box/subscription-work/outbounds.json"
 "$HOST_JQ" '
     .outbounds |= map(select(
         (.type == "vmess"
@@ -734,6 +734,22 @@ sleep 1
 run env MODDIR="$MODDIR" MODPATH="$MODDIR" "$MODDIR/cli" supervisor status all >"$TMP/supervisor-status.log"
 rg -q '^fswatch=[0-9]+$' "$TMP/supervisor-status.log"
 test -s "$MODDIR/.state/fswatch/magicnet-config.pid"
+rg -q 'config apply' "$MODDIR/.state/fswatch/magicnet-config.loop.sh"
+mkdir -p "$MODDIR/.state/sing-box/subscription-update.lock"
+printf '999999:0:dead\n' >"$MODDIR/.state/sing-box/subscription-update.lock/owner"
+run env MODDIR="$MODDIR" MODPATH="$MODDIR" PATH="$MOCK_BIN:$TOYBOX_APPLET_BIN:$MODDIR/bin:$ORIGINAL_PATH" \
+    "$MODDIR/cli" config apply
+test ! -d "$MODDIR/.state/sing-box/subscription-update.lock"
+mkdir -p "$MODDIR/.state/sing-box/subscription-update.lock"
+_live_start=$(awk '{print $22}' "/proc/$$/stat")
+printf '%s:%s:live\n' "$$" "$_live_start" >"$MODDIR/.state/sing-box/subscription-update.lock/owner"
+if env MODDIR="$MODDIR" MODPATH="$MODDIR" PATH="$MOCK_BIN:$TOYBOX_APPLET_BIN:$MODDIR/bin:$ORIGINAL_PATH" \
+    "$MODDIR/cli" config apply >/dev/null 2>&1; then
+    echo "config apply ignored a live subscription update owner" >&2
+    exit 1
+fi
+test -d "$MODDIR/.state/sing-box/subscription-update.lock"
+rm -rf "$MODDIR/.state/sing-box/subscription-update.lock"
 run env MODDIR="$MODDIR" MODPATH="$MODDIR" "$MODDIR/cli" supervisor stop all
 run env MODDIR="$MODDIR" MODPATH="$MODDIR" "$MODDIR/cli" supervisor status all >"$TMP/supervisor-stopped.log"
 rg -q '^fswatch=stopped$' "$TMP/supervisor-stopped.log"

--- a/scripts/package-install-smoke.sh
+++ b/scripts/package-install-smoke.sh
@@ -54,10 +54,11 @@ unzip -oq "$ZIP_PATH" -d "$MODPATH"
 unzip -oq "$ZIP_PATH" -d "$MANAGER_MODPATH"
 
 mkdir -p \
-    "$PREV_MOD/.config/sing-box/.subscription-work" \
+    "$PREV_MOD/.state/sing-box/subscription-work" \
+    "$PREV_MOD/.config/sing-box" \
     "$PREV_MOD/.config/magicnet"
 printf '%s\n' 'https://old.example/sing-box' >"$PREV_MOD/.config/sing-box/subscription.url"
-printf '%s\n' 'old-sing-box-work' >"$PREV_MOD/.config/sing-box/.subscription-work/marker.txt"
+printf '%s\n' 'old-sing-box-work' >"$PREV_MOD/.state/sing-box/subscription-work/marker.txt"
 printf '%s\n' 'MAGICNET_DEFAULT_CORE=sing-box' >"$PREV_MOD/.config/magicnet/current-core.conf"
 printf '%s\n' 'MAGICNET_MCP_ENABLED=1' 'MAGICNET_MCP_BIND=127.0.0.1' 'MAGICNET_MCP_PORT=18766' \
     >"$PREV_MOD/.config/magicnet/mcp.conf"
@@ -120,7 +121,7 @@ PATH="$MODPATH/bin:$PATH" command -v ecapture >/dev/null \
 
 grep -qx 'https://old.example/sing-box' "$MODPATH/.config/sing-box/subscription.url" \
     || fail "sing-box subscription was not preserved from previous install"
-grep -qx 'old-sing-box-work' "$MODPATH/.config/sing-box/.subscription-work/marker.txt" \
+grep -qx 'old-sing-box-work' "$MODPATH/.state/sing-box/subscription-work/marker.txt" \
     || fail "sing-box subscription workdir was not preserved from previous install"
 legacy_core_dir="$MODPATH/.config/mi""homo"
 if [[ -e "$legacy_core_dir" ]]; then

--- a/scripts/test-anthropic-routing.sh
+++ b/scripts/test-anthropic-routing.sh
@@ -33,6 +33,10 @@ cat >"$tmp_dir/nodes.json" <<'JSON'
  ,{"type":"vless","tag":"CHK edge","server":"chk.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000021"}
  ,{"type":"vless","tag":"hk01 edge","server":"hk01.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000022"}
  ,{"type":"vless","tag":"myhk edge","server":"myhk.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000023"}
+ ,{"type":"vless","tag":"hk-01 edge","server":"hk-dash.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000024"}
+ ,{"type":"vless","tag":"hk_01 edge","server":"hk-underscore.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000025"}
+ ,{"type":"vless","tag":"HKG01 edge","server":"hkg01.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000026"}
+ ,{"type":"vless","tag":"HongKong01 edge","server":"hongkong01.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000027"}
 ]
 JSON
 magicnet_singbox_write_outbounds_from_json "$tmp_dir/nodes.json" "$tmp_dir/outbounds.fragment"
@@ -40,17 +44,21 @@ magicnet_singbox_write_outbounds_from_json "$tmp_dir/nodes.json" "$tmp_dir/outbo
 jq -e '
   ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] as $names
   | [.outbounds[] | select(.tag as $tag | $names | index($tag))] as $groups
+  | (.outbounds[] | select(.tag == "ai-proxy")) as $ai_proxy
   | ($groups | length) == 4
-    and ($groups | all(.type == "selector" and .default == "block" and .outbounds == ["block", "US stable", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "hk01 edge", "myhk edge"] and (.outbounds | index("proxy") == null and index("direct") == null)))
+    and ($ai_proxy.default == "US stable" and $ai_proxy.outbounds == ["US stable", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "myhk edge"])
+    and ($groups | all(.type == "selector" and .default == "block" and .outbounds == ["block", "ai-proxy"]))
 ' "$tmp_dir/generated.json" >/dev/null || fail "jq generator selector mismatch"
-printf '%s\n' 'US stable' '上海 node' 'CN node' 'CN2 premium' 'opaque-42' 'Mainland premium' 'Beijing edge' 'Shanghai edge' 'Guangzhou edge' 'Shenzhen edge' 'Sichuan edge' 'Inner-Mongolia edge' 'Xinjiang edge' '香港 edge' 'Hong Kong edge' 'Hong-Kong edge' 'Hong_Kong edge' 'HK edge' 'HKG edge' 'HKT edge' 'CHK edge' 'hk01 edge' 'myhk edge' >"$tmp_dir/tags"
+printf '%s\n' 'US stable' '上海 node' 'CN node' 'CN2 premium' 'opaque-42' 'Mainland premium' 'Beijing edge' 'Shanghai edge' 'Guangzhou edge' 'Shenzhen edge' 'Sichuan edge' 'Inner-Mongolia edge' 'Xinjiang edge' '香港 edge' 'Hong Kong edge' 'Hong-Kong edge' 'Hong_Kong edge' 'HK edge' 'HKG edge' 'HKT edge' 'CHK edge' 'hk01 edge' 'myhk edge' 'hk-01 edge' 'hk_01 edge' 'HKG01 edge' 'HongKong01 edge' >"$tmp_dir/tags"
 magicnet_singbox_emit_selector_block "$tmp_dir/tags" 'US stable' >"$tmp_dir/no-jq.fragment"
 { printf '{"outbounds":['; cat "$tmp_dir/no-jq.fragment"; printf ']}\n'; } >"$tmp_dir/no-jq.json"
 jq -e '
   ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] as $names
   | [.outbounds[] | select(.tag as $tag | $names | index($tag))] as $groups
+  | (.outbounds[] | select(.tag == "ai-proxy")) as $ai_proxy
   | ($groups | length) == 4
-    and ($groups | all(.type == "selector" and .default == "block" and .outbounds == ["block", "US stable", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "hk01 edge", "myhk edge"] and (.outbounds | index("proxy") == null and index("direct") == null)))
+    and ($ai_proxy.default == "US stable" and $ai_proxy.outbounds == ["US stable", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "myhk edge"])
+    and ($groups | all(.type == "selector" and .default == "block" and .outbounds == ["block", "ai-proxy"]))
 ' "$tmp_dir/no-jq.json" >/dev/null || fail "no-jq generator selector mismatch"
 magicnet_singbox_pinned_ai_tags "$tmp_dir/tags" >"$tmp_dir/pinned-ai-tags"
 grep -Fxq 'CN2 premium' "$tmp_dir/pinned-ai-tags" || fail "CN2 false positive"
@@ -59,10 +67,10 @@ grep -Fxq 'opaque-42' "$tmp_dir/pinned-ai-tags" || fail "opaque node filtered"
 for tag in 'Mainland premium' 'Beijing edge' 'Shanghai edge' 'Guangzhou edge' 'Shenzhen edge' 'Sichuan edge' 'Inner-Mongolia edge' 'Xinjiang edge'; do
   ! grep -Fxq "$tag" "$tmp_dir/pinned-ai-tags" || fail "English mainland label retained: $tag"
 done
-for tag in '香港 edge' 'Hong Kong edge' 'Hong-Kong edge' 'Hong_Kong edge' 'HK edge' 'HKG edge'; do
+for tag in '香港 edge' 'Hong Kong edge' 'Hong-Kong edge' 'Hong_Kong edge' 'HK edge' 'HKG edge' 'hk01 edge' 'hk-01 edge' 'hk_01 edge' 'HKG01 edge' 'HongKong01 edge'; do
   ! grep -Fxq "$tag" "$tmp_dir/pinned-ai-tags" || fail "Hong Kong label retained: $tag"
 done
-for tag in 'HKT edge' 'CHK edge' 'hk01 edge' 'myhk edge'; do
+for tag in 'HKT edge' 'CHK edge' 'myhk edge'; do
   grep -Fxq "$tag" "$tmp_dir/pinned-ai-tags" || fail "Hong Kong boundary false positive: $tag"
 done
 jq 'del(.outbounds[] | select(.tag == "ai-chatgpt" or .tag == "ai-gemini" or .tag == "ai-grok" or .tag == "ai-claude"))' \
@@ -72,8 +80,10 @@ magicnet_singbox_sanitize_generated_config "$tmp_dir/legacy-cached.json"
 jq -e '
   ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] as $names
   | [.outbounds[] | select(.tag as $tag | $names | index($tag))] as $groups
+  | (.outbounds[] | select(.tag == "ai-proxy")) as $ai_proxy
   | ($groups | length) == 4
-    and ($groups | all(.type == "selector" and .default == "block" and .outbounds == ["block", "US stable", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "hk01 edge", "myhk edge"]))
+    and ($ai_proxy.default == "US stable" and $ai_proxy.outbounds == ["US stable", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "myhk edge"])
+    and ($groups | all(.type == "selector" and .default == "block" and .outbounds == ["block", "ai-proxy"]))
 ' "$tmp_dir/legacy-cached.json" >/dev/null || fail "legacy cached config AI selector repair mismatch"
 jq '.outbounds += [
       {"type":"direct","tag":"ai-chatgpt"},
@@ -86,8 +96,10 @@ magicnet_singbox_sanitize_generated_config "$tmp_dir/malformed-cached.json"
 jq -e '
   ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] as $names
   | [.outbounds[] | select(.tag as $tag | $names | index($tag))] as $groups
+  | (.outbounds[] | select(.tag == "ai-proxy")) as $ai_proxy
   | ($groups | length) == 4
-    and ($groups | all(.type == "selector" and .default == "block" and .outbounds == ["block", "US stable", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "hk01 edge", "myhk edge"]))
+    and ($ai_proxy.default == "US stable" and $ai_proxy.outbounds == ["US stable", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "myhk edge"])
+    and ($groups | all(.type == "selector" and .default == "block" and .outbounds == ["block", "ai-proxy"]))
 ' "$tmp_dir/malformed-cached.json" >/dev/null || fail "malformed or duplicate AI selectors not canonicalized"
 mkdir "$tmp_dir/no-jq-bin"
 ln -s "$(command -v awk)" "$tmp_dir/no-jq-bin/awk"
@@ -95,15 +107,38 @@ base_config="$MODULE_ROOT/.config/sing-box/config.json"
 jq 'del(.outbounds[] | select(.tag == "ai-chatgpt"))' "$base_config" >"$tmp_dir/no-jq-legacy.json"
 jq '(.outbounds[] | select(.tag == "ai-grok") | .default) = "direct"' "$base_config" >"$tmp_dir/no-jq-malformed.json"
 jq '(.outbounds[] | select(.tag == "ai-chatgpt") | .outbounds) += ["stale-missing-node"]' "$base_config" >"$tmp_dir/no-jq-stale-member.json"
+jq 'del(.outbounds[] | select(.tag == "ai-proxy"))' "$base_config" >"$tmp_dir/no-jq-missing-ai-proxy.json"
+jq '(.outbounds[] | select(.tag == "ai-proxy")) = {"type":"selector","tag":"ai-proxy","outbounds":["proxy"],"default":"proxy"}' \
+  "$base_config" >"$tmp_dir/no-jq-generic-ai-proxy.json"
+jq '(.outbounds[] | select(.tag == "ai-proxy")) = {"type":"selector","tag":"ai-proxy","outbounds":["上海 node"],"default":"上海 node"}' \
+  "$tmp_dir/generated.json" >"$tmp_dir/mainland-ai-proxy.json"
+jq '(.outbounds[] | select(.tag == "ai-proxy")) = {"type":"selector","tag":"ai-proxy","outbounds":["proxy-rule"],"default":"proxy-rule"}' \
+  "$tmp_dir/generated.json" >"$tmp_dir/nested-selector-ai-proxy.json"
+jq '(.outbounds[] | select(.tag == "ai-proxy") | .default) = "opaque-42"' \
+  "$tmp_dir/generated.json" >"$tmp_dir/nonfirst-default-ai-proxy.json"
+jq '(.outbounds[] | select(.tag == "ai-proxy")) = {"type":"selector","tag":"ai-proxy","outbounds":["block"],"default":"block"}' \
+  "$tmp_dir/generated.json" >"$tmp_dir/block-with-nodes-ai-proxy.json"
+! magicnet_singbox_ai_selectors_canonical "$tmp_dir/mainland-ai-proxy.json" 2>/dev/null || fail "jq canonical validator accepted mainland AI proxy"
+! magicnet_singbox_ai_selectors_canonical "$tmp_dir/nested-selector-ai-proxy.json" 2>/dev/null || fail "jq canonical validator accepted nested selector AI proxy"
+! magicnet_singbox_ai_selectors_canonical "$tmp_dir/nonfirst-default-ai-proxy.json" 2>/dev/null || fail "jq canonical validator accepted non-first AI proxy default"
+! magicnet_singbox_ai_selectors_canonical "$tmp_dir/block-with-nodes-ai-proxy.json" 2>/dev/null || fail "jq canonical validator accepted block fallback with nodes"
 PATH="$tmp_dir/no-jq-bin" magicnet_singbox_ai_selectors_canonical "$base_config" || fail "pure-shell canonical validator rejected fresh config"
 ! PATH="$tmp_dir/no-jq-bin" magicnet_singbox_ai_selectors_canonical "$tmp_dir/no-jq-legacy.json" 2>/dev/null || fail "pure-shell canonical validator accepted missing selectors"
 ! PATH="$tmp_dir/no-jq-bin" magicnet_singbox_ai_selectors_canonical "$tmp_dir/no-jq-malformed.json" 2>/dev/null || fail "pure-shell canonical validator accepted malformed selectors"
 ! PATH="$tmp_dir/no-jq-bin" magicnet_singbox_ai_selectors_canonical "$tmp_dir/no-jq-stale-member.json" 2>/dev/null || fail "pure-shell canonical validator accepted undefined selector member"
+! PATH="$tmp_dir/no-jq-bin" magicnet_singbox_ai_selectors_canonical "$tmp_dir/no-jq-missing-ai-proxy.json" 2>/dev/null || fail "pure-shell canonical validator accepted missing AI proxy"
+! PATH="$tmp_dir/no-jq-bin" magicnet_singbox_ai_selectors_canonical "$tmp_dir/no-jq-generic-ai-proxy.json" 2>/dev/null || fail "pure-shell canonical validator accepted generic AI proxy"
+! PATH="$tmp_dir/no-jq-bin" magicnet_singbox_ai_selectors_canonical "$tmp_dir/mainland-ai-proxy.json" 2>/dev/null || fail "pure-shell canonical validator accepted mainland AI proxy"
+! PATH="$tmp_dir/no-jq-bin" magicnet_singbox_ai_selectors_canonical "$tmp_dir/nested-selector-ai-proxy.json" 2>/dev/null || fail "pure-shell canonical validator accepted nested selector AI proxy"
+! PATH="$tmp_dir/no-jq-bin" magicnet_singbox_ai_selectors_canonical "$tmp_dir/nonfirst-default-ai-proxy.json" 2>/dev/null || fail "pure-shell canonical validator accepted non-first AI proxy default"
+! PATH="$tmp_dir/no-jq-bin" magicnet_singbox_ai_selectors_canonical "$tmp_dir/block-with-nodes-ai-proxy.json" 2>/dev/null || fail "pure-shell canonical validator accepted block fallback with nodes"
 jq -e '
   ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] as $names
   | [.outbounds[] | select(.tag as $tag | $names | index($tag))]
-  | length == 4 and all(.default == "block" and .outbounds == ["block"])
+  | length == 4 and all(.default == "block" and .outbounds == ["block", "ai-proxy"])
 ' "$MODULE_ROOT/.config/sing-box/config.json" >/dev/null || fail "base config not fail closed"
+jq -e '.outbounds[] | select(.tag == "ai-proxy") | .default == "block" and .outbounds == ["block"]' \
+  "$MODULE_ROOT/.config/sing-box/config.json" >/dev/null || fail "base config AI proxy not fail closed"
 python3 - "$MODULE_ROOT/.config/sing-box/config.json" <<'PY'
 import json, sys
 c = json.load(open(sys.argv[1], encoding="utf-8")); rules = c["route"]["rules"]

--- a/scripts/test-subscription-fetch-policy.sh
+++ b/scripts/test-subscription-fetch-policy.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+export MODDIR="$ROOT/src/MagicNet"
+export MAGICNET_FETCH_TEST_LOG="$tmp/log"
+. "$MODDIR/lib/magicnet/singbox_subscribe/fetch.sh"
+mkdir "$tmp/bin"
+cat >"$tmp/bin/curl" <<'SH'
+#!/bin/sh
+printf 'env=%s/%s/%s/%s\n' "${http_proxy-}" "${HTTP_PROXY-}" "${all_proxy-}" "${ALL_PROXY-}" >>"$MAGICNET_FETCH_TEST_LOG"
+printf 'curl %s\n' "$*" >>"$MAGICNET_FETCH_TEST_LOG"
+[ "${MAGICNET_FETCH_FAIL:-0}" = 1 ] && exit 1
+case "$*" in *127.0.0.1:9090/version*) printf '{"version":"test"}\n'; exit 0;; esac
+for last do :; done
+case " $* " in *' -o '*) while [ "$#" -gt 1 ]; do [ "$1" = -o ] && { printf ok >"$2"; break; }; shift; done;; esac
+SH
+cat >"$tmp/bin/wget" <<'SH'
+#!/bin/sh
+printf 'wget %s\n' "$*" >>"$MAGICNET_FETCH_TEST_LOG"
+exit 1
+SH
+cat >"$tmp/bin/sing-box" <<'SH'
+#!/bin/sh
+printf 'sing-box %s\n' "$*" >>"$MAGICNET_FETCH_TEST_LOG"
+printf ok
+SH
+cat >"$tmp/bin/timeout" <<'SH'
+#!/bin/sh
+printf 'timeout %s\n' "$1" >>"$MAGICNET_FETCH_TEST_LOG"
+shift
+exec "$@"
+SH
+chmod +x "$tmp/bin/"*
+http_proxy=http://bad HTTP_PROXY=http://bad all_proxy=http://bad ALL_PROXY=http://bad \
+  PATH="$tmp/bin:$PATH" magicnet_singbox_try_fetch_subscription curl https://example.invalid/sub "$tmp/direct" 2 7
+grep -q '^env=///$' "$tmp/log"
+grep -q 'curl .*--noproxy \*' "$tmp/log"
+if grep -q -- '--proxy' "$tmp/log"; then
+  exit 1
+fi
+: >"$tmp/log"
+MAGICNET_SUB_PROXY=http://127.0.0.1:7892 PATH="$tmp/bin:$PATH" \
+  magicnet_singbox_try_fetch_subscription curl https://example.invalid/sub "$tmp/proxy" 2 9
+grep -q 'curl .*--proxy http://127.0.0.1:7892' "$tmp/log"
+: >"$tmp/log"
+PATH="$tmp/bin:$PATH" magicnet_singbox_try_fetch_subscription sing-box https://example.invalid/sub "$tmp/sing" 2 11
+grep -q '^timeout 11$' "$tmp/log"
+grep -q '^sing-box tools fetch ' "$tmp/log"
+: >"$tmp/log"
+MAGICNET_FETCH_FAIL=1 MAGICNET_SUB_PROXY=http://127.0.0.1:7892 PATH="$tmp/bin:$PATH" \
+  magicnet_singbox_fetch_one_subscription https://example.invalid/sub "$tmp/missing" "" '#1' 2>/dev/null && exit 1 || true
+grep -q '^curl ' "$tmp/log"
+if grep -Eq '^(wget|sing-box) ' "$tmp/log"; then
+  exit 1
+fi
+MODDIR="$tmp/module"
+. "$ROOT/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh"
+magicnet_singbox_update_lock_acquire
+if (magicnet_singbox_update_lock_acquire) 2>/dev/null; then
+  exit 1
+fi
+magicnet_singbox_update_lock_release
+mkdir -p "$MODDIR/.state/sing-box/subscription-update.lock"
+printf '999999:0:stale\n' >"$MODDIR/.state/sing-box/subscription-update.lock/owner"
+magicnet_singbox_update_lock_acquire
+magicnet_singbox_update_lock_release
+mkdir -p "$MODDIR/.state/sing-box/subscription-update.lock"
+start=$(awk '{print $22}' "/proc/$$/stat")
+printf '%s:%s:0\n' "$$" "$start" >"$MODDIR/.state/sing-box/subscription-update.lock/owner"
+if (magicnet_singbox_update_lock_acquire) 2>/dev/null; then
+  exit 1
+fi
+rm -rf "$MODDIR/.state/sing-box/subscription-update.lock"
+magicnet_singbox_update_lock_acquire
+old_token=$_update_token
+printf 'replacement-owner\n' >"$MODDIR/.state/sing-box/subscription-update.lock/owner"
+_update_token=$old_token
+magicnet_singbox_update_lock_release
+test -d "$MODDIR/.state/sing-box/subscription-update.lock"
+rm -rf "$MODDIR/.state/sing-box/subscription-update.lock"
+order_log="$tmp/order.log"
+magicnet_singbox_update_subscription_unlocked() { printf 'update-body\n' >>"$order_log"; }
+# Invoked indirectly by the update wrapper.
+# shellcheck disable=SC2329
+magicnet_with_config_lock() {
+  test -d "$MODDIR/.state/sing-box/subscription-update.lock"
+  printf 'global-lock\n' >>"$order_log"
+  "$@"
+}
+magicnet_singbox_update_subscription
+test "$(tr '\n' ' ' <"$order_log")" = 'global-lock update-body '
+test ! -d "$MODDIR/.state/sing-box/subscription-update.lock"
+: >"$order_log"
+global_lock="$tmp/global.lock"
+mkdir "$global_lock"
+# Invoked indirectly by the update wrapper.
+# shellcheck disable=SC2329
+magicnet_with_config_lock() {
+  while [ -d "$global_lock" ]; do sleep 0.02; done
+  printf 'global-after-apply\n' >>"$order_log"
+  "$@"
+}
+(
+  sleep 0.1
+  test -d "$MODDIR/.state/sing-box/subscription-update.lock"
+  printf 'update-waited\n' >>"$order_log"
+  rmdir "$global_lock"
+) &
+waiter=$!
+magicnet_singbox_update_subscription
+wait "$waiter"
+test "$(tr '\n' ' ' <"$order_log")" = 'update-waited global-after-apply update-body '
+. "$ROOT/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh"
+mkdir -p "$MODDIR/bin" "$tmp/foreign"
+cat >"$tmp/sing-box.c" <<'C'
+#include <unistd.h>
+
+int main(void) {
+    sleep(30);
+    return 0;
+}
+C
+cc -o "$MODDIR/bin/sing-box" "$tmp/sing-box.c"
+cc -o "$tmp/foreign/sing-box" "$tmp/sing-box.c"
+"$MODDIR/bin/sing-box" run -c "$tmp/config.json" -D "$tmp" &
+old_core=$!
+magicnet_singbox_pids() { kill -0 "$old_core" 2>/dev/null && printf '%s\n' "$old_core"; }
+magicnet_singbox_is_running() { kill -0 "$old_core" 2>/dev/null; }
+magicnet_supervisors_stop() { printf 'stop\n' >>"$order_log"; }
+magicnet_fswatch_start() { printf 'start\n' >>"$order_log"; }
+magicnet_fswatch_status() { return 0; }
+magicnet_singbox_listener_owned() { kill -0 "$1" 2>/dev/null; }
+magicnet_singbox_subscription_config_file() { printf '%s\n' "$tmp/config.json"; }
+: >"$tmp/config.json"
+# Android Toybox/BusyBox awk treats the NUL-delimited cmdline as one record.
+# Ownership parsing must use the shell's NUL-safe read loop instead of awk.
+awk() { return 99; }
+magicnet_singbox_pid_owned "$old_core" "$tmp/config.json"
+unset -f awk
+cc -o "$tmp/replacement-sing-box" "$tmp/sing-box.c"
+mv "$tmp/replacement-sing-box" "$MODDIR/bin/sing-box"
+magicnet_singbox_pid_owned "$old_core" "$tmp/config.json"
+kill "$old_core"
+wait "$old_core" 2>/dev/null || true
+"$MODDIR/bin/sing-box" run -c "$tmp/config.json" -D "$tmp" &
+old_core=$!
+magicnet_singbox_pid_owned "$old_core" "$tmp/config.json"
+"$tmp/foreign/sing-box" run -c "$tmp/config.json" -D "$tmp" &
+foreign_exe=$!
+magicnet_singbox_pid_owned "$foreign_exe" "$tmp/config.json" && exit 1 || true
+cc -o "$tmp/foreign-replacement" "$tmp/sing-box.c"
+mv "$tmp/foreign-replacement" "$tmp/foreign/sing-box"
+magicnet_singbox_pid_owned "$foreign_exe" "$tmp/config.json" && exit 1 || true
+kill "$foreign_exe"
+wait "$foreign_exe" 2>/dev/null || true
+"$MODDIR/bin/sing-box" run -c "$tmp/other.json" -D "$tmp" &
+wrong_config=$!
+magicnet_singbox_pid_owned "$wrong_config" "$tmp/config.json" && exit 1 || true
+kill "$wrong_config"
+wait "$wrong_config" 2>/dev/null || true
+"$MODDIR/bin/sing-box" run -c "$tmp/config.json" -D "$tmp/other-work" &
+wrong_work=$!
+magicnet_singbox_pid_owned "$wrong_work" "$tmp/config.json" && exit 1 || true
+kill "$wrong_work"
+wait "$wrong_work" 2>/dev/null || true
+newline_config=$(printf '%s\n%s' '-c' "$tmp/config.json")
+"$MODDIR/bin/sing-box" run "$newline_config" -D "$tmp" &
+newline_arg=$!
+magicnet_singbox_pid_owned "$newline_arg" "$tmp/config.json" && exit 1 || true
+kill "$newline_arg"
+wait "$newline_arg" 2>/dev/null || true
+"$MODDIR/bin/sing-box" run -c "$tmp/config.json" -c "$tmp/config.json" -D "$tmp" &
+duplicate_config=$!
+magicnet_singbox_pid_owned "$duplicate_config" "$tmp/config.json" && exit 1 || true
+kill "$duplicate_config"
+wait "$duplicate_config" 2>/dev/null || true
+"$MODDIR/bin/sing-box" run -c "$tmp/config.json" -D "$tmp" -D "$tmp" &
+duplicate_work=$!
+magicnet_singbox_pid_owned "$duplicate_work" "$tmp/config.json" && exit 1 || true
+kill "$duplicate_work"
+wait "$duplicate_work" 2>/dev/null || true
+: >"$order_log"
+PATH="$tmp/bin:$PATH" magicnet_singbox_restart_if_running
+wait "$old_core" 2>/dev/null || true
+# Set by magicnet_singbox_restart_if_running.
+# shellcheck disable=SC2154
+kill "$_new_pid" 2>/dev/null || true
+test "$(tr '\n' ' ' <"$order_log")" = 'stop start '
+(
+  "$tmp/foreign/sing-box" run -c "$tmp/foreign.json" -D "$tmp/foreign" & foreign=$!
+  magicnet_singbox_pids() { printf '%s\n' "$foreign"; }
+  magicnet_supervisors_stop() { :; }
+  magicnet_fswatch_status() { return 0; }
+  magicnet_fswatch_start() { :; }
+  ss() { printf 'LISTEN 0 4096 127.0.0.1:9090 0.0.0.0:* users:(("foreign",pid=%s,fd=1))\n' "$foreign"; }
+  magicnet_singbox_restart_owned "$tmp/config.json" && exit 1 || true
+  kill -0 "$foreign"
+  kill "$foreign"
+)
+(
+  magicnet_singbox_owned_pids() { printf '999999\n'; }
+  magicnet_supervisors_stop() { :; }
+  magicnet_fswatch_status() { return 1; }
+  kill() { :; }
+  MAGICNET_SUB_STOP_TIMEOUT=0 MAGICNET_SUB_KILL_TIMEOUT=0 \
+    magicnet_singbox_restart_owned "$tmp/config.json" && exit 1 || true
+)
+(
+  magicnet_singbox_owned_pids() { :; }
+  magicnet_supervisors_stop() { :; }
+  magicnet_fswatch_status() { return 0; }
+  magicnet_fswatch_start() { return 1; }
+  ss() { :; }
+  magicnet_singbox_ensure_start_owned() { return 0; }
+  magicnet_singbox_restart_owned "$tmp/config.json" && exit 1 || true
+)
+printf 'subscription fetch policy test passed\n'

--- a/src/MagicNet/README.md
+++ b/src/MagicNet/README.md
@@ -5,7 +5,7 @@ MagicNet 是一个 Android root TUN 透明代理模块，用 `sing-box` 和 `mag
 > [!IMPORTANT]
 > DNS 防泄露必读：请打开系统设置，搜索 `DNS`，找到“私人 DNS”“私密 DNS”“Private DNS”或类似表述，把私人 DNS 关闭，不要设置为自动加密。必须让 DNS 正常走 53 端口，让 MagicNet 模块接管并代理 DNS；否则 Android 系统或浏览器可能直接使用 DoT/DoH，导致 DNS 泄露检测仍然显示外部解析器。
 
-> 需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.19`。Release 以发布页为准。
+> 需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.20`。Release 以发布页为准。
 
 ## 定位
 

--- a/src/MagicNet/customize.sh
+++ b/src/MagicNet/customize.sh
@@ -35,7 +35,8 @@ if [ -d "$MAGICNET_PREV_DIR" ] && [ "$MAGICNET_PREV_DIR" != "$MODPATH" ]; then
   for _item in \
     ".config/sing-box/subscription.url" \
     ".config/sing-box/subscription-1.yaml" \
-    ".config/sing-box/.subscription-work" \
+    ".state/sing-box/subscription-work" \
+    ".state/sing-box/selector-selections.json" \
     ".config/magicnet"; do
     if [ -e "${MAGICNET_PREV_DIR}/${_item}" ]; then
       mkdir -p "${MAGICNET_BACKUP_DIR}/${_item%/*}"
@@ -207,7 +208,8 @@ if [ -d "$MAGICNET_BACKUP_DIR" ]; then
   for _item in \
     ".config/sing-box/subscription.url" \
     ".config/sing-box/subscription-1.yaml" \
-    ".config/sing-box/.subscription-work" \
+    ".state/sing-box/subscription-work" \
+    ".state/sing-box/selector-selections.json" \
     ".config/magicnet"; do
     if [ -e "${MAGICNET_BACKUP_DIR}/${_item}" ]; then
       mkdir -p "${MODPATH}/${_item%/*}"

--- a/src/MagicNet/lib/magicnet/core.sh
+++ b/src/MagicNet/lib/magicnet/core.sh
@@ -70,6 +70,7 @@ magicnet_start_kernel() {
 
     if magicnet_start_singbox; then
         magicnet_after_kernel_start
+        "${MODDIR}/cli" api replay >/dev/null 2>&1 || true
         magicnet_notify "magicnet_guard" "MagicNet" "sing-box started"
         return 0
     fi

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh
@@ -12,20 +12,32 @@ magicnet_singbox_ai_selectors_canonical() {
     _ai_config="$1"
     if command -v jq >/dev/null 2>&1; then
         jq -e '
+          def mainland_node_tag:
+            test("中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:Hong[ _-]?Kong(?:[ _-]?[0-9]+)?|HKG?[ _-]?[0-9]+|China|Mainland|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
           ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] as $names
           | [.outbounds[]? | select(.tag as $tag | $names | index($tag))] as $groups
+          | ([.outbounds[]? | select(.tag == "ai-proxy")]) as $ai_proxies
+          | [.outbounds[]?
+              | select(.type == "shadowsocks" or .type == "vmess" or .type == "vless" or .type == "trojan" or .type == "hysteria2" or .type == "anytls" or .type == "tuic")
+              | .tag] as $node_tags
           | ([.outbounds[]?.tag] | unique) as $tags
           | ($groups | length) == 4
+            and ($ai_proxies | length) == 1
+            and ($ai_proxies[0].type == "selector")
+            and (($ai_proxies[0].outbounds == ["block"] and $ai_proxies[0].default == "block" and ($node_tags | length) == 0)
+              or (($ai_proxies[0].outbounds | length) > 0
+                and $ai_proxies[0].default == $ai_proxies[0].outbounds[0]
+                and ($ai_proxies[0].outbounds | all(. as $member | ($node_tags | index($member) != null) and ($member | mainland_node_tag | not)))))
             and ($groups | all(
               .type == "selector" and .default == "block"
-              and (.outbounds | type == "array" and length > 0 and .[0] == "block")
-              and (.outbounds | index("direct") == null and index("proxy") == null)
+              and .outbounds == ["block", "ai-proxy"]
               and (.outbounds | all(. as $member | $tags | index($member) != null))))
         ' "$_ai_config" >/dev/null 2>&1
         _ai_rc=$?
     else
         awk '
           BEGIN {
+            IGNORECASE = 1
             split("ai-chatgpt ai-gemini ai-grok ai-claude", names)
             for (i in names) wanted[names[i]] = 1
           }
@@ -42,6 +54,14 @@ magicnet_singbox_ai_selectors_canonical() {
               sub(/^.*"tag"[[:space:]]*:[[:space:]]*"/, "", tag)
               sub(/".*/, "", tag)
               tags[tag] = 1
+              type = objects[i]
+              if (type !~ /"type"[[:space:]]*:/) continue
+              sub(/^.*"type"[[:space:]]*:[[:space:]]*"/, "", type)
+              sub(/".*/, "", type)
+              if (type ~ /^(shadowsocks|vmess|vless|trojan|hysteria2|anytls|tuic)$/) {
+                node_tags[tag] = 1
+                node_count++
+              }
             }
             for (i = 1; i <= object_count; i++) {
               object = objects[i]
@@ -49,22 +69,37 @@ magicnet_singbox_ai_selectors_canonical() {
               if (tag !~ /"tag"[[:space:]]*:/) continue
               sub(/^.*"tag"[[:space:]]*:[[:space:]]*"/, "", tag)
               sub(/".*/, "", tag)
+              if (tag == "ai-proxy") {
+                ai_proxy_count++
+                if (object !~ /"type"[[:space:]]*:[[:space:]]*"selector"/) bad = 1
+                if (object ~ /中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西/ ||
+                    object ~ /(^|[^[:alnum:]])(Hong[ _-]?Kong([ _-]?[0-9]+)?|HKG?[ _-]?[0-9]+|China|Mainland|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^[:alnum:]]|$)/) bad = 1
+                members = object
+                sub(/^.*"outbounds"[[:space:]]*:[[:space:]]*\[/, "", members)
+                sub(/\].*/, "", members)
+                member_count = split(members, member, ",")
+                default_member = object
+                sub(/^.*"default"[[:space:]]*:[[:space:]]*"/, "", default_member)
+                sub(/".*/, "", default_member)
+                for (j = 1; j <= member_count; j++) {
+                  gsub(/^[[:space:]]*"|"[[:space:]]*$/, "", member[j])
+                }
+                if (member_count == 1 && member[1] == "block") {
+                  if (default_member != "block" || node_count != 0) bad = 1
+                } else {
+                  if (member_count < 1 || default_member != member[1]) bad = 1
+                  for (j = 1; j <= member_count; j++) if (!(member[j] in node_tags)) bad = 1
+                }
+                continue
+              }
               if (!(tag in wanted)) continue
               count[tag]++
               if (object !~ /"type"[[:space:]]*:[[:space:]]*"selector"/ ||
                   object !~ /"default"[[:space:]]*:[[:space:]]*"block"/ ||
-                  object !~ /"outbounds"[[:space:]]*:[[:space:]]*\[[[:space:]]*"block"/ ||
-                  object ~ /"outbounds"[[:space:]]*:[^]]*"(direct|proxy)"/) bad = 1
-              members = object
-              sub(/^.*"outbounds"[[:space:]]*:[[:space:]]*\[/, "", members)
-              sub(/\].*/, "", members)
-              member_count = split(members, member, ",")
-              for (j = 1; j <= member_count; j++) {
-                gsub(/^[[:space:]]*"|"[[:space:]]*$/, "", member[j])
-                if (!(member[j] in tags)) bad = 1
-              }
+                  object !~ /"outbounds"[[:space:]]*:[[:space:]]*\[[[:space:]]*"block"[[:space:]]*,[[:space:]]*"ai-proxy"[[:space:]]*\]/) bad = 1
             }
             for (name in wanted) if (count[name] != 1) bad = 1
+            if (ai_proxy_count != 1) bad = 1
             exit bad ? 1 : 0
           }
         ' "$_ai_config"

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
@@ -75,10 +75,15 @@ magicnet_singbox_build_outbounds_file_with_jq() {
         ([]; if ($item == "" or index($item)) then . else . + [$item] end)) as $items
       | {"type": "selector", "tag": $tag, "outbounds": $items, "default": $fallback};
     def mainland_node_tag:
-      test("中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:China|Mainland|Hong[ _-]?Kong|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
-    def pinned_ai_selector($tag; $tags):
-      (["block"] + [$tags[]? | select(mainland_node_tag | not)]) as $items
-      | {"type": "selector", "tag": $tag, "outbounds": $items, "default": "block"};
+      test("中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:Hong[ _-]?Kong(?:[ _-]?[0-9]+)?|HKG?[ _-]?[0-9]+|China|Mainland|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
+    def ai_proxy_selector($tags):
+      ([$tags[]? | select(mainland_node_tag | not)]) as $items
+      | if ($items | length) > 0
+        then {"type": "selector", "tag": "ai-proxy", "outbounds": $items, "default": $items[0]}
+        else {"type": "selector", "tag": "ai-proxy", "outbounds": ["block"], "default": "block"}
+        end;
+    def pinned_ai_selector($tag):
+      {"type": "selector", "tag": $tag, "outbounds": ["block", "ai-proxy"], "default": "block"};
     def proxy_tag_score($tag):
       if ($tag | test("免费|Free|free|公益|试用|下载专用|剩余|到期|过期|套餐|官网|订阅|Traffic|traffic|Expire|expire|Expired|expired|Subscription|subscription|官方网站|更新订阅")) then 0
       elif ($tag | test("IEPL|IPLC|专线|S[0-9]+|倍率|x1|x2|香港|日本|新加坡|美国|台湾|韩国")) then 2
@@ -119,11 +124,11 @@ magicnet_singbox_build_outbounds_file_with_jq() {
           selector("bing"; ["proxy", "direct"]; "proxy"),
           selector("dns-guard"; ["proxy", "block", "direct"]; "proxy"),
           selector("network-test"; ["proxy", "direct"]; "proxy"),
-          pinned_ai_selector("ai-chatgpt"; $tags),
-          pinned_ai_selector("ai-gemini"; $tags),
-          pinned_ai_selector("ai-grok"; $tags),
-          pinned_ai_selector("ai-claude"; $tags),
-          selector("ai-proxy"; ["proxy", "direct"]; "proxy"),
+          ai_proxy_selector($tags),
+          pinned_ai_selector("ai-chatgpt"),
+          pinned_ai_selector("ai-gemini"),
+          pinned_ai_selector("ai-grok"),
+          pinned_ai_selector("ai-claude"),
           selector("proxy-rule"; ["proxy", "direct"]; "proxy"),
           selector("dev-proxy"; ["proxy", "direct"]; "proxy"),
           selector("social-proxy"; ["proxy", "direct"]; "proxy"),
@@ -228,13 +233,20 @@ magicnet_singbox_emit_static_selectors() {
     magicnet_emit_selector_json "network-test" "$(printf '%s\n%s\n' "proxy" "direct")" "proxy"
     printf ',\n'
     _pinned_ai_tags=$(magicnet_singbox_pinned_ai_tags "$_tags_file")
+    _pinned_ai_default=$(printf '%s\n' "$_pinned_ai_tags" | sed -n '1p')
+    if [ -n "$_pinned_ai_default" ]; then
+        magicnet_emit_selector_json_exact "ai-proxy" "$_pinned_ai_tags" "$_pinned_ai_default"
+    else
+        magicnet_emit_selector_json_exact "ai-proxy" "block" "block"
+    fi
+    printf ',\n'
     _pinned_ai_first=1
     for _name in ai-chatgpt ai-gemini ai-grok ai-claude; do
         [ "$_pinned_ai_first" -eq 1 ] || printf ',\n'
         magicnet_singbox_emit_pinned_ai_selector "$_name" "$_pinned_ai_tags"
         _pinned_ai_first=0
     done
-    for _name in ai-proxy proxy-rule dev-proxy social-proxy media-proxy game-proxy telegram-proxy; do
+    for _name in proxy-rule dev-proxy social-proxy media-proxy game-proxy telegram-proxy; do
         printf ',\n'
         magicnet_emit_selector_json "$_name" "$(printf '%s\n%s\n' "proxy" "direct")" "proxy"
     done
@@ -242,37 +254,27 @@ magicnet_singbox_emit_static_selectors() {
     magicnet_emit_selector_json "download-direct" "$(printf '%s\n%s\n' "direct" "proxy")" "direct"
     printf ',\n'
     magicnet_emit_selector_json "final" "$(printf '%s\n%s\n%s\n' "proxy" "direct" "block")" "proxy"
-    unset _pair _name _default _pinned_ai_tags _pinned_ai_first
+    unset _pair _name _default _pinned_ai_tags _pinned_ai_default _pinned_ai_first
 }
 
 magicnet_singbox_emit_pinned_ai_selector() {
     _pinned_ai_name="$1"
-    _pinned_ai_members="$2"
     printf '    {\n'
     printf '      "type": "selector",\n'
     printf '      "tag": "%s",\n' "$(magicnet_json_escape "$_pinned_ai_name")"
     printf '      "outbounds": ['
-    _pinned_ai_member_first=1
-    while IFS= read -r _pinned_ai_member; do
-        [ -n "$_pinned_ai_member" ] || continue
-        [ "$_pinned_ai_member_first" -eq 1 ] || printf ', '
-        printf '"%s"' "$(magicnet_json_escape "$_pinned_ai_member")"
-        _pinned_ai_member_first=0
-    done <<EOF
-$_pinned_ai_members
-EOF
+    printf '"block", "ai-proxy"'
     printf '],\n'
     printf '      "default": "block"\n'
     printf '    }'
-    unset _pinned_ai_name _pinned_ai_members _pinned_ai_member _pinned_ai_member_first
+    unset _pinned_ai_name
 }
 
 magicnet_singbox_pinned_ai_tags() {
     _pinned_ai_tags_file="$1"
-    printf '%s\n' "block"
     awk 'BEGIN { IGNORECASE = 1 }
       !/中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西/ &&
-      !/(^|[^[:alnum:]])(China|Mainland|Hong[ _-]?Kong|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^[:alnum:]]|$)/ { print }
+      !/(^|[^[:alnum:]])(Hong[ _-]?Kong([ _-]?[0-9]+)?|HKG?[ _-]?[0-9]+|China|Mainland|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^[:alnum:]]|$)/ { print }
     ' "$_pinned_ai_tags_file"
     unset _pinned_ai_tags_file
 }
@@ -290,9 +292,14 @@ magicnet_singbox_sanitize_generated_config() {
     _sanitize_tmp_file="${_sanitize_config_file}.sanitized"
     "$_sanitize_jq" '
       def mainland_node_tag:
-        test("中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:China|Mainland|Hong[ _-]?Kong|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
-      def pinned_ai_selector($tag; $tags):
-        {"type": "selector", "tag": $tag, "outbounds": (["block"] + $tags), "default": "block"};
+        test("中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:Hong[ _-]?Kong(?:[ _-]?[0-9]+)?|HKG?[ _-]?[0-9]+|China|Mainland|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
+      def ai_proxy_selector($tags):
+        if ($tags | length) > 0
+        then {"type": "selector", "tag": "ai-proxy", "outbounds": $tags, "default": $tags[0]}
+        else {"type": "selector", "tag": "ai-proxy", "outbounds": ["block"], "default": "block"}
+        end;
+      def pinned_ai_selector($tag):
+        {"type": "selector", "tag": $tag, "outbounds": ["block", "ai-proxy"], "default": "block"};
       def has_match($rule):
         [
           "inbound",
@@ -319,11 +326,12 @@ magicnet_singbox_sanitize_generated_config() {
           | .tag // empty
           | select(mainland_node_tag | not)]) as $ai_tags
       | .outbounds = ($outbounds
-          | map(select(.tag as $tag | ["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] | index($tag) == null))
+          | map(select(.tag as $tag | ["ai-proxy", "ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] | index($tag) == null))
           | if any(.tag == "dns-guard") then .
             else . + [{"type": "selector", "tag": "dns-guard", "outbounds": ["proxy", "block", "direct"], "default": "proxy"}]
             end
-          | . + (["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] | map(pinned_ai_selector(.; $ai_tags))))
+          | . + [ai_proxy_selector($ai_tags)]
+          | . + (["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"] | map(pinned_ai_selector(.))))
       | .route.rules = ((.route.rules // [])
         | map(select(((has("outbound") and (has_match(.) | not) and (has("action") | not)) | not))))
     ' "$_sanitize_config_file" >"$_sanitize_tmp_file" && mv -f "$_sanitize_tmp_file" "$_sanitize_config_file"
@@ -413,7 +421,7 @@ magicnet_singbox_update_config_with_nodes() {
 }
 
 magicnet_singbox_replay_cached_outbounds() {
-    _cached_outbounds="${MODDIR}/.config/sing-box/.subscription-work/outbounds.json"
+    _cached_outbounds="${MODDIR}/.state/sing-box/subscription-work/outbounds.json"
     [ -s "$_cached_outbounds" ] || {
         unset _cached_outbounds
         return 1
@@ -456,29 +464,136 @@ magicnet_singbox_is_running() {
     [ -n "$(magicnet_singbox_pids)" ]
 }
 
-magicnet_singbox_restart_if_running() {
-    magicnet_singbox_is_running || return 0
+magicnet_singbox_pid_owned() {
+    _owned_pid="$1"
+    _owned_config="$2"
+    _owned_expected=$(readlink -f "${MODDIR}/bin/sing-box" 2>/dev/null) || return 1
+    _owned_exe_link=$(readlink "/proc/${_owned_pid}/exe" 2>/dev/null) || return 1
+    _owned_exe_path=${_owned_exe_link% (deleted)}
+    [ "$_owned_exe_path" = "$_owned_expected" ] || return 1
+    (
+        _argv_index=0
+        _argv_run=0
+        _argv_config_count=0
+        _argv_config_ok=0
+        _argv_work_count=0
+        _argv_work_ok=0
+        _argv_pending=
+        # Android sh and the host-side Bash fixture use an empty read delimiter for NUL.
+        # shellcheck disable=SC3045
+        while IFS= read -r -d '' _argv_arg; do
+            _argv_index=$((_argv_index + 1))
+            [ "$_argv_index" -ne 2 ] || [ "$_argv_arg" != "run" ] || _argv_run=1
+            case "$_argv_pending" in
+                config)
+                    [ "$_argv_arg" != "$_owned_config" ] || _argv_config_ok=1
+                    _argv_pending=
+                    continue
+                    ;;
+                work)
+                    [ "$_argv_arg" != "${_owned_config%/*}" ] || _argv_work_ok=1
+                    _argv_pending=
+                    continue
+                    ;;
+            esac
+            case "$_argv_arg" in
+                -c)
+                    _argv_config_count=$((_argv_config_count + 1))
+                    _argv_pending=config
+                    ;;
+                -D)
+                    _argv_work_count=$((_argv_work_count + 1))
+                    _argv_pending=work
+                    ;;
+            esac
+        done <"/proc/${_owned_pid}/cmdline"
+        [ "$_argv_run" -eq 1 ] &&
+            [ "$_argv_config_count" -eq 1 ] && [ "$_argv_config_ok" -eq 1 ] &&
+            [ "$_argv_work_count" -eq 1 ] && [ "$_argv_work_ok" -eq 1 ] &&
+            [ -z "$_argv_pending" ]
+    ) 2>/dev/null
+}
 
+magicnet_singbox_owned_pids() {
+    _owned_config="$1"
     for _pid in $(magicnet_singbox_pids); do
+        magicnet_singbox_pid_owned "$_pid" "$_owned_config" && printf '%s\n' "$_pid"
+    done
+}
+
+magicnet_singbox_listener_owned() {
+    _listener_pid="$1"
+    ss -lntp 2>/dev/null | grep -E '127\.0\.0\.1:9090[[:space:]]' | grep -q "pid=${_listener_pid},"
+}
+
+magicnet_singbox_supervisor_restore() {
+    [ "${_owned_fswatch_active:-0}" -eq 1 ] || return 0
+    magicnet_fswatch_start >/dev/null 2>&1 || return 1
+    magicnet_fswatch_status >/dev/null 2>&1
+}
+
+magicnet_singbox_ensure_start_owned() {
+    _owned_config="$1"
+    _owned_work="${_owned_config%/*}"
+    _owned_binary="${MODDIR}/bin/sing-box"
+    _owned_log="${MODDIR}/.log/sing-box.log"
+    [ -x "$_owned_binary" ] || return 1
+    ss -lnt 2>/dev/null | grep -q '127\.0\.0\.1:9090[[:space:]]' && return 1
+    mkdir -p "${MODDIR}/.log"
+    nohup "$_owned_binary" run -c "$_owned_config" -D "$_owned_work" >"$_owned_log" 2>&1 </dev/null &
+    _new_pid=$!
+    _ready_deadline=$(($(date +%s) + ${MAGICNET_SUB_READY_TIMEOUT:-15}))
+    while [ "$(date +%s)" -lt "$_ready_deadline" ]; do
+        if kill -0 "$_new_pid" 2>/dev/null &&
+            magicnet_singbox_pid_owned "$_new_pid" "$_owned_config" &&
+            magicnet_singbox_listener_owned "$_new_pid" &&
+            curl -fsS --max-time 1 http://127.0.0.1:9090/version 2>/dev/null | grep -q '"version"'; then
+            return 0
+        fi
+        sleep 1
+    done
+    kill "$_new_pid" 2>/dev/null || true
+    return 1
+}
+
+magicnet_singbox_restart_owned() {
+    _owned_config="$1"
+    _owned_fswatch_active="${MAGICNET_SUB_FSWATCH_WAS_ACTIVE:-0}"
+    if [ -z "${MAGICNET_SUB_FSWATCH_WAS_ACTIVE+x}" ]; then
+        magicnet_fswatch_status >/dev/null 2>&1 && _owned_fswatch_active=1
+    fi
+    magicnet_supervisors_stop >/dev/null 2>&1 || return 1
+    for _pid in $(magicnet_singbox_owned_pids "$_owned_config"); do
         kill "$_pid" 2>/dev/null || true
     done
-    sleep 1
-    if magicnet_singbox_is_running; then
-        for _pid in $(magicnet_singbox_pids); do
+    _stop_deadline=$(($(date +%s) + ${MAGICNET_SUB_STOP_TIMEOUT:-8}))
+    while [ -n "$(magicnet_singbox_owned_pids "$_owned_config")" ] && [ "$(date +%s)" -lt "$_stop_deadline" ]; do
+        sleep 1
+    done
+    if [ -n "$(magicnet_singbox_owned_pids "$_owned_config")" ]; then
+        for _pid in $(magicnet_singbox_owned_pids "$_owned_config"); do
             kill -9 "$_pid" 2>/dev/null || true
         done
-        sleep 1
+        _kill_deadline=$(($(date +%s) + ${MAGICNET_SUB_KILL_TIMEOUT:-3}))
+        while [ -n "$(magicnet_singbox_owned_pids "$_owned_config")" ] && [ "$(date +%s)" -lt "$_kill_deadline" ]; do sleep 1; done
     fi
-    ip link delete magicnet0 2>/dev/null || true
-    ip link delete tun0 2>/dev/null || true
+    _restart_rc=0
+    [ -z "$(magicnet_singbox_owned_pids "$_owned_config")" ] || _restart_rc=1
+    if [ "$_restart_rc" -eq 0 ] && ss -lnt 2>/dev/null | grep -q '127\.0\.0\.1:9090[[:space:]]'; then
+        _restart_rc=1
+    fi
+    if [ "$_restart_rc" -eq 0 ]; then
+        ip link delete magicnet0 2>/dev/null || true
+        ip link delete tun0 2>/dev/null || true
+        magicnet_singbox_ensure_start_owned "$_owned_config" || _restart_rc=1
+    fi
+    magicnet_singbox_supervisor_restore || _restart_rc=1
+    return "$_restart_rc"
+}
 
+magicnet_singbox_restart_if_running() {
     _config_file=$(magicnet_singbox_subscription_config_file)
-    _work_dir="${_config_file%/*}"
-    _log_file="${MODDIR}/.log/sing-box.log"
-    mkdir -p "${MODDIR}/.log"
-    nohup sing-box run -c "$_config_file" -D "$_work_dir" >"$_log_file" 2>&1 &
-    sleep 2
-    magicnet_singbox_is_running
+    magicnet_singbox_restart_owned "$_config_file"
 }
 
 magicnet_singbox_api_has_nodes() {

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/fetch.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/fetch.sh
@@ -1,12 +1,3 @@
-magicnet_singbox_download_proxy_args() {
-    _proxy="${MAGICNET_SUB_PROXY:-}"
-    if [ -z "$_proxy" ] && command -v curl >/dev/null 2>&1; then
-        curl -sS --max-time 2 http://127.0.0.1:9090/proxies >/dev/null 2>&1 &&
-            _proxy="http://127.0.0.1:7892"
-    fi
-    [ -n "$_proxy" ] && printf '%s\n%s\n' "--proxy" "$_proxy"
-}
-
 magicnet_singbox_use_cached_subscription() {
     _source_file="$1"
     _fallback_file="$2"
@@ -35,16 +26,23 @@ magicnet_singbox_try_fetch_subscription() {
     case "$_method" in
         curl)
             command -v curl >/dev/null 2>&1 || return 127
-            # shellcheck disable=SC2046
-            curl -fsSL $(magicnet_singbox_download_proxy_args) --connect-timeout "$_connect_timeout" --max-time "$_max_time" "$_url" -o "$_download_file"
+            if [ -n "${MAGICNET_SUB_PROXY:-}" ]; then
+                env -u http_proxy -u https_proxy -u all_proxy -u no_proxy -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY \
+                    timeout "$_max_time" curl -fsSL --proxy "$MAGICNET_SUB_PROXY" --connect-timeout "$_connect_timeout" --max-time "$_max_time" "$_url" -o "$_download_file"
+            else
+                env -u http_proxy -u https_proxy -u all_proxy -u no_proxy -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY \
+                    timeout "$_max_time" curl -fsSL --noproxy '*' --connect-timeout "$_connect_timeout" --max-time "$_max_time" "$_url" -o "$_download_file"
+            fi
             ;;
         wget)
             command -v wget >/dev/null 2>&1 || return 127
-            wget -T "$_max_time" -qO "$_download_file" "$_url"
+            env -u http_proxy -u https_proxy -u all_proxy -u no_proxy -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY \
+                timeout "$_max_time" wget -T "$_max_time" -qO "$_download_file" "$_url"
             ;;
         sing-box)
             command -v sing-box >/dev/null 2>&1 || return 127
-            sing-box tools fetch "$_url" >"$_download_file"
+            env -u http_proxy -u https_proxy -u all_proxy -u no_proxy -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY \
+                timeout "$_max_time" sing-box tools fetch "$_url" >"$_download_file"
             ;;
         *)
             return 127
@@ -80,7 +78,12 @@ magicnet_singbox_fetch_one_subscription() {
 
     _fetched=0
     _tried=0
-    for _method in curl wget sing-box; do
+    if [ -n "${MAGICNET_SUB_PROXY:-}" ]; then
+        _methods="curl"
+    else
+        _methods="curl wget sing-box"
+    fi
+    for _method in $_methods; do
         rm -f "$_download_file"
         magicnet_singbox_try_fetch_subscription "$_method" "$_url" "$_download_file" "$_connect_timeout" "$_max_time"
         _fetch_rc=$?
@@ -98,6 +101,7 @@ magicnet_singbox_fetch_one_subscription() {
         return 1
     fi
     if [ "$_fetched" -ne 1 ]; then
+        [ -z "${MAGICNET_SUB_PROXY:-}" ] || error "Explicit subscription proxy failed; refusing alternate egress"
         magicnet_singbox_use_cached_subscription "$_source_file" "$_fallback_file" || return 1
         return 0
     fi

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
@@ -1,5 +1,55 @@
+magicnet_singbox_update_lock_active() {
+    _update_lock="${MODDIR}/.state/sing-box/subscription-update.lock"
+    [ -d "$_update_lock" ] || return 1
+    _update_owner=$(sed -n '1p' "$_update_lock/owner" 2>/dev/null)
+    _update_pid=${_update_owner%%:*}
+    _update_rest=${_update_owner#*:}
+    _update_start=${_update_rest%%:*}
+    _update_live_start=$(awk '{print $22}' "/proc/${_update_pid}/stat" 2>/dev/null || true)
+    if [ -n "$_update_pid" ] && kill -0 "$_update_pid" 2>/dev/null &&
+        [ -n "$_update_start" ] && [ "$_update_start" = "$_update_live_start" ]; then
+        return 0
+    fi
+    _update_current=$(sed -n '1p' "$_update_lock/owner" 2>/dev/null)
+    [ "$_update_current" = "$_update_owner" ] && rm -rf "$_update_lock" 2>/dev/null || true
+    return 1
+}
+
+magicnet_singbox_update_lock_acquire() {
+    _update_lock="${MODDIR}/.state/sing-box/subscription-update.lock"
+    mkdir -p "${_update_lock%/*}"
+    if ! mkdir "$_update_lock" 2>/dev/null; then
+        if magicnet_singbox_update_lock_active; then
+            error "Subscription update already running"
+            return 1
+        fi
+        mkdir "$_update_lock" 2>/dev/null || return 1
+    fi
+    _update_start=$(awk '{print $22}' "/proc/$$/stat" 2>/dev/null || true)
+    _update_nonce=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || date +%s)
+    _update_token="$$:${_update_start:-unknown}:${_update_nonce}"
+    printf '%s\n' "$_update_token" >"$_update_lock/owner"
+}
+
+magicnet_singbox_update_lock_release() {
+    _update_lock="${MODDIR}/.state/sing-box/subscription-update.lock"
+    _update_owner=$(sed -n '1p' "$_update_lock/owner" 2>/dev/null)
+    [ -n "${_update_token:-}" ] && [ "$_update_owner" = "$_update_token" ] &&
+        rm -rf "$_update_lock" 2>/dev/null || true
+}
+
 magicnet_singbox_update_subscription() {
-    _work_dir="${MODDIR}/.config/sing-box/.subscription-work"
+    magicnet_singbox_update_lock_acquire || return 1
+    trap 'magicnet_singbox_update_lock_release' EXIT HUP INT TERM
+    magicnet_with_config_lock magicnet_singbox_update_subscription_unlocked
+    _update_rc=$?
+    trap - EXIT HUP INT TERM
+    magicnet_singbox_update_lock_release
+    return "$_update_rc"
+}
+
+magicnet_singbox_update_subscription_unlocked() {
+    _work_dir="${MODDIR}/.state/sing-box/subscription-work"
     _nodes_dir="${_work_dir}/nodes"
     _outbounds_file="${_work_dir}/outbounds.json"
     _tags_file="${_work_dir}/tags.txt"
@@ -9,6 +59,7 @@ magicnet_singbox_update_subscription() {
     rm -rf "$_work_dir"
     mkdir -p "$_nodes_dir"
 
+    info "Subscription update stage: fetch"
     magicnet_singbox_fetch_subscription "$_sources_file" || return 1
 
     _node_total=0
@@ -27,6 +78,7 @@ magicnet_singbox_update_subscription() {
         return 1
     fi
 
+    info "Subscription update stage: convert"
     if [ "${MAGICNET_PROXYLINK_ENABLED:-1}" = "1" ] &&
         magicnet_singbox_proxylink_bin >/dev/null 2>&1 &&
         magicnet_singbox_build_outbounds_with_proxylink "$_sources_file" "$_outbounds_file" "$_node_total" >"${_work_dir}/proxylink-counts.txt" 2>/dev/null; then
@@ -48,7 +100,29 @@ magicnet_singbox_update_subscription() {
         return 1
     fi
 
+    info "Subscription update stage: validate"
+    _active_config=$(magicnet_singbox_subscription_config_file)
+    _previous_config="${_work_dir}/previous-config.json"
+    cp -f "$_active_config" "$_previous_config" || return 1
     magicnet_singbox_update_config_with_nodes "$_outbounds_file" || return 1
-    magicnet_singbox_verify_subscription_ready || return 1
+    info "Subscription update stage: activate"
+    _update_fswatch_active=0
+    magicnet_fswatch_status >/dev/null 2>&1 && _update_fswatch_active=1
+    # Read by magicnet_singbox_restart_owned in config.sh.
+    # shellcheck disable=SC2034
+    MAGICNET_SUB_FSWATCH_WAS_ACTIVE="$_update_fswatch_active"
+    if ! magicnet_singbox_verify_subscription_ready; then
+        mv -f "$_previous_config" "$_active_config" 2>/dev/null || true
+        if ! magicnet_singbox_restart_owned "$_active_config" >/dev/null 2>&1; then
+            unset MAGICNET_SUB_FSWATCH_WAS_ACTIVE
+            error "Subscription activation and previous core recovery both failed"
+            return 1
+        fi
+        unset MAGICNET_SUB_FSWATCH_WAS_ACTIVE
+        error "Subscription activation failed; previous config and core restored"
+        return 1
+    fi
+    unset MAGICNET_SUB_FSWATCH_WAS_ACTIVE
+    rm -f "$_previous_config"
     success "sing-box nodes updated: imported ${_imported}, skipped ${_skipped}"
 }

--- a/src/MagicNet/module.prop
+++ b/src/MagicNet/module.prop
@@ -1,7 +1,7 @@
 id=MagicNet
 name=MagicNet
-version=v1.1.19
-versionCode=1783965200465
+version=v1.1.20
+versionCode=1784009905677
 author=LIghtJUNction
 description=[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM.
 updateJson=https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
   "changelog": "https://github.com/LIghtJUNction/MagicNet/blob/main/CHANGELOG.md",
-  "version": "v1.1.19",
-  "versionCode": 1783965200465,
+  "version": "v1.1.20",
+  "versionCode": 1784009905677,
   "zipUrl": "https://github.com/LIghtJUNction/MagicNet/releases/latest/download/MagicNet.zip"
 }


### PR DESCRIPTION
## Summary
- add a dedicated non-China/Hong Kong `ai-proxy` selector for ChatGPT, Gemini, Grok, and Claude
- persist selector choices and safely replay valid selections after restart or subscription activation
- make subscription refresh direct-by-default, bounded, locked, and transactional
- restart only the verified MagicNet sing-box process and restore the previous config on activation failure
- prepare v1.1.20 release metadata

## Testing
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace` (54 passed)
- subscription policy, AI routing, fake-Magisk smoke
- WebUI typecheck/build, `kam validate`, JSON and diff checks
- PHK110 subscription activation, selector persistence, four AI HTTP probes, routing chain, and browser ChatGPT load

## Notes
- X media endpoints responded, but in-app playback and an unplugged-device restart cycle were not completed before disconnect.
- Local `kam build` was blocked before packaging by transient GitHub dependency TLS/tag API failures. CI must build and validate v1.1.20 before release.
- Base config landed in LIghtJUNction/MagicSingBox#4.