### PR TITLE
fix: stabilize Android network validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Fix #64 by keeping Android network validation on the automatic healthy-node
+  group when the general proxy selector is pinned to a manual node, preventing
+  a stalled node from making the system mark Wi-Fi as disconnected.
 - Keep ChatGPT remote pairing feature traffic on the pinned ChatGPT path and
   route all X Android action requests before the FakeIP guard.
 - Start each AI service selector on its filtered service-specific automatic

--- a/scripts/test-anthropic-routing.sh
+++ b/scripts/test-anthropic-routing.sh
@@ -79,7 +79,13 @@ jq -e '
       outbounds: ($node_tags + ["proxy-auto", "direct", "block"]),
       default: $node_tags[0]
     })
-    and ([.outbounds[] | select(.type == "selector")] | all(. as $selector
+    and ($by_tag["network-test"] == {
+      type: "selector",
+      tag: "network-test",
+      outbounds: ["proxy-auto", "proxy", "direct", "block"],
+      default: "proxy-auto"
+    })
+    and ([.outbounds[] | select(.type == "selector" and .tag != "network-test")] | all(. as $selector
       | ($selector.outbounds | length) == ($selector.outbounds | unique | length)
         and (($selector.outbounds | index($selector.default)) != null)
         and (($by_tag[$selector.default].type // "") != "urltest")
@@ -542,10 +548,16 @@ jq -e '
       outbounds: ($node_tags + ["proxy-auto", "direct", "block"]),
       default: $node_tags[0]
     })
+    and ($by_tag["network-test"] == {
+      type: "selector",
+      tag: "network-test",
+      outbounds: ["proxy-auto", "proxy", "direct", "block"],
+      default: "proxy-auto"
+    })
     and ($ai_proxy.default == "US stable" and $ai_proxy.outbounds == ["US stable", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "myhk edge"])
     and ($by_tag["cn-direct"] == {type: "selector", tag: "cn-direct", outbounds: ["direct", "proxy", "block"], default: "direct"})
     and ($by_tag.final == {type: "selector", tag: "final", outbounds: ["proxy", "direct", "block"], default: "proxy"})
-    and ([.outbounds[] | select(.type == "selector")] | all(. as $selector
+    and ([.outbounds[] | select(.type == "selector" and .tag != "network-test")] | all(. as $selector
       | ($selector.outbounds | length) == ($selector.outbounds | unique | length)
         and (($selector.outbounds | index($selector.default)) != null)
         and (($by_tag[$selector.default].type // "") != "urltest")

--- a/scripts/test-default-routing-policy.sh
+++ b/scripts/test-default-routing-policy.sh
@@ -2144,6 +2144,9 @@ for selector_config in "$selector_jq_zero" "$selector_no_jq_zero"; do
       and [.outbounds[] | select(.tag == "proxy")] == [
         {type: "selector", tag: "proxy", outbounds: ["block"], default: "block"}
       ]
+      and [.outbounds[] | select(.tag == "network-test")] == [
+        {type: "selector", tag: "network-test", outbounds: ["block"], default: "block"}
+      ]
     ' "$selector_config" >/dev/null || fail "zero-node generator emitted a fail-open proxy selector"
 done
 for selector_config in "$selector_jq_populated" "$selector_no_jq_populated"; do
@@ -2158,7 +2161,13 @@ for selector_config in "$selector_jq_populated" "$selector_no_jq_populated"; do
         outbounds: ["fixture-node", "proxy-auto", "direct", "block"],
         default: "fixture-node"
       }]
-    ' "$selector_config" >/dev/null || fail "populated generator changed canonical proxy behavior"
+      and [.outbounds[] | select(.tag == "network-test")] == [{
+        type: "selector", tag: "network-test",
+        outbounds: ["proxy-auto", "proxy", "direct", "block"],
+        default: "proxy-auto"
+      }]
+    ' "$selector_config" >/dev/null ||
+        fail "populated generator changed canonical proxy or network-test behavior"
 done
 
 for selector_config in "$selector_jq_zero" "$selector_jq_populated"; do

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
@@ -125,6 +125,14 @@ magicnet_singbox_build_outbounds_file_with_jq() {
               "default": $tags[0]}
         else {"type": "selector", "tag": "proxy", "outbounds": ["block"], "default": "block"}
         end;
+    def network_test_selector($tags):
+      if ($tags | length) > 0
+        then {"type": "selector", "tag": "network-test",
+              "outbounds": ["proxy-auto", "proxy", "direct", "block"],
+              "default": "proxy-auto"}
+        else {"type": "selector", "tag": "network-test",
+              "outbounds": ["block"], "default": "block"}
+        end;
     def mainland_node_tag:
       test("中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:Hong[ _-]?Kong(?:[ _-]?[0-9]+)?|HKG?[ _-]?[0-9]+|China|Mainland|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
     def ai_proxy_selector($tags):
@@ -182,7 +190,7 @@ magicnet_singbox_build_outbounds_file_with_jq() {
           selector("icloud"; ["direct", "proxy"]; "direct"),
           selector("bing"; ["proxy", "direct"]; "proxy"),
           selector("dns-guard"; ["proxy", "block", "direct"]; "proxy"),
-          selector("network-test"; ["proxy", "direct"]; "proxy"),
+          network_test_selector($tags),
           ai_proxy_selector($ai_tags)
         ] + ai_service_outbounds($ai_tags) + [
           selector("proxy-rule"; ["proxy", "direct"]; "proxy"),
@@ -291,7 +299,14 @@ magicnet_singbox_emit_static_selectors() {
     printf ',\n'
     magicnet_emit_selector_json "dns-guard" "$(printf '%s\n%s\n%s\n' "proxy" "block" "direct")" "proxy"
     printf ',\n'
-    magicnet_emit_selector_json "network-test" "$(printf '%s\n%s\n' "proxy" "direct")" "proxy"
+    if [ -n "$_proxy_tags" ]; then
+        magicnet_emit_selector_json_exact \
+            "network-test" \
+            "$(printf '%s\n%s\n%s\n%s\n' "proxy-auto" "proxy" "direct" "block")" \
+            "proxy-auto"
+    else
+        magicnet_emit_selector_json_exact "network-test" "block" "block"
+    fi
     printf ',\n'
     _pinned_ai_tags=$(magicnet_singbox_pinned_ai_tags "$_tags_file")
     _pinned_ai_default=$(printf '%s\n' "$_pinned_ai_tags" | sed -n '1p')


### PR DESCRIPTION
## What changed

- Route Android connectivity validation through `proxy-auto` when proxy nodes are available.
- Keep the zero-node path fail-closed with `block`.
- Cover both jq and no-jq config generators with exact selector assertions.
- Document the v1.1.26 regression fix.

## Root cause

v1.1.26 changed the general `proxy` selector to default to the first manual node. The `network-test` selector still inherited `proxy`, so a stalled manual node could also stall Android/ColorOS connectivity-validation probes. The system could then mark Wi-Fi as unvalidated and disconnect or switch networks.

Normal traffic keeps its manual selector behavior; only network validation defaults directly to the automatic latency-tested group.

## Validation

- `bash scripts/test-default-routing-policy.sh`
- `bash scripts/test-anthropic-routing.sh`
- `bash scripts/orchestrator-mode-smoke.sh`
- `bash scripts/singbox-subscription-protocol-smoke.sh`
- `bash scripts/test-subscription-lifecycle.sh`
- Shell syntax checks and `git diff --check`

Fixes #64

## 由 Sourcery 提供的摘要

通过将连接性检查与手动代理固定分离，并在不同配置间确保选择器行为一致，稳定 Android 网络验证路由。

错误修复：
- 确保 Android 的 `network-test` 选择器优先使用自动的健康节点组，并且当手动代理选择器被固定在坏节点上时不再阻塞。
- 在没有代理节点可用时，通过将 `network-test` 路由到阻塞型选择器来保持零节点配置在网络验证时“失败即关闭”（fail-closed）的行为。

功能增强：
- 让使用 `jq` 和不使用 `jq` 的选择器生成器在一个规范化的 `network-test` 选择器结构上保持一致，并具备明确的出站顺序和默认值。

文档：
- 在变更日志中记录 Android 网络验证回归问题及其修复方案。

测试：
- 收紧路由策略和 Anthropic 路由测试，明确断言使用 `jq` 和非 `jq` 生成配置时 `network-test` 选择器的精确结构和行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过将 network-test 选择器与通用代理选择器解耦，并在各类配置生成器中统一其行为，稳定 Android 网络验证路由。

Bug Fixes（错误修复）:
- 确保 Android 的 network-test 选择器优先使用自动的 healthy-node 分组，并在手动代理选择器固定在故障节点时不再导致阻塞。
- 在零节点配置中保留“失败即关闭”（fail-closed）行为：当没有可用代理节点时，将 network-test 通过阻塞型选择器进行路由。

Enhancements（增强）:
- 在 jq 和非 jq 的选择器生成器之间统一为一个规范的 network-test 选择器结构，并显式指定出站顺序和默认值。

Documentation（文档）:
- 在变更日志中记录 Android 网络验证回归问题及其修复。

Tests（测试）:
- 收紧路由和 Anthropic 路由测试，用于断言在 jq 和非 jq 生成的配置中，network-test 选择器的具体结构和行为完全一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize Android network validation routing by decoupling the network-test selector from the general proxy selector and aligning its behavior across configuration generators.

Bug Fixes:
- Ensure the Android network-test selector prefers the automatic healthy-node group and no longer stalls when the manual proxy selector is pinned to a bad node.
- Preserve fail-closed behavior for zero-node configurations by routing network-test through a blocking selector when no proxy nodes are available.

Enhancements:
- Unify jq and non-jq selector generators around a canonical network-test selector structure with explicit outbound order and defaults.

Documentation:
- Document the Android network validation regression and its fix in the changelog.

Tests:
- Tighten routing and Anthropic routing tests to assert the exact structure and behavior of the network-test selector across jq and non-jq generated configs.

</details>

</details>