### PR TITLE
fix(dns): clean interception when core stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Unreleased
 
+## v1.1.21 (2026-07-16)
+
+- Fix #44 by removing DNS capture and leak-guard rules whenever the core stops,
+  keeping runtime configuration inert while stopped, and clearing stale rules
+  before subscription refresh or kernel startup.
+- Route the dedicated `magicnet-dns-in` listener directly to `hijack-dns`
+  without requiring protocol sniffing before the DNS rule can match.
+- Add default direct bypasses for Xianyu, Taobao, Pinduoduo, Meituan, Ctrip,
+  and Railway 12306 in blacklist app-routing mode.
+
 ## v1.1.20 (2026-07-14)
 
 - Add an independent non-China/Hong Kong `ai-proxy` selector and route the

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   <p>
-    <a href="kam.toml"><img alt="MagicNet v1.1.20" src="https://img.shields.io/badge/MagicNet-v1.1.20-31c2f2" /></a>
+    <a href="kam.toml"><img alt="MagicNet v1.1.21" src="https://img.shields.io/badge/MagicNet-v1.1.21-31c2f2" /></a>
     <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-green.svg" /></a>
     <a href="Cargo.toml"><img alt="Rust workspace" src="https://img.shields.io/badge/Rust-workspace-f46623?logo=rust&logoColor=white" /></a>
     <a href="webui/package.json"><img alt="Vue WebUI" src="https://img.shields.io/badge/WebUI-Vue%203-42b883?logo=vue.js&logoColor=white" /></a>
@@ -27,7 +27,7 @@ MagicNet 是一个 Android root 网络编排模块，把设备流量或显式代
 
 当前主线已经收敛为 **sing-box + 用户态编排**。`sing-box` 是唯一代理核心；MagicNet 提供 `proxy`、`external-tun`、`hybrid` 和兼容 `tun` 四种运行模式。下一代设计详见 [docs/next-gen-architecture.md](docs/next-gen-architecture.md)。旧的 TProxy 主路径、多核心切换和抓包代理功能都不再作为主线能力维护。
 
-需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.20`。Release 以发布页为准。
+需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.21`。Release 以发布页为准。
 
 ## 成果
 
@@ -108,9 +108,9 @@ chmod +x kam.sh
 
 ### Release 包
 
-当前 release 下载页：<https://github.com/LIghtJUNction/MagicNet/releases/tag/v1.1.20>
+当前 release 下载页：<https://github.com/LIghtJUNction/MagicNet/releases/tag/v1.1.21>
 
-直接下载当前模块包：<https://github.com/LIghtJUNction/MagicNet/releases/download/v1.1.20/MagicNet.zip>
+直接下载当前模块包：<https://github.com/LIghtJUNction/MagicNet/releases/download/v1.1.21/MagicNet.zip>
 
 ```bash
 kam -S MagicNet

--- a/crates/magicnet-cli/src/service.rs
+++ b/crates/magicnet-cli/src/service.rs
@@ -8,6 +8,8 @@ use crate::{
 };
 
 const START_SUPERVISORS_COMMAND: &str = "\"${MODDIR}/cli\" supervisor start all >/dev/null 2>&1 &";
+const STOP_RUNTIME_CLEANUP_COMMAND: &str =
+    "magicnet_disable_dns_capture || true; magicnet_disable_dns_leak_guard || true";
 
 pub(crate) fn service_status(app: &App) {
     let singbox = pid_summary("sing-box");
@@ -194,8 +196,12 @@ fn stop_all_direct(app: &App) -> Result<(), String> {
     ignore_command("killall", &["sing-box"]);
     std::thread::sleep(Duration::from_secs(1));
     ignore_command("killall", &["-9", "sing-box"]);
-    run_magicnet_function(app, "magicnet_disable_dns_leak_guard || true")?;
+    run_magicnet_function(app, stop_runtime_cleanup_command())?;
     Ok(())
+}
+
+fn stop_runtime_cleanup_command() -> &'static str {
+    STOP_RUNTIME_CLEANUP_COMMAND
 }
 
 fn stop_supervisor_pidfile(path: PathBuf) {
@@ -329,7 +335,7 @@ fn tail_lines(text: &str, lines: usize) -> Vec<&str> {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_transparent_mode, restart_command};
+    use super::{normalize_transparent_mode, restart_command, stop_runtime_cleanup_command};
 
     #[test]
     fn transparent_modes_accept_orchestrator_modes() {
@@ -355,5 +361,13 @@ mod tests {
             assert!(command.contains("supervisor start all"));
             assert!(command.contains("& }"));
         }
+    }
+
+    #[test]
+    fn stop_runtime_cleanup_disables_dns_capture_before_leak_guard() {
+        assert_eq!(
+            stop_runtime_cleanup_command(),
+            "magicnet_disable_dns_capture || true; magicnet_disable_dns_leak_guard || true"
+        );
     }
 }

--- a/kam.toml
+++ b/kam.toml
@@ -1,8 +1,8 @@
 [prop]
 id = "MagicNet"
 name = "MagicNet"
-version = "v1.1.20"
-versionCode = 1784009905677
+version = "v1.1.21"
+versionCode = 1784196824900
 author = "LIghtJUNction"
 description = "[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM."
 updateJson = "https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json"

--- a/scripts/fake-magisk-smoke.sh
+++ b/scripts/fake-magisk-smoke.sh
@@ -476,6 +476,25 @@ stop_fake_core() {
     fi
 }
 
+assert_dns_cleanup_log() {
+    local log_file="$1"
+    rg -q '^iptables -t nat -D OUTPUT -j magicnet-dns-output$' "$log_file"
+    rg -q '^iptables -D OUTPUT -o wlan0 -p udp --dport 53 -j REJECT$' "$log_file"
+}
+
+assert_dns_interception_not_enabled() {
+    local log_file="$1"
+    local context="$2"
+    if rg -q '^iptables -t nat -A magicnet-dns-output .*--dport 53 .*REDIRECT --to-ports 1053$' "$log_file"; then
+        echo "$context enabled DNS capture without a listener" >&2
+        exit 1
+    fi
+    if rg -q '^iptables -I OUTPUT -o wlan0 .*--dport (53|853) -j REJECT$' "$log_file"; then
+        echo "$context enabled DNS leak guard without a core" >&2
+        exit 1
+    fi
+}
+
 run sh -c '
     . "$MODDIR/lib/kamfw/.kamfwrc"
     import self
@@ -629,6 +648,65 @@ if "$HOST_JQ" -e '.outbounds[] | select(.tag == "old-cached-node")' \
     exit 1
 fi
 stop_fake_core "$MODDIR/.state/fake-sing-box.pid" "sing-box"
+: >"$MOCK_LOG"
+# shellcheck disable=SC2016
+run env MAGIC_DNS_LEAK_GUARD=1 MAGIC_DNS_GUARD_IFACES=wlan0 sh -c '
+    . "$MODDIR/lib/kamfw/.kamfwrc"
+    import __runtime__
+    . "$MODDIR/lib/magicnet.sh"
+    magicnet_apply_runtime_config
+'
+assert_dns_cleanup_log "$MOCK_LOG"
+assert_dns_interception_not_enabled "$MOCK_LOG" "stopped runtime config"
+: >"$MOCK_LOG"
+# shellcheck disable=SC2016
+run env MAGIC_DNS_GUARD_IFACES=wlan0 sh -c '
+    . "$MODDIR/lib/kamfw/.kamfwrc"
+    import __runtime__
+    . "$MODDIR/lib/magicnet.sh"
+    magicnet_start_kernel
+'
+python3 - "$MOCK_LOG" <<'PY'
+import sys
+
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+capture = next((i for i, line in enumerate(lines) if line == "iptables -t nat -D OUTPUT -j magicnet-dns-output"), None)
+guard = next((i for i, line in enumerate(lines) if line == "iptables -D OUTPUT -o wlan0 -p udp --dport 53 -j REJECT"), None)
+run = next((i for i, line in enumerate(lines) if line.startswith("sing-box run")), None)
+if capture is None or guard is None or run is None or capture > run or guard > run:
+    raise SystemExit("kernel bootstrap did not clear DNS interception before starting sing-box")
+PY
+stop_fake_core "$MODDIR/.state/fake-sing-box.pid" "sing-box"
+sleep 3600 &
+echo "$!" >"$MODDIR/.state/fake-sing-box.pid"
+: >"$MOCK_LOG"
+# shellcheck disable=SC2016
+run env MAGIC_DNS_GUARD_IFACES=wlan0 sh -c '
+    . "$MODDIR/lib/kamfw/.kamfwrc"
+    import __runtime__
+    . "$MODDIR/lib/magicnet.sh"
+    magicnet_action_toggle_singbox
+'
+assert_dns_cleanup_log "$MOCK_LOG"
+assert_dns_interception_not_enabled "$MOCK_LOG" "toggle stop"
+sleep 3600 &
+echo "$!" >"$MODDIR/.state/fake-sing-box.pid"
+: >"$MOCK_LOG"
+run env MAGIC_DNS_GUARD_IFACES=wlan0 "$MODDIR/cli" service stop
+assert_dns_cleanup_log "$MOCK_LOG"
+: >"$MOCK_LOG"
+# shellcheck disable=SC2016
+if env MAGIC_SINGBOX=0 MAGIC_DNS_GUARD_IFACES=wlan0 sh -c '
+    . "$MODDIR/lib/kamfw/.kamfwrc"
+    import __runtime__
+    . "$MODDIR/lib/magicnet.sh"
+    magicnet_action_toggle_singbox
+'; then
+    echo "toggle start reported success while sing-box was disabled" >&2
+    exit 1
+fi
+assert_dns_cleanup_log "$MOCK_LOG"
+assert_dns_interception_not_enabled "$MOCK_LOG" "failed toggle start"
 : >"$MOCK_LOG"
 run env \
     MAGICNET_WATCHDOG_ENABLED=0 \
@@ -830,8 +908,8 @@ dns_hijack = next(
     (
         rule for rule in singbox.get("route", {}).get("rules", [])
         if rule.get("action") == "hijack-dns"
-        and rule.get("protocol") == "dns"
         and rule.get("inbound") == ["magicnet-dns-in"]
+        and "protocol" not in rule
     ),
     None,
 )

--- a/scripts/orchestrator-mode-smoke.sh
+++ b/scripts/orchestrator-mode-smoke.sh
@@ -81,7 +81,7 @@ assert_mode() {
     local config="$MODDIR/.config/sing-box/config.json"
     jq -e '.inbounds[] | select(.type == "mixed" and .tag == "mixed-in" and .listen == "127.0.0.1" and .listen_port == 7892)' "$config" >/dev/null
     jq -e '.inbounds[] | select(.type == "direct" and .tag == "magicnet-dns-in" and .listen == "127.0.0.1" and .listen_port == 1053)' "$config" >/dev/null
-    jq -e '.route.rules[] | select(.action == "hijack-dns" and .protocol == "dns" and (.inbound == ["magicnet-dns-in"]))' "$config" >/dev/null
+    jq -e '.route.rules[] | select(.action == "hijack-dns" and (.inbound == ["magicnet-dns-in"]) and (has("protocol") | not))' "$config" >/dev/null
     jq -e '.inbounds[] | select(.tag == "user-mixed")' "$config" >/dev/null
     if jq -e '.inbounds[] | select(.type == "tproxy" or .tag == "magicnet-old" or .tag == "old-tun")' "$config" >/dev/null; then
         echo "orchestrator smoke failed: stale managed inbound survived for mode $mode" >&2

--- a/src/MagicNet/.config/magicnet/app-bypass.list
+++ b/src/MagicNet/.config/magicnet/app-bypass.list
@@ -1,5 +1,13 @@
 # Packages that bypass MagicNet TUN when MAGICNET_APP_MODE=blacklist.
 # One package name per line.
+# Domestic shopping, local services, travel, and rail apps.
+com.taobao.idlefish
+com.taobao.taobao
+com.xunmeng.pinduoduo
+com.sankuai.meituan
+ctrip.android.view
+com.MobileTicket
+
 com.tailscale.ipn
 com.wireguard.android
 net.openvpn.openvpn

--- a/src/MagicNet/README.md
+++ b/src/MagicNet/README.md
@@ -5,7 +5,7 @@ MagicNet 是一个 Android root TUN 透明代理模块，用 `sing-box` 和 `mag
 > [!IMPORTANT]
 > DNS 防泄露必读：请打开系统设置，搜索 `DNS`，找到“私人 DNS”“私密 DNS”“Private DNS”或类似表述，把私人 DNS 关闭，不要设置为自动加密。必须让 DNS 正常走 53 端口，让 MagicNet 模块接管并代理 DNS；否则 Android 系统或浏览器可能直接使用 DoT/DoH，导致 DNS 泄露检测仍然显示外部解析器。
 
-> 需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.20`。Release 以发布页为准。
+> 需要 Magisk / KernelSU / APatch 等 root 管理器。当前版本：`v1.1.21`。Release 以发布页为准。
 
 ## 定位
 

--- a/src/MagicNet/lib/magicnet/action_menu.sh
+++ b/src/MagicNet/lib/magicnet/action_menu.sh
@@ -18,11 +18,15 @@ magicnet_action_toggle_singbox() {
     import __singbox__
     if is_singbox_running >/dev/null 2>&1; then
         singbox_stop
+        _status=$?
+        magicnet_disable_dns_capture || true
+        magicnet_disable_dns_leak_guard || true
     else
-        magicnet_start_singbox
+        magicnet_start_kernel
+        _status=$?
     fi
     magicnet_refresh_status
-    magicnet_after_kernel_start
+    return "$_status"
 }
 
 magicnet_diag_http() {

--- a/src/MagicNet/lib/magicnet/core.sh
+++ b/src/MagicNet/lib/magicnet/core.sh
@@ -66,6 +66,8 @@ magicnet_start_kernel() {
         return 0
     fi
 
+    magicnet_disable_dns_capture || true
+    magicnet_disable_dns_leak_guard || true
     magicnet_require_subscription_or_stop || return 1
 
     if magicnet_start_singbox; then

--- a/src/MagicNet/lib/magicnet/runtime_config.sh
+++ b/src/MagicNet/lib/magicnet/runtime_config.sh
@@ -14,8 +14,13 @@ magicnet_apply_runtime_config_unlocked() {
     magicnet_warp_apply_unlocked || _runtime_rc=1
     magicnet_route_apply_unlocked || _runtime_rc=1
     magicnet_block_apply_unlocked || _runtime_rc=1
-    magicnet_enable_dns_capture || true
-    magicnet_enable_dns_leak_guard || true
+    if magicnet_kernel_running; then
+        magicnet_enable_dns_capture || true
+        magicnet_enable_dns_leak_guard || true
+    else
+        magicnet_disable_dns_capture || true
+        magicnet_disable_dns_leak_guard || true
+    fi
     return "$_runtime_rc"
 }
 

--- a/src/MagicNet/lib/magicnet/transparent.sh
+++ b/src/MagicNet/lib/magicnet/transparent.sh
@@ -61,7 +61,7 @@ magicnet_singbox_apply_transparent_mode() {
             def references_managed_inbound:
               ((.inbound // []) | map(select(startswith("magicnet-"))) | length) > 0;
             def dns_hijack_rule:
-              {"inbound": ["magicnet-dns-in"], "protocol": "dns", "action": "hijack-dns"};
+              {"inbound": ["magicnet-dns-in"], "action": "hijack-dns"};
             def normalize_sniff_rule:
               if (.action // "") == "sniff" then
                 .inbound = (if $mode == "proxy" or $mode == "external-tun" then ["mixed-in"] else ["mixed-in", "tun-in"] end)

--- a/src/MagicNet/module.prop
+++ b/src/MagicNet/module.prop
@@ -1,7 +1,7 @@
 id=MagicNet
 name=MagicNet
-version=v1.1.20
-versionCode=1784009905677
+version=v1.1.21
+versionCode=1784196824900
 author=LIghtJUNction
 description=[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM.
 updateJson=https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
   "changelog": "https://github.com/LIghtJUNction/MagicNet/blob/main/CHANGELOG.md",
-  "version": "v1.1.20",
-  "versionCode": 1784009905677,
+  "version": "v1.1.21",
+  "versionCode": 1784196824900,
   "zipUrl": "https://github.com/LIghtJUNction/MagicNet/releases/latest/download/MagicNet.zip"
 }

--- a/webui/src/components/pages/appPolicyInsights.ts
+++ b/webui/src/components/pages/appPolicyInsights.ts
@@ -43,6 +43,7 @@ export const recommendedBypass = [
   "com.greenpoint.android.mc10086.activity",
   "com.ct.client",
   "com.sinovatech.unicom.ui",
+  "com.taobao.idlefish",
   "com.taobao.taobao",
   "com.tmall.wireless",
   "com.jingdong.app.mall",


### PR DESCRIPTION
## Summary

- fix issue #44 by removing DNS capture and leak-guard rules whenever the core stops
- keep runtime configuration inert while stopped and clear stale interception before bootstrap
- make the dedicated DNS ingress hijack unconditional so redirected DNS cannot fall through to `block`
- add default blacklist bypasses for Xianyu, Taobao, Pinduoduo, Meituan, Ctrip, and Railway 12306
- prepare release `v1.1.21`

## Verification

- `cargo fmt --check`
- `cargo test -p magicnet-cli` — 55/55 passed
- `bash scripts/orchestrator-mode-smoke.sh`
- `bash scripts/test-app-routing-policy.sh`
- `bash scripts/fake-magisk-smoke.sh` — exit 0
- `npm --prefix webui run typecheck`
- `kam validate`
- `git diff --check`
- independent Reviewer PASS

## Real-device differential

- reproduced the old failure: stopped core left DNS `53 -> 1053` redirects while port 1053 had no listener
- candidate `service stop`: core, TUN, port 1053, DNS capture, and leak guard all absent
- stopped `config apply`: remains stopped with interception absent
- `service start`: restores cached configuration, TUN, DNS, and HTTPS connectivity
- six requested bypass packages verified in both the list and TUN exclusion config

Refs #44
