### PR TITLE
feat: add optional version bump to build workflow

### DIFF
--- a/.github/workflows/README-CN.md
+++ b/.github/workflows/README-CN.md
@@ -22,10 +22,16 @@ kam check
 `exec.yml` 用于构建模块。触发方式包括 `push`、`pull_request` 和手动
 `workflow_dispatch`。
 
-这个工作流不会自动向仓库提交。手动运行时只有两个安全发布输入：
+手动运行支持以下输入：
 
+- `bump`：构建前按需提升模块版本，可选 `none`、`patch`、`minor` 和
+  `major`。成功提升版本后会同时刷新 `versionCode`、`module.prop` 和
+  `update.json`，并将这些元数据提交回启动工作流时选择的分支。
 - `release`：通过 `kam publish` 创建或更新 GitHub Release。
 - `prerelease`：将该 Release 标记为 prerelease。
+
+只有手动运行并选择版本提升时，工作流才会向仓库提交。普通 push、PR 和未选择
+版本提升的手动构建都不会提交。
 
 普通 push 和 pull request 会构建并上传 workflow artifact；如果存在
 `KAM_PRIVATE_KEY`，上传内容也会包含模块签名旁路文件。

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,11 +24,17 @@ top-level `kam.sh` when they exist.
 `exec.yml` builds the module. It runs on `push`, `pull_request`, and manual
 `workflow_dispatch`.
 
-The workflow never commits back to the repository. Manual dispatch has two safe
-release inputs:
+Manual dispatch supports these inputs:
 
+- `bump`: optionally bump the module version before building. The choices are
+  `none`, `patch`, `minor`, and `major`. A successful bump also refreshes
+  `versionCode`, `module.prop`, and `update.json`, then commits the metadata
+  back to the branch used to dispatch the workflow.
 - `release`: create/update a GitHub Release through `kam publish`.
 - `prerelease`: mark that release as a prerelease.
+
+The workflow only commits back to the repository when a manual run selects a
+version bump. Normal push, pull request, and non-bump manual runs never commit.
 
 Normal push and pull request runs build and upload workflow artifacts. When
 `KAM_PRIVATE_KEY` is available, the uploaded artifact also includes the module

--- a/.github/workflows/exec.yml
+++ b/.github/workflows/exec.yml
@@ -3,6 +3,16 @@ name: Build Kam Module
 on:
   workflow_dispatch:
     inputs:
+      bump:
+        description: Bump module version before building
+        required: false
+        type: choice
+        options:
+          - none
+          - patch
+          - minor
+          - major
+        default: none
       release:
         description: Create GitHub release and upload artifacts
         required: false
@@ -64,6 +74,15 @@ jobs:
           cache-targets: cargo,kam
           install-commitizen: 'false'
           private-key: ${{ secrets.KAM_PRIVATE_KEY }}
+
+      - name: Bump module version
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.bump != 'none' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          kam version "${{ inputs.bump }}"
+          kam export prop
+          kam export update
 
       - name: Install artifact tools
         run: sudo apt-get update && sudo apt-get install -y binutils file jq ripgrep unzip zip
@@ -142,6 +161,25 @@ jobs:
           scripts/package-smoke.sh "dist/${module_id}.zip"
           scripts/package-install-smoke.sh "dist/${module_id}.zip"
           scripts/fake-magisk-smoke.sh "dist/${module_id}.zip"
+
+      - name: Commit bumped version
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.bump != 'none' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_TYPE}" != "branch" ]; then
+            echo "::error::Version bumps must be dispatched from a branch."
+            exit 1
+          fi
+          if git diff --quiet -- kam.toml src/MagicNet/module.prop update.json; then
+            echo "::error::Version bump did not change version metadata."
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- kam.toml src/MagicNet/module.prop update.json
+          git commit -m "chore: bump module version"
+          git push origin "HEAD:${GITHUB_REF_NAME}"
 
       - name: Create GitHub release
         if: ${{ inputs.release == true }}


### PR DESCRIPTION
## What changed

- add a `bump` choice input to manual Build workflow runs with `none`, `patch`, `minor`, and `major`
- use `kam version` to update the semantic version and timestamp-based `versionCode`
- regenerate `src/MagicNet/module.prop` and `update.json`
- commit the version metadata back to the dispatched branch only after the artifact passes verification
- document the new behavior in English and Chinese

## Why

Manual release builds previously required version metadata to be updated separately. The new input keeps the bump, generated metadata, verified artifact, and optional release in one workflow run.

## Impact

Push and pull-request builds are unchanged. Manual runs default to `bump: none`, so existing behavior remains the default.

## Validation

- parsed the workflow as YAML
- asserted the bump choices and step ordering
- checked all changed files for whitespace errors
- verified the remote branch diff contains only the intended workflow and documentation files

## Summary by Sourcery

在手动构建工作流中添加可选的版本号提升支持，并为这一新行为编写文档。

New Features:
- 引入一个手动触发输入项，在构建前可选择性地提升模块版本号，支持 `none`、`patch`、`minor` 和 `major` 等提升方式。

Enhancements:
- 更新构建工作流，使其仅在手动运行执行了版本号提升时，才重新生成版本元数据并将其提交回触发的分支。

Build:
- 扩展 `exec.yml` 工作流，增加一个条件执行的版本号提升步骤，以及一个受保护的提交步骤，在经过验证的手动构建后推送更新的版本元数据。

Documentation:
- 在英文和中文的工作流 README 中记录新的版本提升输入项以及条件提交的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional version bump support to the manual build workflow and document the new behavior.

New Features:
- Introduce a manual dispatch input to optionally bump the module version before building, supporting none, patch, minor, and major bumps.

Enhancements:
- Update the build workflow to regenerate version metadata and commit it back to the dispatch branch only when a manual run performs a version bump.

Build:
- Extend the exec.yml workflow with a conditional version bump step and a guarded commit step that push updated version metadata after a verified manual build.

Documentation:
- Document the new bump input and conditional commit behavior in the English and Chinese workflow READMEs.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在手动构建工作流中添加可选的版本号提升支持，并为这一新行为编写文档。

New Features:
- 引入一个手动触发输入项，在构建前可选择性地提升模块版本号，支持 `none`、`patch`、`minor` 和 `major` 等提升方式。

Enhancements:
- 更新构建工作流，使其仅在手动运行执行了版本号提升时，才重新生成版本元数据并将其提交回触发的分支。

Build:
- 扩展 `exec.yml` 工作流，增加一个条件执行的版本号提升步骤，以及一个受保护的提交步骤，在经过验证的手动构建后推送更新的版本元数据。

Documentation:
- 在英文和中文的工作流 README 中记录新的版本提升输入项以及条件提交的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional version bump support to the manual build workflow and document the new behavior.

New Features:
- Introduce a manual dispatch input to optionally bump the module version before building, supporting none, patch, minor, and major bumps.

Enhancements:
- Update the build workflow to regenerate version metadata and commit it back to the dispatch branch only when a manual run performs a version bump.

Build:
- Extend the exec.yml workflow with a conditional version bump step and a guarded commit step that push updated version metadata after a verified manual build.

Documentation:
- Document the new bump input and conditional commit behavior in the English and Chinese workflow READMEs.

</details>

</details>