### PR TITLE
Fix Android subscription refresh and add User-Agent presets

### DIFF
--- a/crates/magicnet-cli/src/main.rs
+++ b/crates/magicnet-cli/src/main.rs
@@ -49,7 +49,8 @@ use service::{
 };
 use subscriptions::{
     setup_subscription, sub_apply_file, sub_filter, sub_get, sub_list, sub_schedule, sub_set,
-    sub_set_file, sub_status, sub_target_file, sub_update, sub_update_all, sub_user_agent,
+    sub_resolve_host, sub_set_file, sub_status, sub_target_file, sub_update, sub_update_all,
+    sub_user_agent,
 };
 pub(crate) use utils::{
     clean_lines, clear_node_cache, command_text_timeout, first_clean_line, read_kv,
@@ -291,6 +292,9 @@ fn dispatch(app: &App, args: &[String]) -> Result<(), String> {
             sub_user_agent(app, args)
         }
         "sub" if args.get(1).map(String::as_str) == Some("filter") => sub_filter(app, args),
+        "sub" if args.get(1).map(String::as_str) == Some("resolve-host") => {
+            sub_resolve_host(args)
+        }
         "config-editor" => config_editor(app, &args[1..]),
         "sub"
             if matches!(

--- a/crates/magicnet-cli/src/subscriptions.rs
+++ b/crates/magicnet-cli/src/subscriptions.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::ffi::{CString, OsStr, OsString};
 use std::fs::{self, File};
 use std::io::{self, Seek, SeekFrom, Write};
-use std::net::IpAddr;
+use std::net::{IpAddr, ToSocketAddrs};
 use std::os::fd::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
@@ -130,6 +130,34 @@ pub fn sub_filter(app: &App, args: &[String]) -> Result<(), String> {
         "clear" => write_text_file(app, Path::new(SUBSCRIPTION_FILTER_PATH), ""),
         _ => Err("Usage: cli sub filter {list|set <base64-lines>|clear}".to_string()),
     }
+}
+
+/// Resolve a validated subscription hostname through Android's libc resolver.
+///
+/// The shell fetcher pins curl to these addresses with `--resolve`, so DNS is
+/// completed before the privileged request and every returned address can be
+/// rejected if it targets a private or special-use network.
+pub fn sub_resolve_host(args: &[String]) -> Result<(), String> {
+    let host = args.get(2).map(String::as_str).unwrap_or_default();
+    let port = args.get(3).map(String::as_str).unwrap_or_default();
+    if host.is_empty() || port.is_empty() {
+        return Err("Usage: cli sub resolve-host <hostname> <port>".to_string());
+    }
+    validate_subscription_hostname(host)?;
+    let port = parse_subscription_port(port)?;
+    let resolved = (host, port)
+        .to_socket_addrs()
+        .map_err(|_| "Subscription hostname resolution failed".to_string())?
+        .map(|address| address.ip())
+        .collect::<HashSet<_>>();
+    validate_resolved_subscription_addresses(&resolved)?;
+
+    let mut addresses = resolved.into_iter().collect::<Vec<_>>();
+    addresses.sort_by_key(ToString::to_string);
+    for address in addresses {
+        println!("{address}");
+    }
+    Ok(())
 }
 
 pub fn sub_apply_file(app: &App, args: &[String]) -> Result<(), String> {
@@ -699,6 +727,21 @@ fn is_public_subscription_address(address: IpAddr) -> bool {
     }
 }
 
+fn validate_resolved_subscription_addresses(addresses: &HashSet<IpAddr>) -> Result<(), String> {
+    if addresses.is_empty() {
+        return Err("Subscription hostname returned no addresses".to_string());
+    }
+    if addresses
+        .iter()
+        .any(|address| !is_public_subscription_address(*address))
+    {
+        return Err(
+            "Subscription hostname resolved to a private or special-use address".to_string(),
+        );
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
@@ -781,6 +824,22 @@ mod tests {
                 "{address} must remain permitted"
             );
         }
+    }
+
+    #[test]
+    fn resolved_subscription_addresses_fail_closed() {
+        let public = HashSet::from([
+            IpAddr::from_str("1.1.1.1").unwrap(),
+            IpAddr::from_str("2606:4700:4700::1111").unwrap(),
+        ]);
+        validate_resolved_subscription_addresses(&public).unwrap();
+
+        let mixed = HashSet::from([
+            IpAddr::from_str("1.1.1.1").unwrap(),
+            IpAddr::from_str("127.0.0.1").unwrap(),
+        ]);
+        assert!(validate_resolved_subscription_addresses(&mixed).is_err());
+        assert!(validate_resolved_subscription_addresses(&HashSet::new()).is_err());
     }
 
     #[test]

--- a/scripts/fake-magisk-smoke.sh
+++ b/scripts/fake-magisk-smoke.sh
@@ -518,6 +518,24 @@ SH
 chmod +x "$MOCK_BIN/pidof"
 cp "$MOCK_BIN/pidof" "$MODDIR/bin/pidof"
 
+# Keep the fake subscription refresh deterministic after the production
+# fetcher moved DNS resolution into magicnet-cli. All normal CLI commands still
+# execute the host-built binary; only the reserved example.invalid fixture is
+# resolved locally for this smoke test.
+cat >"$MODDIR/bin/magicnet-cli-smoke" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "sub" && "${2:-}" == "resolve-host" && "${3:-}" == "example.invalid" ]]; then
+    printf '%s\n' "magicnet-cli resolve-host ${3:-} ${4:-}" >>"${MAGICNET_FAKE_LOG:?}"
+    printf '%s\n' "1.1.1.1"
+    exit 0
+fi
+exec "${MODDIR:?}/bin/magicnet-cli" "$@"
+SH
+chmod +x "$MODDIR/bin/magicnet-cli-smoke"
+rm -f "$MODDIR/cli"
+ln -s "bin/magicnet-cli-smoke" "$MODDIR/cli"
+
 install_runtime_path_fixtures() {
     local applet host_applet mock
     local applets=(
@@ -1003,9 +1021,10 @@ fi
 python3 - "$MOCK_LOG" <<'PY'
 import sys
 lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+resolve = next((i for i, line in enumerate(lines) if line == "magicnet-cli resolve-host example.invalid 443"), None)
 fetch = next((i for i, line in enumerate(lines) if line.startswith("curl ") and "subscription.yaml" in line), None)
 run = next((i for i, line in enumerate(lines) if line.startswith("sing-box run")), None)
-if fetch is None or run is None or fetch > run:
+if resolve is None or fetch is None or run is None or resolve > fetch or fetch > run:
     raise SystemExit("forced refresh started sing-box before fetching the subscription")
 PY
 stop_fake_core "$MODDIR/.state/fake-sing-box.pid" "sing-box"

--- a/scripts/test-subscription-fetch-policy.sh
+++ b/scripts/test-subscription-fetch-policy.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-export MODDIR="$ROOT/src/MagicNet"
+export MODDIR="$tmp/module"
 export MAGICNET_FETCH_TEST_LOG="$tmp/log"
-. "$MODDIR/lib/magicnet/singbox_subscribe/fetch.sh"
+. "$ROOT/src/MagicNet/lib/magicnet/singbox_subscribe/fetch.sh"
 
 magicnet_singbox_subscription_url_file() {
   printf '%s\n' "$tmp/subscription.url"
@@ -24,6 +24,7 @@ warn() {
 }
 
 mkdir "$tmp/bin"
+mkdir -p "$MODDIR"
 cat >"$tmp/bin/curl" <<'SH'
 #!/bin/sh
 printf 'env=%s/%s/%s/%s\n' "${http_proxy-}" "${HTTP_PROXY-}" "${all_proxy-}" "${ALL_PROXY-}" >>"$MAGICNET_FETCH_TEST_LOG"
@@ -43,9 +44,16 @@ else
   printf ok
 fi
 SH
-cat >"$tmp/bin/getent" <<'SH'
+cat >"$MODDIR/cli" <<'SH'
 #!/bin/sh
-printf '%s STREAM test\n' "1.1.1.1"
+printf 'resolver %s\n' "$*" >>"$MAGICNET_FETCH_TEST_LOG"
+[ "$1" = sub ] && [ "$2" = resolve-host ] || exit 2
+case "${MAGICNET_RESOLVE_RESULT:-public}" in
+  public) printf '%s\n' "1.1.1.1" "2606:4700:4700::1111" ;;
+  private) printf '%s\n' "127.0.0.1" ;;
+  empty) ;;
+  fail) exit 1 ;;
+esac
 SH
 cat >"$tmp/bin/timeout" <<'SH'
 #!/bin/sh
@@ -53,17 +61,30 @@ printf 'timeout %s\n' "$1" >>"$MAGICNET_FETCH_TEST_LOG"
 shift
 exec "$@"
 SH
-chmod +x "$tmp/bin/"*
+chmod +x "$tmp/bin/"* "$MODDIR/cli"
 http_proxy=http://bad HTTP_PROXY=http://bad all_proxy=http://bad ALL_PROXY=http://bad \
   PATH="$tmp/bin:$PATH" magicnet_singbox_try_fetch_subscription https://example.invalid/sub "$tmp/direct" 2 7
 grep -q '^env=///$' "$tmp/log"
 grep -q 'curl .*--noproxy \*' "$tmp/log"
 grep -q 'curl .*--resolve example.invalid:443:1.1.1.1' "$tmp/log"
+grep -Fq -- '--resolve example.invalid:443:[2606:4700:4700::1111]' "$tmp/log"
 grep -q 'curl .* -o - ' "$tmp/log"
 if grep -q -- '--proxy' "$tmp/log"; then
   exit 1
 fi
 test "$(cat "$tmp/direct")" = ok
+: >"$tmp/log"
+if MAGICNET_RESOLVE_RESULT=private PATH="$tmp/bin:$PATH" \
+  magicnet_singbox_try_fetch_subscription https://example.invalid/sub "$tmp/private" 2 7; then
+  exit 1
+fi
+test ! -e "$tmp/private"
+: >"$tmp/log"
+if MAGICNET_RESOLVE_RESULT=empty PATH="$tmp/bin:$PATH" \
+  magicnet_singbox_try_fetch_subscription https://example.invalid/sub "$tmp/unresolved" 2 7; then
+  exit 1
+fi
+test ! -e "$tmp/unresolved"
 : >"$tmp/log"
 MAGICNET_FETCH_LARGE=1 PATH="$tmp/bin:$PATH" \
   magicnet_singbox_try_fetch_subscription https://example.invalid/sub "$tmp/large" 2 11
@@ -95,7 +116,6 @@ MAGICNET_FETCH_FAIL=1 PATH="$tmp/bin:$PATH" \
   magicnet_singbox_fetch_one_subscription \
     https://example.invalid/sub "$tmp/local-proxy" "" "" "" '#1' 2>/dev/null && exit 1 || true
 grep -q '^curl ' "$tmp/log"
-MODDIR="$tmp/module"
 . "$ROOT/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh"
 magicnet_singbox_update_lock_acquire
 if (magicnet_singbox_update_lock_acquire) 2>/dev/null; then

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/fetch.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/fetch.sh
@@ -25,6 +25,7 @@ magicnet_singbox_use_cached_subscription() {
 # A single per-subscription response limit. Keep this fixed so scheduled
 # refreshes cannot be expanded through an environment override.
 MAGICNET_SUB_MAX_RESPONSE_BYTES=8388608
+MAGICNET_SUB_RESOLVE_TIMEOUT=10
 
 magicnet_singbox_subscription_parse_authority() {
     _subscription_url="$1"
@@ -133,10 +134,10 @@ magicnet_singbox_public_address() {
 magicnet_singbox_subscription_resolve_public() {
     _subscription_url="$1"
     magicnet_singbox_subscription_parse_authority "$_subscription_url" || return 1
-    command -v getent >/dev/null 2>&1 || return 1
-    _subscription_resolved=0
-    getent ahosts "$_subscription_host" 2>/dev/null |
-        while IFS=' ' read -r _subscription_address _subscription_rest; do
+    [ -x "${MODDIR}/cli" ] || return 1
+    timeout "$MAGICNET_SUB_RESOLVE_TIMEOUT" \
+        "${MODDIR}/cli" sub resolve-host "$_subscription_host" "$_subscription_port" 2>/dev/null |
+        while IFS= read -r _subscription_address; do
             magicnet_singbox_public_address "$_subscription_address" || exit 1
             case "$_subscription_address" in
                 *:*) _subscription_resolve_address="[$_subscription_address]" ;;

--- a/webui/src/components/pages/SubscriptionsPage.vue
+++ b/webui/src/components/pages/SubscriptionsPage.vue
@@ -41,6 +41,7 @@ import {
   type PendingSubscriptionApply,
   type SubscriptionPreview,
 } from "./subscriptionPreview";
+import { subscriptionUserAgentPresets } from "./subscriptionUserAgent";
 
 type ScheduleValue = "off" | "12" | "24" | "48" | "72";
 
@@ -354,6 +355,11 @@ async function persistUserAgent(): Promise<boolean> {
   return true;
 }
 
+function selectUserAgent(value: string): void {
+  userAgentText.value = value;
+  userAgentDirty.value = true;
+}
+
 function hasFilter(value: string): boolean {
   const folded = value.toLocaleLowerCase();
   return normalizedFilters.value.some((item) => item.toLocaleLowerCase() === folded);
@@ -636,6 +642,24 @@ async function saveFilters(): Promise<void> {
               <span class="text-[10px] uppercase tracking-[0.17em] text-[var(--mn-ink-faint)]">Request identity</span>
               <h3 class="mt-1 text-base font-semibold text-[var(--mn-ink)]">订阅 User-Agent</h3>
             </div>
+          </div>
+
+          <div class="mt-4 flex flex-wrap gap-2" aria-label="User-Agent 预设">
+            <button
+              v-for="preset in subscriptionUserAgentPresets"
+              :key="preset.label"
+              type="button"
+              :aria-pressed="normalizedUserAgent === preset.value"
+              :class="[
+                'min-h-8 rounded-sm px-2.5 text-xs ring-1 transition-colors',
+                normalizedUserAgent === preset.value
+                  ? 'bg-[color-mix(in_srgb,var(--mn-cactus)_28%,var(--mn-carrier))] text-[var(--mn-success)] ring-[color-mix(in_srgb,var(--mn-cactus)_45%,transparent)]'
+                  : 'bg-[var(--mn-ivory)] text-[var(--mn-ink-muted)] ring-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)]',
+              ]"
+              @click="selectUserAgent(preset.value)"
+            >
+              {{ preset.label }}
+            </button>
           </div>
 
           <label class="mt-4 block text-xs font-medium text-[var(--mn-ink-muted)]" for="subscription-user-agent">自定义值</label>

--- a/webui/src/components/pages/subscriptionUserAgent.ts
+++ b/webui/src/components/pages/subscriptionUserAgent.ts
@@ -1,0 +1,13 @@
+export type SubscriptionUserAgentPreset = {
+  label: string;
+  value: string;
+};
+
+export const subscriptionUserAgentPresets = [
+  { label: "默认", value: "" },
+  { label: "sing-box", value: "sing-box" },
+  { label: "Mihomo", value: "clash.meta" },
+  { label: "Clash for Windows", value: "ClashforWindows" },
+  { label: "Shadowrocket", value: "Shadowrocket" },
+  { label: "v2rayNG", value: "v2rayNG" },
+] as const satisfies readonly SubscriptionUserAgentPreset[];

--- a/webui/subscription-user-agent.test.mjs
+++ b/webui/subscription-user-agent.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { subscriptionUserAgentPresets } from "./src/components/pages/subscriptionUserAgent.ts";
+
+assert.deepEqual(
+  subscriptionUserAgentPresets.map(({ label }) => label),
+  ["默认", "sing-box", "Mihomo", "Clash for Windows", "Shadowrocket", "v2rayNG"],
+);
+assert.equal(subscriptionUserAgentPresets[0].value, "");
+assert.equal(
+  new Set(subscriptionUserAgentPresets.map(({ value }) => value.toLocaleLowerCase())).size,
+  subscriptionUserAgentPresets.length,
+);
+assert.ok(subscriptionUserAgentPresets.every(({ value }) => new TextEncoder().encode(value).length <= 256));
+
+console.log("subscription User-Agent preset tests passed");


### PR DESCRIPTION
## What changed

- replace the device-side `getent ahosts` dependency with a bounded `magicnet-cli` resolver that uses Android's libc DNS path
- validate every resolved address, reject mixed/private/special-use results, and keep curl pinned with `--resolve`
- add subscription User-Agent presets for default, sing-box, Mihomo, Clash for Windows, Shadowrocket, and v2rayNG while preserving custom input
- add resolver fail-closed and User-Agent preset coverage

## Root cause

v1.2.1 made subscription fetching depend on the GNU-style `getent ahosts` interface. Android devices do not reliably provide that interface, so refreshes could fail during the fetch phase before curl made a request. The fix keeps the SSRF boundary intact and moves DNS resolution into the bundled Rust CLI, which uses the platform resolver available on Android.

## Impact

Applying node filters or changing User-Agent can refresh configured subscriptions again on Android. Users can also select common User-Agent values with one tap.

## Validation

- subscription User-Agent and subscription-state Node tests pass
- 13 dependency-free WebUI tests pass
- new fetch-policy cases cover IPv4/IPv6 pinning, private-address rejection, and empty resolution
- POSIX/Bash syntax checks and `git diff --check` pass
- full Rust/WebUI builds are left to GitHub Actions because this runner lacks the Rust toolchain and could not install the complete WebUI dependency tree

Fixes #69

## 由 Sourcery 提供的摘要

将订阅的 DNS 解析移入 Rust CLI 中，使用平台解析器并收紧对已解析地址的校验，同时为 WebUI 添加常见客户端的 User-Agent 预设。

Bug 修复：
- 通过在捆绑的 CLI 中用有界解析器替换基于 `getent` 的 DNS 解析，并强制只允许公共地址，修复 Android 订阅刷新失败的问题。

增强：
- 添加 CLI 子命令，在发起 `curl` 请求前先解析并验证订阅主机名，对空结果或公有/私有地址混合结果予以拒绝。
- 为 WebUI 引入热门客户端的 User-Agent 预设，同时保留自定义输入，并在界面上直观标示当前选中的预设。

测试：
- 扩展订阅获取策略的测试，用于覆盖双栈固定、公有/私有或空解析失败，以及解析器调用等场景，并为 WebUI 的 User-Agent 预设新增测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move subscription DNS resolution into the Rust CLI using the platform resolver and tighten validation of resolved addresses while adding WebUI User-Agent presets for common clients.

Bug Fixes:
- Fix Android subscription refresh failures by replacing getent-based DNS resolution with a bounded resolver in the bundled CLI and enforcing public-only addresses.

Enhancements:
- Add CLI subcommand to resolve and validate subscription hostnames ahead of curl requests, rejecting empty or mixed public/private results.
- Introduce WebUI User-Agent presets for popular clients while preserving custom input, and visually indicate the selected preset.

Tests:
- Extend subscription fetch-policy tests to cover dual-stack pinning, private/empty resolution failure, and resolver invocation, and add WebUI tests for User-Agent presets.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

将订阅的 DNS 解析移入 Rust CLI 中，使用平台解析器并收紧对已解析地址的校验，同时为 WebUI 添加常见客户端的 User-Agent 预设。

Bug 修复：
- 通过在捆绑的 CLI 中用有界解析器替换基于 `getent` 的 DNS 解析，并强制只允许公共地址，修复 Android 订阅刷新失败的问题。

增强：
- 添加 CLI 子命令，在发起 `curl` 请求前先解析并验证订阅主机名，对空结果或公有/私有地址混合结果予以拒绝。
- 为 WebUI 引入热门客户端的 User-Agent 预设，同时保留自定义输入，并在界面上直观标示当前选中的预设。

测试：
- 扩展订阅获取策略的测试，用于覆盖双栈固定、公有/私有或空解析失败，以及解析器调用等场景，并为 WebUI 的 User-Agent 预设新增测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move subscription DNS resolution into the Rust CLI using the platform resolver and tighten validation of resolved addresses while adding WebUI User-Agent presets for common clients.

Bug Fixes:
- Fix Android subscription refresh failures by replacing getent-based DNS resolution with a bounded resolver in the bundled CLI and enforcing public-only addresses.

Enhancements:
- Add CLI subcommand to resolve and validate subscription hostnames ahead of curl requests, rejecting empty or mixed public/private results.
- Introduce WebUI User-Agent presets for popular clients while preserving custom input, and visually indicate the selected preset.

Tests:
- Extend subscription fetch-policy tests to cover dual-stack pinning, private/empty resolution failure, and resolver invocation, and add WebUI tests for User-Agent presets.

</details>

</details>