### PR TITLE
fix: stabilize ChatGPT and X action routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Keep ChatGPT remote pairing feature traffic on the pinned ChatGPT path and
+  route all X Android action requests before the FakeIP guard.
 - Start each AI service selector on its filtered service-specific automatic
   failover group after a subscription provides eligible nodes, while keeping
   zero-node configurations blocked and preserving explicit user selections.

--- a/scripts/package-smoke.sh
+++ b/scripts/package-smoke.sh
@@ -304,7 +304,7 @@ if len(packaged_tuns) != 1 or packaged_tuns[0].get("route_exclude_address") != c
 dns_rules = config.get("dns", {}).get("rules", [])
 dns_servers = config.get("dns", {}).get("servers", [])
 route_rules = config.get("route", {}).get("rules", [])
-if len(route_rules) != 66 or len(dns_rules) != 25:
+if len(route_rules) != 67 or len(dns_rules) != 25:
     raise SystemExit(
         f"canonical rule counts changed: route={len(route_rules)} dns={len(dns_rules)}"
     )
@@ -419,20 +419,20 @@ legacy_early_local_msft_dns_rule = {
 }
 if legacy_early_local_msft_dns_rule in dns_rules:
     raise SystemExit("legacy early local Microsoft connectivity DNS rule must be absent")
-if route_rules[26] != {
+if route_rules[27] != {
     "domain_suffix": msft_network_test_suffixes,
     "outbound": "network-test",
 }:
-    raise SystemExit("route rule 26 Microsoft network-test suffixes changed")
-if route_rules[28] != {
+    raise SystemExit("route rule 27 Microsoft network-test suffixes changed")
+if route_rules[29] != {
     "domain_suffix": foreign_network_test_suffixes,
     "outbound": "network-test",
 }:
-    raise SystemExit("route rule 28 foreign network-test suffixes changed")
+    raise SystemExit("route rule 29 foreign network-test suffixes changed")
 if foreign_connectivity_rule["domain_suffix"] != (
-    route_rules[26]["domain_suffix"] + route_rules[28]["domain_suffix"]
+    route_rules[27]["domain_suffix"] + route_rules[29]["domain_suffix"]
 ):
-    raise SystemExit("foreign network-test DNS suffixes must equal route rules 26 + 28")
+    raise SystemExit("foreign network-test DNS suffixes must equal route rules 27 + 29")
 apple_icloud_rule = {
     "domain_suffix": [
         "apple.com",
@@ -1363,7 +1363,7 @@ def rule_sets(rule):
     return set(value if isinstance(value, list) else [value])
 
 ai_domain_routes = {
-    "ai-chatgpt": {"openai.com", "chatgpt.com", "chat.openai.com", "auth.openai.com", "oaistatic.com", "oaiusercontent.com", "openaiapi-site.azureedge.net"},
+    "ai-chatgpt": {"openai.com", "chatgpt.com", "chat.openai.com", "auth.openai.com", "oaistatic.com", "oaiusercontent.com", "oaistatsig.com", "openaiapi-site.azureedge.net"},
     "ai-gemini": {"gemini.google.com", "bard.google.com", "generativelanguage.googleapis.com", "ai.google.dev"},
     "ai-grok": {"grok.com", "x.ai", "api.x.ai"},
     "ai-claude": {"anthropic.com", "claude.ai"},
@@ -1371,6 +1371,30 @@ ai_domain_routes = {
 for outbound, required_domains in ai_domain_routes.items():
     if find_rule(route_rules, required_domains, outbound=outbound) < 0:
         raise SystemExit(f"missing dedicated domain route for {outbound}")
+
+x_package_routes = [
+    index
+    for index, rule in enumerate(route_rules)
+    if rule == {"package_name": ["com.twitter.android"], "outbound": "social-proxy"}
+]
+fakeip_guard_routes = [
+    index
+    for index, rule in enumerate(route_rules)
+    if rule == {
+        "ip_cidr": ["127.0.0.1/32", "::1/128", "198.18.0.0/16", "28.0.0.0/8"],
+        "outbound": "block",
+    }
+]
+if len(x_package_routes) != 1 or len(fakeip_guard_routes) != 1:
+    raise SystemExit(
+        "packaged X action route or FakeIP guard is non-canonical: "
+        f"x={x_package_routes} guard={fakeip_guard_routes}"
+    )
+if x_package_routes[0] >= fakeip_guard_routes[0]:
+    raise SystemExit(
+        "packaged X action route must precede the FakeIP guard: "
+        f"x={x_package_routes[0]} guard={fakeip_guard_routes[0]}"
+    )
 
 for tag in ("ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude", "ai-proxy"):
     expected_selector = {"type": "selector", "tag": tag, "outbounds": ["block"], "default": "block"}
@@ -1551,9 +1575,9 @@ foreign_priority_route_rule = {
     "domain_suffix": foreign_priority_domains,
     "outbound": "proxy-rule",
 }
-if route_rules[48] != foreign_priority_route_rule:
-    raise SystemExit("packaged exact 56-domain foreign-priority route must remain at index 48")
-if route_rules[48]["domain_suffix"] != dns_rules[20]["domain_suffix"]:
+if route_rules[49] != foreign_priority_route_rule:
+    raise SystemExit("packaged exact 56-domain foreign-priority route must remain at index 49")
+if route_rules[49]["domain_suffix"] != dns_rules[20]["domain_suffix"]:
     raise SystemExit("packaged foreign-priority route/DNS lists must remain identical")
 canonical_keyword_rule = {"domain_keyword": network_test_keywords, "outbound": "network-test"}
 keyword_routes = [
@@ -1828,12 +1852,12 @@ if recursively_effective_outbound(global_bing_route_rule["outbound"]) != "block"
     )
 
 if (
-    route_rules[30].get("outbound") != "cn-direct"
-    or not explicit_domain_matches(route_rules[30], "mmstat.com")
-    or any(explicit_domain_matches(rule, "mmstat.com") for rule in route_rules[:30])
-    or recursively_effective_outbound(route_rules[30]["outbound"]) != "direct"
+    route_rules[31].get("outbound") != "cn-direct"
+    or not explicit_domain_matches(route_rules[31], "mmstat.com")
+    or any(explicit_domain_matches(rule, "mmstat.com") for rule in route_rules[:31])
+    or recursively_effective_outbound(route_rules[31]["outbound"]) != "direct"
 ):
-    raise SystemExit("packaged mmstat.com route must first-match index 30 cn-direct/direct")
+    raise SystemExit("packaged mmstat.com route must first-match index 31 cn-direct/direct")
 
 download_probes = set(download_suffixes)
 for index, rule in enumerate(route_rules[:download_route_index]):

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -37,6 +37,7 @@ jq empty src/MagicNet/.config/sing-box/config.json
 sh scripts/test-kamfw-i18n.sh
 bash scripts/test-default-routing-policy.sh
 bash scripts/test-wechat-routing.sh
+bash scripts/test-action-routing.sh
 bash scripts/test-anthropic-routing.sh
 bash scripts/singbox-subscription-protocol-smoke.sh
 bash scripts/test-subscription-lifecycle.sh

--- a/scripts/test-action-routing.sh
+++ b/scripts/test-action-routing.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG_DIR="${MAGICNET_ROUTING_CONFIG_DIR:-$ROOT/src/MagicNet/.config/sing-box}"
+CONFIG_FILE="$CONFIG_DIR/config.json"
+
+[[ -f "$CONFIG_FILE" ]] || {
+    printf 'Action routing test failed: missing config: %s\n' "$CONFIG_FILE" >&2
+    exit 1
+}
+command -v python3 >/dev/null 2>&1 || {
+    printf 'Action routing test failed: python3 is required\n' >&2
+    exit 1
+}
+
+python3 - "$CONFIG_FILE" <<'PY'
+import ipaddress
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    config = json.load(handle)
+
+route_rules = config["route"]["rules"]
+fakeip_guard = {
+    "ip_cidr": ["127.0.0.1/32", "::1/128", "198.18.0.0/16", "28.0.0.0/8"],
+    "outbound": "block",
+}
+chatgpt_packages = {"com.openai.chatgpt", "com.openai.chat", "ai.openai.chatgpt"}
+x_packages = {"com.twitter.android"}
+
+
+def values(value):
+    if value is None:
+        return []
+    return value if isinstance(value, list) else [value]
+
+
+def exact_indexes(expected):
+    return [index for index, rule in enumerate(route_rules) if rule == expected]
+
+
+def package_indexes(packages, outbound):
+    return [
+        index
+        for index, rule in enumerate(route_rules)
+        if rule.get("outbound") == outbound
+        and set(values(rule.get("package_name"))) == packages
+        and set(rule) == {"package_name", "outbound"}
+    ]
+
+
+guard_indexes = exact_indexes(fakeip_guard)
+chatgpt_indexes = package_indexes(chatgpt_packages, "ai-chatgpt")
+x_indexes = package_indexes(x_packages, "social-proxy")
+if len(guard_indexes) != 1:
+    raise AssertionError(f"expected one exact FakeIP guard, got {guard_indexes}")
+if len(chatgpt_indexes) != 1:
+    raise AssertionError(f"expected one exact ChatGPT package route, got {chatgpt_indexes}")
+if len(x_indexes) != 1:
+    raise AssertionError(f"expected one exact X package route, got {x_indexes}")
+
+guard_index = guard_indexes[0]
+if chatgpt_indexes[0] >= guard_index or x_indexes[0] >= guard_index:
+    raise AssertionError(
+        "ChatGPT and X package routes must precede the FakeIP guard: "
+        f"chatgpt={chatgpt_indexes[0]} x={x_indexes[0]} guard={guard_index}"
+    )
+
+
+def domain_matches(rule, domain):
+    return any(
+        domain == suffix or domain.endswith("." + suffix)
+        for suffix in values(rule.get("domain_suffix"))
+    )
+
+
+def ip_matches(rule, destination_ip):
+    cidrs = values(rule.get("ip_cidr"))
+    if not cidrs:
+        return True
+    address = ipaddress.ip_address(destination_ip)
+    return any(address in ipaddress.ip_network(cidr) for cidr in cidrs)
+
+
+def package_matches(rule, package_name):
+    packages = values(rule.get("package_name"))
+    return not packages or package_name in packages
+
+
+def first_modeled_outbound(domain, destination_ip, package_name):
+    for index, rule in enumerate(route_rules):
+        if "outbound" not in rule:
+            continue
+        if rule.get("clash_mode") is not None:
+            continue
+        if rule.get("protocol") not in (None, "tls"):
+            continue
+        if rule.get("network") not in (None, "tcp"):
+            continue
+        ports = values(rule.get("port"))
+        if ports and 443 not in ports:
+            continue
+        if not package_matches(rule, package_name):
+            continue
+        if rule.get("domain_suffix") and not domain_matches(rule, domain):
+            continue
+        if not ip_matches(rule, destination_ip):
+            continue
+        if any(key in rule for key in ("domain", "domain_keyword", "rule_set", "ip_is_private")):
+            continue
+        return index, rule["outbound"]
+    raise AssertionError("action flow did not match any modeled route")
+
+
+for package_name, expected_index, expected_outbound in (
+    ("com.openai.chatgpt", chatgpt_indexes[0], "ai-chatgpt"),
+    ("com.twitter.android", x_indexes[0], "social-proxy"),
+):
+    index, outbound = first_modeled_outbound(
+        "unclassified-action.invalid",
+        "198.18.1.1",
+        package_name,
+    )
+    if (index, outbound) != (expected_index, expected_outbound):
+        raise AssertionError(
+            f"{package_name} FakeIP action flow matched index={index} outbound={outbound}"
+        )
+
+chatgpt_domain_rules = [
+    rule
+    for rule in route_rules
+    if rule.get("outbound") == "ai-chatgpt"
+    and "domain_suffix" in rule
+]
+oaistatsig_owners = [
+    rule for rule in chatgpt_domain_rules if domain_matches(rule, "events.oaistatsig.com")
+]
+if len(oaistatsig_owners) != 1:
+    raise AssertionError(
+        "OpenAI feature/auth traffic must have one ai-chatgpt owner for oaistatsig.com"
+    )
+
+print("ChatGPT/X action routing policy test passed")
+PY

--- a/scripts/test-anthropic-routing.sh
+++ b/scripts/test-anthropic-routing.sh
@@ -884,7 +884,7 @@ import json, sys
 c = json.load(open(sys.argv[1], encoding="utf-8")); rules = c["route"]["rules"]
 groups = {"ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"}
 ai_domains = {
-    "ai-chatgpt": {"openai.com", "chatgpt.com", "chat.openai.com", "auth.openai.com", "oaistatic.com", "oaiusercontent.com", "openaiapi-site.azureedge.net"},
+    "ai-chatgpt": {"openai.com", "chatgpt.com", "chat.openai.com", "auth.openai.com", "oaistatic.com", "oaiusercontent.com", "oaistatsig.com", "openaiapi-site.azureedge.net"},
     "ai-gemini": {"gemini.google.com", "bard.google.com", "generativelanguage.googleapis.com", "ai.google.dev"},
     "ai-grok": {"grok.com", "x.ai", "api.x.ai"},
     "ai-claude": {"anthropic.com", "claude.ai"},

--- a/scripts/test-default-routing-policy.sh
+++ b/scripts/test-default-routing-policy.sh
@@ -218,7 +218,7 @@ proxy_dns_tags = {
     for server in config["dns"]["servers"]
     if server.get("detour") == "proxy"
 }
-if len(rules) != 66 or len(dns_rules) != 25:
+if len(rules) != 67 or len(dns_rules) != 25:
     raise AssertionError(
         f"canonical rule counts changed: route={len(rules)} dns={len(dns_rules)}"
     )
@@ -274,14 +274,14 @@ legacy_early_local_msft_dns_rule = {
 }
 if legacy_early_local_msft_dns_rule in dns_rules:
     raise AssertionError("legacy early local Microsoft connectivity DNS rule must be absent")
-if rules[26] != {"domain_suffix": msft_network_test_suffixes, "outbound": "network-test"}:
-    raise AssertionError("route rule 26 Microsoft network-test suffixes changed")
-if rules[28] != {"domain_suffix": foreign_network_test_suffixes, "outbound": "network-test"}:
-    raise AssertionError("route rule 28 foreign network-test suffixes changed")
+if rules[27] != {"domain_suffix": msft_network_test_suffixes, "outbound": "network-test"}:
+    raise AssertionError("route rule 27 Microsoft network-test suffixes changed")
+if rules[29] != {"domain_suffix": foreign_network_test_suffixes, "outbound": "network-test"}:
+    raise AssertionError("route rule 29 foreign network-test suffixes changed")
 if foreign_network_test_dns_rule["domain_suffix"] != (
-    rules[26]["domain_suffix"] + rules[28]["domain_suffix"]
+    rules[27]["domain_suffix"] + rules[29]["domain_suffix"]
 ):
-    raise AssertionError("foreign network-test DNS suffixes must equal route rules 26 + 28")
+    raise AssertionError("foreign network-test DNS suffixes must equal route rules 27 + 29")
 cn_bing_dns_rule = {
     "domain_suffix": ["cn.bing.com"],
     "server": "bootstrap-local-dns",
@@ -730,9 +730,9 @@ if (
     != karing_false_positive_domains
 ):
     raise AssertionError("foreign-priority domain sequence must preserve 51 entries and append 5")
-if rules[48] != foreign_priority_route_rule or dns_rules[20] != foreign_priority_dns_rule:
+if rules[49] != foreign_priority_route_rule or dns_rules[20] != foreign_priority_dns_rule:
     raise AssertionError("exact 56-domain foreign-priority route/DNS indexes changed")
-if rules[48]["domain_suffix"] != dns_rules[20]["domain_suffix"]:
+if rules[49]["domain_suffix"] != dns_rules[20]["domain_suffix"]:
     raise AssertionError("foreign-priority route/DNS domain lists must remain identical")
 flows = (
     {
@@ -1014,7 +1014,7 @@ for domain in karing_false_positive_domains:
         dns_index, dns_rule, _ = dns_match
         dns_server = dns_rule.get("server")
     if (
-        route_index != 48
+        route_index != 49
         or route_rule.get("outbound") != "proxy-rule"
         or dns_index != 20
         or dns_server != "doh-google"
@@ -1533,9 +1533,9 @@ mmstat_dns_index = mmstat_dns_indexes[0]
 route_index, route_rule, matching_rule_sets = first_matching_outbound("mmstat.com", flows[0])
 route_outbound = route_rule.get("outbound")
 route_effective = recursively_effective_outbound(route_outbound)
-if route_index != 30 or route_outbound != "cn-direct" or route_effective != "direct":
+if route_index != 31 or route_outbound != "cn-direct" or route_effective != "direct":
     raise AssertionError(
-        "mmstat.com route must remain index 30 cn-direct/direct: "
+        "mmstat.com route must remain index 31 cn-direct/direct: "
         f"index={route_index} outbound={route_outbound} effective={route_effective}"
     )
 mmstat_dns = first_matching_dns("mmstat.com", flows[0])
@@ -1567,9 +1567,9 @@ explicit_route_domains = sorted({
     for key in ("domain", "domain_suffix")
     for domain in values(route_rule.get(key))
 })
-if len(explicit_route_domains) != 346:
+if len(explicit_route_domains) != 347:
     raise AssertionError(
-        f"explicit route-domain audit coverage changed: count={len(explicit_route_domains)} expected=346"
+        f"explicit route-domain audit coverage changed: count={len(explicit_route_domains)} expected=347"
     )
 
 def audit_explicit_route_dns_parity(domain):
@@ -1715,7 +1715,7 @@ network_test_route_indexes = [
 if (
     rule.get("outbound") != "dns-guard"
     or recursively_effective_outbound(rule["outbound"]) != "block"
-    or network_test_route_indexes != [28]
+    or network_test_route_indexes != [29]
     or not index < network_test_route_indexes[0]
 ):
     raise AssertionError(


### PR DESCRIPTION
## Summary

- route the official X Android package through `social-proxy` before the FakeIP guard
- keep `oaistatsig.com` on the pinned ChatGPT selector used by Remote pairing flows
- add regression coverage for unsniffed FakeIP action requests and packaged configuration
- update the canonical MagicSingBox submodule configuration

## Root cause

Normal page loads could match the existing domain rules, while action-specific requests such as X replies could arrive as unsniffed FakeIP connections. Without an early package rule, those connections reached the FakeIP guard first. ChatGPT Remote pairing also uses OpenAI feature/auth traffic under `oaistatsig.com`, which was falling through to the generic proxy path instead of staying on the ChatGPT-specific node.

## Validation

- `sing-box check -c config.json`
- `bash scripts/test-action-routing.sh`
- `bash scripts/test-default-routing-policy.sh`
- `bash scripts/test-wechat-routing.sh`
- `bash scripts/test-anthropic-routing.sh`
- `bash scripts/singbox-subscription-protocol-smoke.sh`
- `bash scripts/test-app-routing-policy.sh`
- ShellCheck on all changed shell scripts
- `git diff --check`

`scripts/test-subscription-lifecycle.sh` was also exercised; its supervisor-failure fixture races with process visibility in this container and leaves the deliberately spawned loop visible, an environment-specific failure outside this routing diff.

Closes #57

## Summary by Sourcery

稳定 ChatGPT 和 X Android 的动作路由，使其相对于 FakeIP 保护更可靠，并确保 OpenAI 的功能/认证流量始终走专用的 ChatGPT 路径。

Bug Fixes:
- 确保 X Android 包的动作流在到达 FakeIP 保护之前，先通过社交代理进行路由。
- 保证打包的 ChatGPT 流量以及发往 `oaistatsig.com` 的功能/认证请求始终使用 `ai-chatgpt` 出站路径，而不是退回到通用代理路由。

Enhancements:
- 更新规范路由规则的数量和索引，以纳入新的打包动作路由，同时保持现有的 `network-test` 和 `foreign-priority` 语义不变。

Documentation:
- 在变更日志中记录 ChatGPT 远程配对以及 X Android 动作路由的变更。

Tests:
- 新增专用的动作路由测试脚本，用于验证 ChatGPT 和 X 包的 FakeIP 流以及 `oaistatsig.com` 归属，并将其接入 pre-commit 测试套件。
- 调整默认路由、包冒烟测试、Anthropic 路由和审计测试，以反映新的规则数量、索引以及对 ChatGPT 域名的覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize ChatGPT and X Android action routing relative to the FakeIP guard and keep OpenAI feature/auth traffic on the dedicated ChatGPT path.

Bug Fixes:
- Ensure X Android package action flows are routed through the social proxy before reaching the FakeIP guard.
- Guarantee ChatGPT packaged traffic and oaistatsig.com feature/auth requests consistently use the ai-chatgpt outbound path instead of falling back to generic proxy routing.

Enhancements:
- Update canonical routing rule counts and indexes to account for the new packaged action routes while preserving existing network-test and foreign-priority semantics.

Documentation:
- Document ChatGPT remote pairing and X Android action routing changes in the changelog.

Tests:
- Add a dedicated action routing test script validating ChatGPT and X package FakeIP flows and oaistatsig.com ownership, and wire it into the pre-commit suite.
- Adjust default routing, package smoke, Anthropic routing, and audit tests to reflect the new rule counts, indexes, and ChatGPT domain coverage.

</details>

Bug Fixes（缺陷修复）：
- 确保 X Android 包的动作请求在命中 FakeIP 保护之前，先通过社交代理（social proxy）进行路由。
- 将 OpenAI 的特性与认证流量（在 `oaistatsig.com` 域下）保持在专用的 ChatGPT 出站路径上，而不是走通用代理路径。

Enhancements（增强）：
- 在保留现有网络测试（network-test）和外部优先级（foreign-priority）行为的前提下，使打包路由规则的索引和数量与更新后的配置保持一致。

Documentation（文档）：
- 在变更日志中记录 ChatGPT 远程配对以及 X Android 动作路由的相关变更。

Tests（测试）：
- 为 ChatGPT 和 X 的打包流量新增专门的动作路由回归测试，包括 FakeIP 动作场景以及对 `oaistatsig.com` 归属的验证。
- 更新默认路由、Anthropic 路由以及包的冒烟测试，以反映新的规范规则数量、索引以及明确的域名覆盖范围。
- 将新的动作路由测试接入 pre-commit 测试套件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

稳定 ChatGPT 和 X Android 的动作路由，使其相对于 FakeIP 保护更可靠，并确保 OpenAI 的功能/认证流量始终走专用的 ChatGPT 路径。

Bug Fixes:
- 确保 X Android 包的动作流在到达 FakeIP 保护之前，先通过社交代理进行路由。
- 保证打包的 ChatGPT 流量以及发往 `oaistatsig.com` 的功能/认证请求始终使用 `ai-chatgpt` 出站路径，而不是退回到通用代理路由。

Enhancements:
- 更新规范路由规则的数量和索引，以纳入新的打包动作路由，同时保持现有的 `network-test` 和 `foreign-priority` 语义不变。

Documentation:
- 在变更日志中记录 ChatGPT 远程配对以及 X Android 动作路由的变更。

Tests:
- 新增专用的动作路由测试脚本，用于验证 ChatGPT 和 X 包的 FakeIP 流以及 `oaistatsig.com` 归属，并将其接入 pre-commit 测试套件。
- 调整默认路由、包冒烟测试、Anthropic 路由和审计测试，以反映新的规则数量、索引以及对 ChatGPT 域名的覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize ChatGPT and X Android action routing relative to the FakeIP guard and keep OpenAI feature/auth traffic on the dedicated ChatGPT path.

Bug Fixes:
- Ensure X Android package action flows are routed through the social proxy before reaching the FakeIP guard.
- Guarantee ChatGPT packaged traffic and oaistatsig.com feature/auth requests consistently use the ai-chatgpt outbound path instead of falling back to generic proxy routing.

Enhancements:
- Update canonical routing rule counts and indexes to account for the new packaged action routes while preserving existing network-test and foreign-priority semantics.

Documentation:
- Document ChatGPT remote pairing and X Android action routing changes in the changelog.

Tests:
- Add a dedicated action routing test script validating ChatGPT and X package FakeIP flows and oaistatsig.com ownership, and wire it into the pre-commit suite.
- Adjust default routing, package smoke, Anthropic routing, and audit tests to reflect the new rule counts, indexes, and ChatGPT domain coverage.

</details>

</details>