### PR TITLE
fix(subscription): strip trailing slash from hysteria2 hostport before parsing port

### DIFF
--- a/src/MagicNet/lib/magicnet/singbox_subscribe/parse.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/parse.sh
@@ -184,6 +184,7 @@ magicnet_singbox_emit_share_link_json() {
     [ "$_body" != "$_base" ] && _query=${_body#*\?}
     _userinfo=${_base%@*}
     _hostport=${_base#*@}
+    _hostport=${_hostport%/}
     _server=${_hostport%:*}
     _port=${_hostport##*:}
     _tag=$(magicnet_share_link_tag "$_link" "${_scheme}-${_server}-${_port}")


### PR DESCRIPTION
## Problem

Some `hysteria2://` share links include a trailing slash after the `host:port` segment, e.g.:

```text
hysteria2://uuid@host:35000/?insecure=false&sni=www.apple.com#node-name
```

`magicnet_singbox_emit_share_link_json()` in `parse.sh` did not strip that slash before extracting the port, so the generated node JSON became:

```json
{"server_port":35000/, ...}
```

This invalid numeric literal then breaks the downstream `jq --slurpfile` / `jq` pipeline and produces the reported subscription parsing error.

## Fix

Strip any trailing `/` from `_hostport` before extracting `_server` and `_port`:

```sh
_hostport=${_base#*@}
_hostport=${_hostport%/}
_server=${_hostport%:*}
_port=${_hostport##*:}
```

This handles both the standard form `host:port?query...` and the slashed form `host:port/?query...`.

## Verification

Tested against a user-provided subscription that contains 72 nodes (58 vless, 14 hysteria2). Before the fix the hysteria2 nodes produced `35000/` and `jq` failed; after the fix:

- 72 nodes extracted
- 70 valid imported
- 2 skipped as info tags (remaining traffic / expiration)
- `jq empty` passes on the generated node JSON

No subscription URL is included in this PR.

## Summary by Sourcery

错误修复：
- 修复 hysteria2 节点订阅解析问题：在提取端口之前，先从 host:port 段中移除末尾的斜杠。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix subscription parsing of hysteria2 nodes by stripping a trailing slash from the host:port segment before extracting the port.

</details>