### PR TITLE
fix: update PostCSS to patched release

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1462,9 +1462,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -1504,9 +1504,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -1523,7 +1523,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary

- update the transitive `postcss` dependency from 8.5.15 to 8.5.23
- update its compatible `nanoid` dependency from 3.3.12 to 3.3.16
- resolve Dependabot alert #2 / GHSA-r28c-9q8g-f849

## Root cause

The WebUI lockfile pinned PostCSS 8.5.15, which is affected by a path traversal issue in previous source map auto-loading. The patched dependency remains within Vite's existing semver range, so no application code or direct dependency declarations need to change.

## Validation

- `npm audit`: 0 vulnerabilities
- `npm run test`: 13/13 passed
- `npm run typecheck`: passed
- `npm run build`: passed

## Summary by Sourcery

更新 WebUI 依赖锁定文件，使用已打补丁的 PostCSS 和兼容的 nanoid 版本，以解决安全公告中指出的问题。

Bug 修复：
- 通过将 PostCSS 的传递依赖升级到已打补丁的版本，修复其安全漏洞。

构建：
- 刷新 `webui/package-lock.json`，将 PostCSS 从 8.5.15 升级到 8.5.23，并将 nanoid 从 3.3.12 升级到 3.3.16。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update WebUI dependency lockfile to use patched PostCSS and compatible nanoid versions addressing a security advisory.

Bug Fixes:
- Resolve security vulnerability in PostCSS by upgrading the transitive dependency to a patched release.

Build:
- Refresh webui/package-lock.json to bump PostCSS from 8.5.15 to 8.5.23 and nanoid from 3.3.12 to 3.3.16.

</details>