### PR TITLE
fix: validate synced templates against runtime data

### DIFF
--- a/crates/magicnet-cli/src/config_editor.rs
+++ b/crates/magicnet-cli/src/config_editor.rs
@@ -69,8 +69,8 @@ fn save_config_file(app: &App, target: &str, path: &Path, args: &[String]) -> Re
     if tmp.as_os_str().is_empty() {
         return Err("Usage: cli config-editor save-file sing-box <webui-payload-path>".to_string());
     }
-    let (source, tmp_directory) = open_webui_payload_source(app, &tmp)?;
-    validate_and_commit_open_config_file(app, target, path, &source, &tmp_directory)?;
+    let (source, _tmp_directory) = open_webui_payload_source(app, &tmp)?;
+    validate_and_commit_open_config_file(app, target, path, &source)?;
     println!(
         "[info] Saved and validated {target} config: {}\n[info] Runtime policy changes can be applied from the control/app pages.",
         path.display()
@@ -285,13 +285,17 @@ fn validate_and_commit_open_config_file(
     target: &str,
     path: &Path,
     source: &File,
-    data_directory: &File,
 ) -> Result<(), String> {
     let name = OsStr::new(config_target_filename(target)?);
     let directory = open_config_destination_directory(app, target)?;
     let (snapshot, staged_name) = snapshot_config_file(source, &directory)?;
     let result = (|| {
-        validate_config_from_open_file(app, target, &snapshot, data_directory)?;
+        // sing-box resolves relative rule-set and UI paths from its data
+        // directory. The candidate may originate in a private temporary
+        // namespace, but after commit it lives beside the existing rules
+        // under .config/sing-box. Validate against that final directory so
+        // the check sees the same resources as the runtime.
+        validate_config_from_open_file(app, target, &snapshot, &directory)?;
         backup_config_at(&directory, name)?;
         commit_staged_config_file(&directory, &staged_name, name, path)
     })();
@@ -428,8 +432,8 @@ fn commit_config_text(
     bytes: &[u8],
     role: &str,
 ) -> Result<(), String> {
-    with_generated_config_input(app, role, bytes, |source, directory| {
-        validate_and_commit_open_config_file(app, target, path, source, directory)
+    with_generated_config_input(app, role, bytes, |source, _directory| {
+        validate_and_commit_open_config_file(app, target, path, source)
     })?;
     println!(
         "[info] Saved and validated {target} config: {}\n[info] Runtime policy changes can be applied from the control/app pages.",
@@ -947,6 +951,57 @@ mod tests {
         assert!(
             open_webui_payload_source(&app, &nested).is_err(),
             "nested WebUI payload paths must not be accepted as a config source"
+        );
+    }
+
+    #[test]
+    fn validation_resolves_relative_resources_from_final_config_directory() {
+        let app = temp_app();
+        let bin_dir = app.moddir.join("bin");
+        let payload_dir = app.moddir.join(".tmp/webui-payload");
+        let rules_dir = app.moddir.join(".config/sing-box/rules");
+        fs::create_dir_all(&bin_dir).expect("create bin directory");
+        fs::create_dir_all(&payload_dir).expect("create WebUI payload directory");
+        fs::create_dir_all(&rules_dir).expect("create final rules directory");
+
+        let validator = bin_dir.join("sing-box");
+        fs::write(
+            &validator,
+            r#"#!/bin/sh
+config=
+data=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -c) config=$2; shift 2 ;;
+    -D) data=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+test -r "$config"
+test -r "$data/rules/required.srs"
+"#,
+        )
+        .expect("write fake validator");
+        let mut permissions = fs::metadata(&validator)
+            .expect("stat fake validator")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&validator, permissions).expect("make fake validator executable");
+
+        fs::write(rules_dir.join("required.srs"), "compiled rule set")
+            .expect("write final relative resource");
+        let payload = payload_dir.join("candidate.json");
+        fs::write(&payload, "{}\n").expect("write candidate config");
+
+        let (source, _source_directory) =
+            open_webui_payload_source(&app, &payload).expect("open candidate config");
+        let target = config_path(&app, "sing-box").expect("resolve config target");
+        validate_and_commit_open_config_file(&app, "sing-box", &target, &source)
+            .expect("validate candidate against final config directory");
+
+        assert_eq!(
+            fs::read_to_string(target).expect("read committed config"),
+            "{}\n"
         );
     }
 

--- a/webui/src/composables/parsers.ts
+++ b/webui/src/composables/parsers.ts
@@ -384,9 +384,20 @@ export function parseConfigValidation(text: string): Pick<ConfigValidationState,
     return { status: "ok", summary: firstUsefulLine(trimmed) || "配置已通过校验并保存。" };
   }
   if (/config validation failed|validator missing|config target must/i.test(trimmed)) {
-    return { status: "error", summary: firstUsefulLine(trimmed) || "配置校验失败。" };
+    return { status: "error", summary: configValidationFailureDetail(trimmed) };
   }
   return { status: trimmed.includes("[error]") ? "error" : "ok", summary: firstUsefulLine(trimmed) || trimmed.slice(0, 160) };
+}
+
+function configValidationFailureDetail(text: string): string {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("command:"));
+  return lines.find((line) =>
+    /(?:fatal|no such file|not found|permission denied|timed out|validator missing)/i.test(line)
+    && !/^config validation failed$/i.test(line),
+  ) || lines.find((line) => !/^config validation failed$/i.test(line)) || "配置校验失败。";
 }
 
 export function parseRouteRuleSummary(text: string): RouteRuleSummary {

--- a/webui/src/composables/useMagicNet.ts
+++ b/webui/src/composables/useMagicNet.ts
@@ -34,6 +34,7 @@ import {
   parseHealth,
   parseMcp,
   parsePackages,
+  parseConfigValidation,
   parseRuntime,
   parseSubs,
   parseWifiPolicy,
@@ -667,15 +668,17 @@ async function syncConfigTemplate(): Promise<void> {
     `config-editor sync-template ${target}`,
     `同步 ${target} 上游模板`,
   );
-  state.config.status = execFailed(text) ? "同步失败" : "已同步上游模板";
+  const failed = execFailed(text);
+  const validation = parseConfigValidation(text);
+  state.config.status = failed ? "同步失败" : "已同步上游模板";
   state.config.validation = {
-    status: execFailed(text) ? "error" : "ok",
-    summary: execFailed(text)
-      ? "上游模板同步失败。"
+    status: failed ? "error" : "ok",
+    summary: failed
+      ? validation.summary
       : "上游模板已同步并通过校验。",
     checkedAt: new Date().toLocaleTimeString(),
   };
-  if (!execFailed(text)) {
+  if (!failed) {
     state.config.dirty = false;
     await loadConfig();
   }


### PR DESCRIPTION
## What changed

- validate staged sing-box configs with `.config/sing-box` as the data directory
- keep the descriptor-based immutable snapshot and atomic commit protections intact
- add a regression test for relative `rules/*.srs` resolution
- surface the actual validation failure detail in the WebUI sync status

## Root cause

`config-editor save-file` and `sync-template` passed their private temporary directory to `sing-box check -D`. Templates reference rule sets relative to the final `.config/sing-box` directory, so both built-in template validation and upstream template synchronization failed even when the JSON itself was valid.

## Validation

- `cargo test -p magicnet-cli config_editor::tests` — 10 passed
- `npm run check` in `webui` — 13 test files passed; typecheck and production build passed
- `rustfmt --check crates/magicnet-cli/src/config_editor.rs` — passed
- full Rust workspace run reached 273 passed with 2 unrelated existing failures in `selector_store::tests::live_owner_never_expires_by_age` and `webui_backup::tests::backup_without_password_is_plaintext_and_restores_known_files_only`

## 由 Sourcery 提供的总结

根据最终的运行时数据目录验证 sing-box 配置，并改进在 WebUI 中呈现验证失败信息的方式（包括模板同步过程中）。

错误修复（Bug Fixes）：
- 确保 config-editor 和模板同步使用最终的 `.config/sing-box` 目录来验证 sing-box 配置，使得诸如 `rules/*.srs` 之类的相对资源能够被正确解析。
- 通过在 WebUI 状态中暴露底层的验证错误信息，避免模板同步仅报告笼统的失败信息。

增强功能（Enhancements）：
- 添加回归测试，以保证配置验证会从已提交的配置目录中解析相对资源。
- 优化 WebUI 中的配置验证解析逻辑，从验证器输出中提取并展示更有意义的失败详情。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

针对最终运行时数据目录验证 sing-box 配置，并改进 WebUI 在模板同步和配置保存时对验证失败的报告。

Bug Fixes:
- 确保 config-editor 和模板同步使用最终的 `.config/sing-box` 目录来验证 sing-box 配置，从而使相对规则资源能够被正确解析。
- 在 WebUI 的配置验证和模板同步状态中暴露详细的验证器错误信息，而不是只显示通用的失败提示字符串。

Tests:
- 添加回归测试，确保配置验证会从已提交配置所在的目录解析相对资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate sing-box configs against the final runtime data directory and improve WebUI reporting of validation failures for template syncs and config saves.

Bug Fixes:
- Ensure config-editor and template sync validate sing-box configs using the final .config/sing-box directory so relative rule resources resolve correctly.
- Expose detailed validator error messages in WebUI config validation and template sync status instead of a generic failure string.

Tests:
- Add a regression test ensuring config validation resolves relative resources from the committed config directory.

</details>

</details>