### PR TITLE
fix: resolve ChatGPT and WeChat routing failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- Start each AI service selector on its filtered service-specific automatic
+  failover group after a subscription provides eligible nodes, while keeping
+  zero-node configurations blocked and preserving explicit user selections.
+- Resolve WeChat media uploads through the local DNS path and route Tencent
+  media domains before the FakeIP loop guard, while preserving Clash mode and
+  destination-specific policy precedence.
 - Include the redacted startup blocker in support bundles so stopped-core issue
   reports distinguish missing subscriptions or nodes from runtime crashes.
 

--- a/scripts/fake-magisk-smoke.sh
+++ b/scripts/fake-magisk-smoke.sh
@@ -824,7 +824,7 @@ fi
       and ($services | all(. as $service
       | ($service.name + "-auto") as $auto
       | $by_tag[$service.name].type == "selector"
-        and $by_tag[$service.name].default == "block"
+        and $by_tag[$service.name].default == $auto
         and $by_tag[$service.name].outbounds == ["block", $auto]
         and $by_tag[$auto].type == "urltest"
         and $by_tag[$auto].outbounds == $ai_proxy.outbounds

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -36,6 +36,7 @@ shellcheck -s sh -e SC1091,SC1090,SC2329,SC2059 "${posix_shell_files[@]}"
 jq empty src/MagicNet/.config/sing-box/config.json
 sh scripts/test-kamfw-i18n.sh
 bash scripts/test-default-routing-policy.sh
+bash scripts/test-wechat-routing.sh
 bash scripts/test-anthropic-routing.sh
 bash scripts/singbox-subscription-protocol-smoke.sh
 bash scripts/test-subscription-lifecycle.sh

--- a/scripts/test-anthropic-routing.sh
+++ b/scripts/test-anthropic-routing.sh
@@ -88,7 +88,7 @@ jq -e '
     and ($services | all(. as $service
       | ($service.name + "-auto") as $auto
       | $by_tag[$service.name].type == "selector"
-        and $by_tag[$service.name].default == "block"
+        and $by_tag[$service.name].default == $auto
         and $by_tag[$service.name].outbounds == ["block", $auto]
         and $by_tag[$auto] == {
           type: "urltest",
@@ -546,7 +546,7 @@ jq -e '
     and ($services | all(. as $service
       | ($service.name + "-auto") as $auto
       | $by_tag[$service.name].type == "selector"
-        and $by_tag[$service.name].default == "block"
+        and $by_tag[$service.name].default == $auto
         and $by_tag[$service.name].outbounds == ["block", $auto]
         and $by_tag[$auto] == {
           type: "urltest",
@@ -791,7 +791,7 @@ jq -e '
     and ($services | all(. as $service
       | ($service.name + "-auto") as $auto
       | $by_tag[$service.name].type == "selector"
-        and $by_tag[$service.name].default == "block"
+        and $by_tag[$service.name].default == $auto
         and $by_tag[$service.name].outbounds == ["block", $auto]
         and $by_tag[$auto].type == "urltest"
         and $by_tag[$auto].outbounds == $ai_proxy.outbounds
@@ -827,7 +827,7 @@ jq -e '
     and ($services | all(. as $service
       | ($service.name + "-auto") as $auto
       | $by_tag[$service.name].type == "selector"
-        and $by_tag[$service.name].default == "block"
+        and $by_tag[$service.name].default == $auto
         and $by_tag[$service.name].outbounds == ["block", $auto]
         and $by_tag[$auto].type == "urltest"
         and $by_tag[$auto].outbounds == $ai_proxy.outbounds

--- a/scripts/test-default-routing-policy.sh
+++ b/scripts/test-default-routing-policy.sh
@@ -218,7 +218,7 @@ proxy_dns_tags = {
     for server in config["dns"]["servers"]
     if server.get("detour") == "proxy"
 }
-if len(rules) != 65 or len(dns_rules) != 24:
+if len(rules) != 66 or len(dns_rules) != 25:
     raise AssertionError(
         f"canonical rule counts changed: route={len(rules)} dns={len(dns_rules)}"
     )
@@ -228,6 +228,10 @@ apple_icloud_dns_rule = {
 }
 direct_mode_dns_rule = {"clash_mode": "Direct", "server": "bootstrap-local-dns"}
 global_mode_dns_rule = {"clash_mode": "Global", "server": "doh-cloudflare"}
+wechat_dns_rule = {
+    "package_name": ["com.tencent.mm"],
+    "server": "bootstrap-local-dns",
+}
 domestic_connectivity_dns_rule = {
     "domain_suffix": ["connect.rom.miui.com", "connectivitycheck.platform.hicloud.com"],
     "server": "bootstrap-local-dns",
@@ -270,14 +274,14 @@ legacy_early_local_msft_dns_rule = {
 }
 if legacy_early_local_msft_dns_rule in dns_rules:
     raise AssertionError("legacy early local Microsoft connectivity DNS rule must be absent")
-if rules[25] != {"domain_suffix": msft_network_test_suffixes, "outbound": "network-test"}:
-    raise AssertionError("route rule 25 Microsoft network-test suffixes changed")
-if rules[27] != {"domain_suffix": foreign_network_test_suffixes, "outbound": "network-test"}:
-    raise AssertionError("route rule 27 foreign network-test suffixes changed")
+if rules[26] != {"domain_suffix": msft_network_test_suffixes, "outbound": "network-test"}:
+    raise AssertionError("route rule 26 Microsoft network-test suffixes changed")
+if rules[28] != {"domain_suffix": foreign_network_test_suffixes, "outbound": "network-test"}:
+    raise AssertionError("route rule 28 foreign network-test suffixes changed")
 if foreign_network_test_dns_rule["domain_suffix"] != (
-    rules[25]["domain_suffix"] + rules[27]["domain_suffix"]
+    rules[26]["domain_suffix"] + rules[28]["domain_suffix"]
 ):
-    raise AssertionError("foreign network-test DNS suffixes must equal route rules 25 + 27")
+    raise AssertionError("foreign network-test DNS suffixes must equal route rules 26 + 28")
 cn_bing_dns_rule = {
     "domain_suffix": ["cn.bing.com"],
     "server": "bootstrap-local-dns",
@@ -328,6 +332,7 @@ ordered_dns_policy_indexes = []
 for expected_rule in (
     direct_mode_dns_rule,
     global_mode_dns_rule,
+    wechat_dns_rule,
     domestic_connectivity_dns_rule,
     foreign_network_test_dns_rule,
     apple_icloud_dns_rule,
@@ -344,13 +349,14 @@ if not all(
     for left, right in zip(ordered_dns_policy_indexes, ordered_dns_policy_indexes[1:])
 ):
     raise AssertionError(
-        "required DNS order is Direct -> Global -> domestic connectivity -> foreign network-test "
+        "required DNS order is Direct -> Global -> WeChat local -> domestic connectivity -> foreign network-test "
         "-> Apple -> cn Bing -> global Bing -> local Microsoft: "
         f"indexes={ordered_dns_policy_indexes}"
     )
 (
     direct_mode_dns_index,
     global_mode_dns_index,
+    wechat_dns_index,
     domestic_connectivity_dns_index,
     foreign_network_test_dns_index,
     apple_icloud_dns_index,
@@ -604,11 +610,11 @@ expected_dns_tail = [
     specialized_foreign_dns_rule,
     domestic_package_dns_fallback_rule,
 ]
-if dns_rules[13:] != expected_dns_tail:
+if dns_rules[14:] != expected_dns_tail:
     raise AssertionError(
         "required DNS order is private < mmstat local < ad suffix < ad keyword < ad rule-set < game < "
         "foreign priority < canonical CN < generic foreign < specialized < domestic package: "
-        f"{dns_rules[13:]}"
+        f"{dns_rules[14:]}"
     )
 for expected_rule in expected_dns_tail:
     matches = [index for index, rule in enumerate(dns_rules) if rule == expected_rule]
@@ -724,9 +730,9 @@ if (
     != karing_false_positive_domains
 ):
     raise AssertionError("foreign-priority domain sequence must preserve 51 entries and append 5")
-if rules[47] != foreign_priority_route_rule or dns_rules[19] != foreign_priority_dns_rule:
+if rules[48] != foreign_priority_route_rule or dns_rules[20] != foreign_priority_dns_rule:
     raise AssertionError("exact 56-domain foreign-priority route/DNS indexes changed")
-if rules[47]["domain_suffix"] != dns_rules[19]["domain_suffix"]:
+if rules[48]["domain_suffix"] != dns_rules[20]["domain_suffix"]:
     raise AssertionError("foreign-priority route/DNS domain lists must remain identical")
 flows = (
     {
@@ -1008,9 +1014,9 @@ for domain in karing_false_positive_domains:
         dns_index, dns_rule, _ = dns_match
         dns_server = dns_rule.get("server")
     if (
-        route_index != 47
+        route_index != 48
         or route_rule.get("outbound") != "proxy-rule"
-        or dns_index != 19
+        or dns_index != 20
         or dns_server != "doh-google"
     ):
         karing_false_positive_failures.append(
@@ -1151,10 +1157,45 @@ for tag in fail_closed_ai_tags:
     if matches != [expected_selector]:
         raise AssertionError(f"{tag} selector is not canonical fail-closed: {matches}")
 
+wechat_route_rule = {
+    "domain_suffix": [
+        "qq.com", "weixin.qq.com", "wechat.com", "wechatapp.com", "wechatpay.cn",
+        "tenpay.com", "tencent.com", "tencent-cloud.com", "myqcloud.com", "qcloud.com",
+        "gtimg.com", "idqqimg.com", "qpic.cn", "qlogo.cn", "qmail.com", "smtcdns.com",
+        "servicewechat.com", "weixinbridge.com", "weixinsxy.com", "wx.gtimg.com", "wx.qq.com",
+    ],
+    "outbound": "cn-direct",
+}
+wechat_route_indexes = [
+    index for index, rule in enumerate(rules) if rule == wechat_route_rule
+]
+if len(wechat_route_indexes) != 1:
+    raise AssertionError(f"expected one exact WeChat route: indexes={wechat_route_indexes}")
+wechat_route_index = wechat_route_indexes[0]
+for domain in wechat_route_rule["domain_suffix"]:
+    owners = [
+        index for index, rule in enumerate(rules)
+        if domain in values(rule.get("domain_suffix"))
+        and rule.get("outbound") == "cn-direct"
+    ]
+    if owners != [wechat_route_index]:
+        raise AssertionError(f"WeChat domain must have one early cn-direct owner: {domain} indexes={owners}")
+
 loop_fake_guard_rule = {
     "ip_cidr": ["127.0.0.1/32", "::1/128", "198.18.0.0/16", "28.0.0.0/8"],
     "outbound": "block",
 }
+loop_fake_guard_indexes = [
+    index for index, rule in enumerate(rules) if rule == loop_fake_guard_rule
+]
+if len(loop_fake_guard_indexes) != 1:
+    raise AssertionError(f"expected one exact loop/FakeIP guard: indexes={loop_fake_guard_indexes}")
+loop_fake_guard_index = loop_fake_guard_indexes[0]
+if wechat_route_index + 1 != loop_fake_guard_index:
+    raise AssertionError(
+        "WeChat media route must immediately precede the loop/FakeIP guard: "
+        f"wechat={wechat_route_index} guard={loop_fake_guard_index}"
+    )
 lan_rules = [
     {"domain_suffix": ["local", "home.arpa", "lan"], "outbound": "lan"},
     {"domain_suffix": ["tailscale.net", "ts.net"], "outbound": "lan"},
@@ -1227,15 +1268,43 @@ for base_flow in flows:
                     ip_version=ipaddress.ip_address(destination_ip).version)
         index, rule, _ = first_matching_outbound(domain, flow)
         effective = recursively_effective_outbound(rule["outbound"])
-        if index != 11 or rule != loop_fake_guard_rule or effective != "block":
+        if index != loop_fake_guard_index or rule != loop_fake_guard_rule or effective != "block":
             raise AssertionError(
                 f"{flow['name']} guard {domain}/{destination_ip}: index={index} "
-                f"rule={rule} effective={effective}, expected unchanged index-11 block guard"
+                f"rule={rule} effective={effective}, expected unchanged index-{loop_fake_guard_index} block guard"
             )
 
+wechat_media_flow = dict(
+    flows[0],
+    package_name="com.tencent.mm",
+    destination_ip="198.18.1.1",
+    ip_version=4,
+)
+index, rule, _ = first_matching_outbound("upload.qpic.cn", wechat_media_flow)
+effective = recursively_effective_outbound(rule["outbound"])
+if index != wechat_route_index or rule != wechat_route_rule or effective != "direct":
+    raise AssertionError(
+        "WeChat media traffic with a cached FakeIP must bypass the later guard through cn-direct: "
+        f"index={index} rule={rule} effective={effective}"
+    )
+wechat_dns_result = first_matching_dns("unclassified-wechat-upload.invalid", wechat_media_flow)
+if wechat_dns_result is None:
+    raise AssertionError("WeChat DNS query unexpectedly fell through to dns.final")
+index, rule, _ = wechat_dns_result
+if index != wechat_dns_index or rule != wechat_dns_rule:
+    raise AssertionError(
+        "WeChat DNS must use the early local resolver rule to avoid new FakeIP media destinations: "
+        f"index={index} rule={rule}"
+    )
+
 expected_lan_ad_block = lan_rules + ad_rules
-if rules[12:18] != expected_lan_ad_block:
-    raise AssertionError(f"LAN/ad canonical order at indexes 12..17 changed: {rules[12:18]}")
+lan_ad_start = loop_fake_guard_index + 1
+lan_ad_end = lan_ad_start + len(expected_lan_ad_block)
+if rules[lan_ad_start:lan_ad_end] != expected_lan_ad_block:
+    raise AssertionError(
+        f"LAN/ad canonical order at indexes {lan_ad_start}..{lan_ad_end - 1} changed: "
+        f"{rules[lan_ad_start:lan_ad_end]}"
+    )
 for expected_rule in [loop_fake_guard_rule, *expected_lan_ad_block]:
     matches = [index for index, rule in enumerate(rules) if rule == expected_rule]
     if len(matches) != 1:
@@ -1345,7 +1414,7 @@ for domain in ("www.microsoft.com", "msftauth.net", "www.office.com", "www.live.
         )
 
 domestic_package_flow = dict(
-    flows[0], name="tcp-tls-domestic-package", package_name="com.tencent.mm"
+    flows[0], name="tcp-tls-domestic-package", package_name="com.taobao.taobao"
 )
 for domain, (expected_outbound, expected_effective) in {
     "github.com": ("dev-proxy", "block"),
@@ -1393,9 +1462,9 @@ if (
     )
 
 for domain, expected_index, expected_rule in (
-    ("doubleclick.net", 15, ad_suffix_dns_rule),
-    ("www.google-analytics.com", 16, ad_keyword_dns_rule),
-    ("outbrain.com", 17, ad_rule_set_dns_rule),
+    ("doubleclick.net", 16, ad_suffix_dns_rule),
+    ("www.google-analytics.com", 17, ad_keyword_dns_rule),
+    ("outbrain.com", 18, ad_rule_set_dns_rule),
 ):
     result = first_matching_dns(domain, domestic_package_flow)
     if result is None:
@@ -1458,15 +1527,15 @@ if index >= domestic_package_dns_index or rule.get("server") != "bootstrap-local
 mmstat_dns_indexes = [
     index for index, rule in enumerate(dns_rules) if rule == mmstat_local_dns_rule
 ]
-if mmstat_dns_indexes != [14]:
-    raise AssertionError(f"expected one exact mmstat local DNS rule at index 14: {mmstat_dns_indexes}")
+if mmstat_dns_indexes != [15]:
+    raise AssertionError(f"expected one exact mmstat local DNS rule at index 15: {mmstat_dns_indexes}")
 mmstat_dns_index = mmstat_dns_indexes[0]
 route_index, route_rule, matching_rule_sets = first_matching_outbound("mmstat.com", flows[0])
 route_outbound = route_rule.get("outbound")
 route_effective = recursively_effective_outbound(route_outbound)
-if route_index != 29 or route_outbound != "cn-direct" or route_effective != "direct":
+if route_index != 30 or route_outbound != "cn-direct" or route_effective != "direct":
     raise AssertionError(
-        "mmstat.com route must remain index 29 cn-direct/direct: "
+        "mmstat.com route must remain index 30 cn-direct/direct: "
         f"index={route_index} outbound={route_outbound} effective={route_effective}"
     )
 mmstat_dns = first_matching_dns("mmstat.com", flows[0])
@@ -1646,7 +1715,7 @@ network_test_route_indexes = [
 if (
     rule.get("outbound") != "dns-guard"
     or recursively_effective_outbound(rule["outbound"]) != "block"
-    or network_test_route_indexes != [27]
+    or network_test_route_indexes != [28]
     or not index < network_test_route_indexes[0]
 ):
     raise AssertionError(
@@ -2192,7 +2261,7 @@ network_connectivity_keyword_index=$(jq -er '
 
 assert_connectivity_dns_safety() {
     local config_file="$1"
-    local default_mode direct_mode_index global_mode_index domestic_rule_index foreign_rule_index
+    local default_mode direct_mode_index global_mode_index wechat_rule_index domestic_rule_index foreign_rule_index
     local apple_rule_index cn_bing_rule_index global_bing_rule_index local_service_index
     local private_dns_index mmstat_dns_index ad_suffix_dns_index ad_keyword_dns_index ad_rule_set_dns_index
     local game_dns_index foreign_priority_dns_index cn_dns_index
@@ -2211,7 +2280,7 @@ assert_connectivity_dns_safety() {
         printf 'DNS safety guard: default Clash mode must remain Rule\n' >&2
         return 1
     }
-    read -r direct_mode_index global_mode_index domestic_rule_index foreign_rule_index \
+    read -r direct_mode_index global_mode_index wechat_rule_index domestic_rule_index foreign_rule_index \
         apple_rule_index cn_bing_rule_index global_bing_rule_index local_service_index \
         private_dns_index mmstat_dns_index ad_suffix_dns_index ad_keyword_dns_index ad_rule_set_dns_index \
         game_dns_index foreign_priority_dns_index cn_dns_index < <(jq -er '
@@ -2221,6 +2290,7 @@ assert_connectivity_dns_safety() {
       [
         unique_index({clash_mode: "Direct", server: "bootstrap-local-dns"}),
         unique_index({clash_mode: "Global", server: "doh-cloudflare"}),
+        unique_index({package_name: ["com.tencent.mm"], server: "bootstrap-local-dns"}),
         unique_index({
           domain_suffix: ["connect.rom.miui.com", "connectivitycheck.platform.hicloud.com"],
           server: "bootstrap-local-dns"
@@ -2329,7 +2399,8 @@ assert_connectivity_dns_safety() {
         return 1
     }
     ((global_mode_index == direct_mode_index + 1 \
-        && domestic_rule_index == global_mode_index + 1 \
+        && wechat_rule_index == global_mode_index + 1 \
+        && domestic_rule_index == wechat_rule_index + 1 \
         && foreign_rule_index == domestic_rule_index + 1 \
         && apple_rule_index == foreign_rule_index + 1 \
         && cn_bing_rule_index == apple_rule_index + 1 \
@@ -2434,8 +2505,8 @@ dns_rule_match_result() {
     local rule_index="$2"
     local domain="$3"
     local default_mode="$4"
-    local has_domain_group has_clash_mode has_rule_set invert
-    local domain_matches=true clash_mode_matches=true rule_set_matches=true
+    local has_domain_group has_clash_mode has_package_name has_rule_set invert
+    local domain_matches=true clash_mode_matches=true package_name_matches=true rule_set_matches=true
     local rule_set_tag rule_set_path rule_set_file rule_set_output
     local config_base
     local -a rule_set_tags=()
@@ -2452,6 +2523,7 @@ dns_rule_match_result() {
         and (((($rule | has("domain_suffix")) | not) or string_values($rule.domain_suffix)))
         and (((($rule | has("domain_keyword")) | not) or string_values($rule.domain_keyword)))
         and (((($rule | has("clash_mode")) | not) or string_values($rule.clash_mode)))
+        and (((($rule | has("package_name")) | not) or string_values($rule.package_name)))
         and (((($rule | has("rule_set")) | not) or string_values($rule.rule_set)))
         and ((($rule | keys) - [
           "clash_mode",
@@ -2459,6 +2531,7 @@ dns_rule_match_result() {
           "domain_keyword",
           "domain_suffix",
           "invert",
+          "package_name",
           "rule_set",
           "server",
           "type"
@@ -2500,6 +2573,13 @@ dns_rule_match_result() {
             if ($value | type) == "array" then $value else [$value] end;
           values(.dns.rules[$index].clash_mode) | index($default_mode) != null
         ' "$config_file")
+    fi
+
+    has_package_name=$(jq -r --argjson index "$rule_index" '
+      .dns.rules[$index] | has("package_name")
+    ' "$config_file")
+    if [[ "$has_package_name" == "true" ]]; then
+        package_name_matches=false
     fi
 
     has_rule_set=$(jq -r --argjson index "$rule_index" '
@@ -2556,6 +2636,7 @@ dns_rule_match_result() {
     ' "$config_file")
     if [[ "$domain_matches" == "true" \
         && "$clash_mode_matches" == "true" \
+        && "$package_name_matches" == "true" \
         && "$rule_set_matches" == "true" ]]; then
         if [[ "$invert" == "true" ]]; then
             printf 'no-match\n'

--- a/scripts/test-wechat-routing.sh
+++ b/scripts/test-wechat-routing.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG_DIR="${MAGICNET_ROUTING_CONFIG_DIR:-$ROOT/src/MagicNet/.config/sing-box}"
+CONFIG_FILE="$CONFIG_DIR/config.json"
+
+[[ -f "$CONFIG_FILE" ]] || {
+    printf 'WeChat routing test failed: missing config: %s\n' "$CONFIG_FILE" >&2
+    exit 1
+}
+command -v python3 >/dev/null 2>&1 || {
+    printf 'WeChat routing test failed: python3 is required\n' >&2
+    exit 1
+}
+
+python3 - "$CONFIG_FILE" <<'PY'
+import ipaddress
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    config = json.load(handle)
+
+route_rules = config["route"]["rules"]
+dns_rules = config["dns"]["rules"]
+wechat_domains = [
+    "qq.com", "weixin.qq.com", "wechat.com", "wechatapp.com", "wechatpay.cn",
+    "tenpay.com", "tencent.com", "tencent-cloud.com", "myqcloud.com", "qcloud.com",
+    "gtimg.com", "idqqimg.com", "qpic.cn", "qlogo.cn", "qmail.com", "smtcdns.com",
+    "servicewechat.com", "weixinbridge.com", "weixinsxy.com", "wx.gtimg.com", "wx.qq.com",
+]
+wechat_route = {"domain_suffix": wechat_domains, "outbound": "cn-direct"}
+wechat_dns = {"package_name": ["com.tencent.mm"], "server": "bootstrap-local-dns"}
+fakeip_guard = {
+    "ip_cidr": ["127.0.0.1/32", "::1/128", "198.18.0.0/16", "28.0.0.0/8"],
+    "outbound": "block",
+}
+
+
+def exact_indexes(rules, expected):
+    return [index for index, rule in enumerate(rules) if rule == expected]
+
+
+wechat_route_indexes = exact_indexes(route_rules, wechat_route)
+guard_indexes = exact_indexes(route_rules, fakeip_guard)
+wechat_dns_indexes = exact_indexes(dns_rules, wechat_dns)
+if len(wechat_route_indexes) != 1:
+    raise AssertionError(f"expected one exact WeChat route, got {wechat_route_indexes}")
+if len(guard_indexes) != 1:
+    raise AssertionError(f"expected one exact FakeIP guard, got {guard_indexes}")
+if len(wechat_dns_indexes) != 1:
+    raise AssertionError(f"expected one exact WeChat DNS rule, got {wechat_dns_indexes}")
+if wechat_route_indexes[0] >= guard_indexes[0]:
+    raise AssertionError("WeChat media route must precede the FakeIP guard")
+
+for domain in wechat_domains:
+    owners = [
+        index
+        for index, rule in enumerate(route_rules)
+        if rule.get("outbound") == "cn-direct"
+        and domain in (rule.get("domain_suffix") or [])
+    ]
+    if owners != wechat_route_indexes:
+        raise AssertionError(f"{domain} has non-canonical cn-direct owners: {owners}")
+
+global_dns_indexes = [
+    index
+    for index, rule in enumerate(dns_rules)
+    if rule.get("clash_mode") == "Global"
+]
+if global_dns_indexes and wechat_dns_indexes[0] <= global_dns_indexes[-1]:
+    raise AssertionError("Global DNS mode must retain priority over the WeChat local resolver")
+
+
+def domain_matches(rule, domain):
+    return any(
+        domain == suffix or domain.endswith("." + suffix)
+        for suffix in rule.get("domain_suffix", [])
+    )
+
+
+def ip_matches(rule, destination_ip):
+    cidrs = rule.get("ip_cidr")
+    if not cidrs:
+        return True
+    address = ipaddress.ip_address(destination_ip)
+    return any(address in ipaddress.ip_network(cidr) for cidr in cidrs)
+
+
+def package_matches(rule, package_name):
+    packages = rule.get("package_name")
+    return packages is None or package_name in packages
+
+
+def first_media_outbound(domain, destination_ip, package_name):
+    for index, rule in enumerate(route_rules):
+        if "outbound" not in rule:
+            continue
+        if rule.get("clash_mode") is not None:
+            continue
+        if rule.get("protocol") not in (None, "tls"):
+            continue
+        if rule.get("network") not in (None, "tcp"):
+            continue
+        ports = rule.get("port")
+        if ports is not None and 443 not in (ports if isinstance(ports, list) else [ports]):
+            continue
+        if not package_matches(rule, package_name):
+            continue
+        if rule.get("domain_suffix") and not domain_matches(rule, domain):
+            continue
+        if not ip_matches(rule, destination_ip):
+            continue
+        if any(key in rule for key in ("domain", "domain_keyword", "rule_set", "ip_is_private")):
+            continue
+        return index, rule["outbound"]
+    raise AssertionError("WeChat media flow did not match any modeled route")
+
+
+index, outbound = first_media_outbound("upload.qpic.cn", "198.18.1.1", "com.tencent.mm")
+if (index, outbound) != (wechat_route_indexes[0], "cn-direct"):
+    raise AssertionError(
+        f"cached-FakeIP WeChat media flow matched index={index} outbound={outbound}"
+    )
+
+print("WeChat routing policy test passed")
+PY

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh
@@ -118,7 +118,8 @@ magicnet_singbox_ai_selectors_canonical() {
               | ([ $auto_groups[] | select(.tag == $auto_name) ]) as $service_auto_groups
               | ($service_groups | length) == 1
                 and $service_groups[0].type == "selector"
-                and $service_groups[0].default == "block"
+                and $service_groups[0].default
+                  == (if ($ai_tags | length) > 0 then $auto_name else "block" end)
                 and ($service_groups[0].outbounds
                   == (if ($ai_tags | length) > 0 then ["block", $auto_name] else ["block"] end))
                 and ($service_groups[0].outbounds | all(. as $member | $tags | index($member) != null))
@@ -575,13 +576,15 @@ magicnet_singbox_ai_selectors_canonical() {
                 continue
               }
               object = group_object[name]
-              if (field_string(object, "type") != "selector" || !field_valid ||
-                  field_string(object, "default") != "block" || !field_valid) bad = 1
+              if (field_string(object, "type") != "selector" || !field_valid) bad = 1
               member_count = field_array(object, "outbounds", member)
               if (member_count < 0) bad = 1
               auto_tag = name "-auto"
+              group_default = field_string(object, "default")
+              if (!field_valid) bad = 1
               if (eligible_count > 0) {
-                if (member_count != 2 || member[1] != "block" || member[2] != auto_tag) bad = 1
+                if (member_count != 2 || member[1] != "block" || member[2] != auto_tag ||
+                    group_default != auto_tag) bad = 1
                 if (auto_count[auto_tag] != 1) {
                   bad = 1
                   continue
@@ -601,7 +604,8 @@ magicnet_singbox_ai_selectors_canonical() {
                   if (auto_member[j] != ai_member[j] || !(auto_member[j] in eligible_nodes)) bad = 1
                 }
               } else {
-                if (member_count != 1 || member[1] != "block" || auto_count[auto_tag] != 0) bad = 1
+                if (member_count != 1 || member[1] != "block" || group_default != "block" ||
+                    auto_count[auto_tag] != 0) bad = 1
               }
             }
             exit bad ? 1 : 0

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
@@ -137,7 +137,7 @@ magicnet_singbox_build_outbounds_file_with_jq() {
     def pinned_ai_selector($tag; $tags):
       {"type": "selector", "tag": $tag,
        "outbounds": (if ($tags | length) > 0 then ["block", ($tag + "-auto")] else ["block"] end),
-       "default": "block"};
+       "default": (if ($tags | length) > 0 then ($tag + "-auto") else "block" end)};
     def ai_service_outbounds($tags):
       [
         {tag: "ai-chatgpt", url: "https://chatgpt.com/"},
@@ -370,16 +370,23 @@ magicnet_singbox_emit_pinned_ai_selector() {
     printf '"block"'
     [ -z "$_pinned_ai_selector_tags" ] || printf ', "%s-auto"' "$(magicnet_json_escape "$_pinned_ai_name")"
     printf '],\n'
-    printf '      "default": "block"\n'
+    if [ -n "$_pinned_ai_selector_tags" ]; then
+        printf '      "default": "%s-auto"\n' "$(magicnet_json_escape "$_pinned_ai_name")"
+    else
+        printf '      "default": "block"\n'
+    fi
     printf '    }'
     unset _pinned_ai_name _pinned_ai_selector_tags
 }
 
 magicnet_singbox_pinned_ai_tags() {
     _pinned_ai_tags_file="$1"
-    awk 'BEGIN { IGNORECASE = 1 }
-      !/中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西/ &&
-      !/(^|[^[:alnum:]])(Hong[ _-]?Kong([ _-]?[0-9]+)?|HKG?[ _-]?[0-9]+|China|Mainland|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^[:alnum:]]|$)/ { print }
+    awk '
+      {
+        folded = tolower($0)
+        if ($0 !~ /中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西/ &&
+            folded !~ /(^|[^[:alnum:]])(hong[ _-]?kong([ _-]?[0-9]+)?|hkg?[ _-]?[0-9]+|china|mainland|hk|hkg|cn|beijing|shanghai|guangzhou|shenzhen|chongqing|tianjin|hebei|shanxi|liaoning|jilin|heilongjiang|jiangsu|zhejiang|anhui|fujian|jiangxi|shandong|henan|hubei|hunan|guangdong|hainan|sichuan|guizhou|yunnan|shaanxi|gansu|qinghai|inner[ _-]?mongolia|guangxi|tibet|ningxia|xinjiang)([^[:alnum:]]|$)/) print
+      }
     ' "$_pinned_ai_tags_file"
     unset _pinned_ai_tags_file
 }
@@ -520,7 +527,7 @@ magicnet_singbox_sanitize_generated_config() {
       def pinned_ai_selector($tag; $tags):
         {"type": "selector", "tag": $tag,
          "outbounds": (if ($tags | length) > 0 then ["block", ($tag + "-auto")] else ["block"] end),
-         "default": "block"};
+         "default": (if ($tags | length) > 0 then ($tag + "-auto") else "block" end)};
       def ai_service_outbounds($tags):
         [
           {tag: "ai-chatgpt", url: "https://chatgpt.com/"},


### PR DESCRIPTION
## What changed

- Activates each AI service selector on its service-specific URLTest group after a subscription imports eligible non-mainland nodes.
- Preserves fail-closed behavior when no eligible AI node exists and preserves explicit selector choices.
- Updates the MagicSingBox submodule to the restored canonical routing configuration from MagicSingBox PR #6.
- Gives WeChat a local-DNS path and evaluates Tencent media domains before the FakeIP loop guard.
- Adds focused WeChat cached-FakeIP coverage and updates the full routing-policy invariants.

## Root causes

### #51
The generated `ai-chatgpt` selector contained a usable automatic group but still defaulted to `block`. The Android app consequently failed before a user manually selected a route and surfaced a generic SSL/network-configuration warning.

### #52
The diagnostic bundle was captured after the UI explicitly stopped sing-box, which explains the reported stopped core. Before that stop, WeChat media destinations could resolve to FakeIP and hit the loop guard because Tencent media routing was ordered later; text traffic could survive on existing connections while new image-upload connections failed.

## Validation

- Full default routing policy test with sing-box 1.13.14
- 66 route rules / 25 DNS rules
- 346 explicit route/DNS parity probes
- cached-FakeIP WeChat media regression
- pinned AI routing regression
- subscription lifecycle regression
- app routing and ad routing regressions

Closes #51
Closes #52

## Summary by Sourcery

调整 AI 服务选择器和微信路由，以修复 ChatGPT 和微信连接失败问题，同时强化路由策略不变式和测试。

New Features:
- 当有符合条件的非中国大陆节点可用时，将默认 AI 服务选择器指向其各自服务的自动故障切换分组，同时保持“零节点”配置处于阻止状态。
- 引入专用的微信路由与 DNS 路径，使微信流量通过本地 DNS 解析，并在 `FakeIP` 循环保护之前优先路由腾讯媒体域名。

Enhancements:
- 更新路由策略不变式以适配新的微信 DNS 和路由规则，同时保持 Clash 模式优先级以及基于目标地址的策略不变。
- 优化 AI 选择器生成逻辑和规范性检查，使被固定（pinned）的 AI 选择器与其自动 `URLTest` 分组对齐，而不是默认“失败即关闭”。

Tests:
- 新增独立的微信路由策略测试，用于验证微信媒体流、`FakeIP` 保护顺序和本地 DNS 行为。
- 更新默认路由策略测试、连接性 DNS 安全性测试、Anthropic 路由测试以及冒烟测试，以反映 AI 和微信路由的新规则数量与排序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust AI service selectors and WeChat routing to fix ChatGPT and WeChat connectivity failures while tightening routing-policy invariants and tests.

New Features:
- Default AI service selectors to their service-specific automatic failover groups once eligible non-mainland nodes are available, while keeping zero-node configurations blocked.
- Introduce a dedicated WeChat routing and DNS path that resolves WeChat traffic via local DNS and routes Tencent media domains ahead of the FakeIP loop guard.

Enhancements:
- Update routing-policy invariants to account for the new WeChat DNS and route rules, preserving Clash mode precedence and destination-specific policies.
- Refine AI selector generation and canonicality checks so pinned AI selectors align with their auto URLTest groups instead of failing closed by default.

Tests:
- Add a standalone WeChat routing policy test to validate WeChat media flows, FakeIP guard ordering, and local-DNS behavior.
- Update default routing policy, connectivity DNS safety, anthropic routing, and smoke tests to reflect new rule counts and ordering for AI and WeChat routing.

</details>