### PR TITLE
feat: improve UDP and IPv6 network policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ su -c /data/adb/modules/MagicNet/cli health
 # 查看透明代理是否运行在 magicnet0 TUN
 su -c /data/adb/modules/MagicNet/cli transparent status
 
+# 查看 UDP / IPv6 策略（默认双栈、IPv4 优先、MTU 1400、UDP 5m）
+su -c /data/adb/modules/MagicNet/cli network status
+
+# 网络或节点不支持 IPv6 时切换兼容模式
+su -c '/data/adb/modules/MagicNet/cli network set ipv4_only 1400 5m'
+
 # 重启 sing-box
 su -c /data/adb/modules/MagicNet/cli service restart sing-box
 

--- a/crates/magicnet-cli/src/diagnostics.rs
+++ b/crates/magicnet-cli/src/diagnostics.rs
@@ -25,6 +25,7 @@ fn health_items(app: &App) -> Vec<(&'static str, bool, String)> {
     let singbox = pid_summary("sing-box");
     let mode = transparent_mode(app);
     let (tun_ok, tun_detail) = tun_check(app, &mode);
+    let (network_ok, network_detail) = network_policy_check(app);
     let ecapture = app.moddir.join("bin/ecapture");
     let (dns_ok, dns_detail) = dns_leak_check(app, &singbox, &mode);
     let (routing_ok, routing_detail) = routing_policy_check(app);
@@ -34,6 +35,7 @@ fn health_items(app: &App) -> Vec<(&'static str, bool, String)> {
     vec![
         ("Core", running(&singbox), format!("sing-box={singbox}")),
         ("TUN", tun_ok, tun_detail),
+        ("UDP/IPv6", network_ok, network_detail),
         (
             "eCapture",
             ecapture.is_file(),
@@ -720,6 +722,91 @@ fn traffic_loop_guard_check(app: &App) -> (bool, String) {
     )
 }
 
+fn network_policy_check(app: &App) -> (bool, String) {
+    let path = app.moddir.join(".config/sing-box/config.json");
+    let Ok(text) = fs::read_to_string(&path) else {
+        return (false, format!("config missing: {}", path.display()));
+    };
+    let Ok(config) = serde_json::from_str::<Value>(&text) else {
+        return (false, "sing-box config is not valid JSON".to_string());
+    };
+    let strategy = config
+        .get("dns")
+        .and_then(|dns| dns.get("strategy"))
+        .and_then(Value::as_str)
+        .unwrap_or("unset");
+    let tun = config
+        .get("inbounds")
+        .and_then(Value::as_array)
+        .and_then(|items| {
+            items
+                .iter()
+                .find(|item| item.get("type").and_then(Value::as_str) == Some("tun"))
+        });
+    let stack = tun
+        .and_then(|tun| tun.get("stack"))
+        .and_then(Value::as_str)
+        .unwrap_or("unset");
+    let mtu = tun
+        .and_then(|tun| tun.get("mtu"))
+        .and_then(Value::as_u64)
+        .unwrap_or_default();
+    let udp_timeout = tun
+        .and_then(|tun| tun.get("udp_timeout"))
+        .and_then(Value::as_str)
+        .unwrap_or("unset");
+    let ipv6_address = tun
+        .and_then(|tun| tun.get("address"))
+        .and_then(Value::as_array)
+        .is_some_and(|addresses| {
+            addresses
+                .iter()
+                .filter_map(Value::as_str)
+                .any(|address| address.contains(':'))
+        });
+    let ipv6_guard = config
+        .get("route")
+        .and_then(|route| route.get("rules"))
+        .and_then(Value::as_array)
+        .is_some_and(|rules| rules.iter().any(is_managed_ipv6_guard));
+    let strategy_ok = matches!(strategy, "ipv4_only" | "prefer_ipv4" | "prefer_ipv6");
+    let guard_ok = if strategy == "ipv4_only" {
+        ipv6_guard
+    } else {
+        !ipv6_guard
+    };
+    let address_ok = strategy == "ipv4_only" || ipv6_address;
+    let ok = strategy_ok
+        && stack == "mixed"
+        && (1280..=1500).contains(&mtu)
+        && matches!(udp_timeout, "1m" | "3m" | "5m" | "10m" | "15m" | "30m")
+        && guard_ok
+        && address_ok;
+    (
+        ok,
+        format!(
+            "strategy={strategy} stack={stack} mtu={mtu} udp_timeout={udp_timeout} ipv6_address={} ipv6_guard={}",
+            ipv6_address as u8, ipv6_guard as u8
+        ),
+    )
+}
+
+fn is_managed_ipv6_guard(rule: &Value) -> bool {
+    let Some(rule) = rule.as_object() else {
+        return false;
+    };
+    let legacy_guard = rule.len() == 2
+        && rule.get("ip_version").and_then(Value::as_u64) == Some(6)
+        && rule.get("outbound").and_then(Value::as_str) == Some("block");
+    let canonical_fields = (rule.len() == 3 && !rule.contains_key("method"))
+        || (rule.len() == 4 && rule.get("method").and_then(Value::as_str) == Some("default"));
+    legacy_guard
+        || (canonical_fields
+            && rule.get("ip_version").and_then(Value::as_u64) == Some(6)
+            && rule.get("action").and_then(Value::as_str) == Some("reject")
+            && rule.get("no_drop").and_then(Value::as_bool) == Some(true))
+}
+
 fn json_string_value(line: &str, key: &str) -> Option<String> {
     let needle = format!("\"{key}\"");
     let (_, rest) = line.split_once(&needle)?;
@@ -1121,8 +1208,8 @@ fn looks_like_hostname(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        proxy_chain_evidence_from_values, read_only_command_with_timeout, redact, support_bundle,
-        traffic_loop_guard_check,
+        network_policy_check, proxy_chain_evidence_from_values, read_only_command_with_timeout,
+        redact, support_bundle, traffic_loop_guard_check,
     };
     use crate::App;
     use std::fs;
@@ -1157,6 +1244,71 @@ mod tests {
         )
         .unwrap();
         assert!(!traffic_loop_guard_check(&app).0);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn network_policy_accepts_dual_stack_and_rejects_stale_ipv6_guard() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("magicnet-network-policy-{stamp}"));
+        fs::create_dir_all(root.join(".config/sing-box")).unwrap();
+        let config_path = root.join(".config/sing-box/config.json");
+        fs::write(
+            &config_path,
+            r#"{
+              "dns": {"strategy": "prefer_ipv4"},
+              "inbounds": [{
+                "type": "tun",
+                "stack": "mixed",
+                "mtu": 1400,
+                "udp_timeout": "5m",
+                "address": ["172.19.0.1/30", "fdfe:dcba:9876::1/126"]
+              }],
+              "route": {"rules": []}
+            }"#,
+        )
+        .unwrap();
+        let app = App::for_test(root.clone());
+        assert!(network_policy_check(&app).0);
+
+        fs::write(
+            &config_path,
+            r#"{
+              "dns": {"strategy": "prefer_ipv4"},
+              "inbounds": [{
+                "type": "tun",
+                "stack": "mixed",
+                "mtu": 1400,
+                "udp_timeout": "5m",
+                "address": ["172.19.0.1/30", "fdfe:dcba:9876::1/126"]
+              }],
+              "route": {"rules": [
+                {"ip_version": 6, "action": "reject", "method": "default", "no_drop": true}
+              ]}
+            }"#,
+        )
+        .unwrap();
+        assert!(!network_policy_check(&app).0);
+
+        fs::write(
+            &config_path,
+            r#"{
+              "dns": {"strategy": "prefer_ipv6"},
+              "inbounds": [{
+                "type": "tun",
+                "stack": "mixed",
+                "mtu": 1280,
+                "udp_timeout": "10m",
+                "address": ["172.19.0.1/30", "fdfe:dcba:9876::1/126"]
+              }],
+              "route": {"rules": [{"ip_version": 6, "outbound": "block"}]}
+            }"#,
+        )
+        .unwrap();
+        assert!(!network_policy_check(&app).0);
         let _ = fs::remove_dir_all(root);
     }
 

--- a/crates/magicnet-cli/src/diagnostics_dns.rs
+++ b/crates/magicnet-cli/src/diagnostics_dns.rs
@@ -33,6 +33,7 @@ enum Ipv6GuardStatus {
     Ok,
     Missing,
     NotRequired,
+    Unexpected,
 }
 
 impl Ipv6GuardStatus {
@@ -41,11 +42,12 @@ impl Ipv6GuardStatus {
             Self::Ok => "ok",
             Self::Missing => "missing",
             Self::NotRequired => "not_required",
+            Self::Unexpected => "unexpected",
         }
     }
 
     fn ok(self) -> bool {
-        self != Self::Missing
+        !matches!(self, Self::Missing | Self::Unexpected)
     }
 }
 
@@ -129,14 +131,12 @@ fn value_contains_string(value: Option<&Value>, expected: &str) -> bool {
 }
 
 fn ipv6_guard_status(strategy: &str, config: Option<&Value>) -> Ipv6GuardStatus {
-    if strategy != "ipv4_only" {
-        return Ipv6GuardStatus::NotRequired;
-    }
-
-    if config.is_some_and(has_ipv6_reject_guard) {
-        Ipv6GuardStatus::Ok
-    } else {
-        Ipv6GuardStatus::Missing
+    let has_guard = config.is_some_and(has_ipv6_reject_guard);
+    match (strategy, has_guard) {
+        ("ipv4_only", true) => Ipv6GuardStatus::Ok,
+        ("ipv4_only", false) => Ipv6GuardStatus::Missing,
+        (_, true) => Ipv6GuardStatus::Unexpected,
+        (_, false) => Ipv6GuardStatus::NotRequired,
     }
 }
 
@@ -403,6 +403,17 @@ mod tests {
         let guard = ipv6_guard_status("prefer_ipv4", Some(&config));
 
         assert!(healthy_config("prefer_ipv4", guard).ok());
+    }
+
+    #[test]
+    fn prefer_ipv4_with_stale_ipv6_reject_guard_fails() {
+        let config = parsed(
+            r#"{"route":{"rules":[{"ip_version":6,"action":"reject","method":"default","no_drop":true}]}}"#,
+        );
+        let guard = ipv6_guard_status("prefer_ipv4", Some(&config));
+
+        assert_eq!(guard, Ipv6GuardStatus::Unexpected);
+        assert!(!healthy_config("prefer_ipv4", guard).ok());
     }
 
     #[test]

--- a/crates/magicnet-cli/src/main.rs
+++ b/crates/magicnet-cli/src/main.rs
@@ -9,6 +9,7 @@ mod diagnostics_routing;
 mod dns;
 mod ecapture;
 mod mcp;
+mod network;
 mod node_delay;
 mod nodes;
 mod ping;
@@ -40,6 +41,7 @@ use diagnostics::{health, support, sysroute, topology};
 use dns::dns_cmd;
 use ecapture::ecapture_cmd;
 use mcp::mcp;
+use network::network_cmd;
 use nodes::node_cmd;
 use ping::{pingtest, speedtest};
 use rules::{app_cmd, block_cmd, route_cmd};
@@ -124,6 +126,10 @@ const COMMAND_HELP: &[CommandHelp] = &[
     CommandHelp {
         command: "transparent",
         usage: "cli transparent {status|set tun|apply}",
+    },
+    CommandHelp {
+        command: "network",
+        usage: "cli network {status|set <ipv4_only|prefer_ipv4|prefer_ipv6> <mtu:1280-1500> <udp-timeout:1m|3m|5m|10m|15m|30m>|apply}",
     },
     CommandHelp {
         command: "core",
@@ -272,6 +278,7 @@ fn dispatch(app: &App, args: &[String]) -> Result<(), String> {
         "setup" => setup_subscription(app, args.get(1).map(String::as_str).unwrap_or_default()),
         "config" => config_cmd(app, &args[1..]),
         "transparent" => transparent_cmd(app, &args[1..]),
+        "network" => network_cmd(app, &args[1..]),
         "core" => core_cmd(app, &args[1..]),
         "api" => api_cmd(app, &args[1..]),
         "mode" => webui_api::clash_mode_cmd(app, &args[1..]),

--- a/crates/magicnet-cli/src/network.rs
+++ b/crates/magicnet-cli/src/network.rs
@@ -1,0 +1,210 @@
+use std::fs;
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::{read_kv, run_magicnet_function, write_kv, App};
+
+const NETWORK_POLICY_CONF: &str = ".config/magicnet/network-policy.conf";
+const DEFAULT_IPV6_MODE: &str = "prefer_ipv4";
+const DEFAULT_MTU: u16 = 1400;
+const DEFAULT_UDP_TIMEOUT: &str = "5m";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct NetworkPolicy {
+    ipv6_mode: &'static str,
+    mtu: u16,
+    udp_timeout: &'static str,
+}
+
+impl Default for NetworkPolicy {
+    fn default() -> Self {
+        Self {
+            ipv6_mode: DEFAULT_IPV6_MODE,
+            mtu: DEFAULT_MTU,
+            udp_timeout: DEFAULT_UDP_TIMEOUT,
+        }
+    }
+}
+
+pub(crate) fn network_cmd(app: &App, args: &[String]) -> Result<(), String> {
+    match args.first().map(String::as_str).unwrap_or("status") {
+        "status" => {
+            print_status(app, &NetworkPolicy::load(app));
+            Ok(())
+        }
+        "set" => {
+            let policy = NetworkPolicy::from_args(&args[1..])?;
+            policy.write(app)?;
+            run_magicnet_function(app, "magicnet_transparent_apply")?;
+            print_status(app, &policy);
+            println!("[info] Network policy applied");
+            Ok(())
+        }
+        "apply" => {
+            run_magicnet_function(app, "magicnet_transparent_apply")?;
+            print_status(app, &NetworkPolicy::load(app));
+            Ok(())
+        }
+        _ => Err(network_usage()),
+    }
+}
+
+impl NetworkPolicy {
+    fn load(app: &App) -> Self {
+        let values = read_kv(app.moddir.join(NETWORK_POLICY_CONF));
+        Self {
+            ipv6_mode: normalize_ipv6_mode(
+                values
+                    .get("MAGICNET_IPV6_MODE")
+                    .map(String::as_str)
+                    .unwrap_or_default(),
+            )
+            .unwrap_or(DEFAULT_IPV6_MODE),
+            mtu: normalize_mtu(
+                values
+                    .get("MAGICNET_TUN_MTU")
+                    .map(String::as_str)
+                    .unwrap_or_default(),
+            )
+            .unwrap_or(DEFAULT_MTU),
+            udp_timeout: normalize_udp_timeout(
+                values
+                    .get("MAGICNET_UDP_TIMEOUT")
+                    .map(String::as_str)
+                    .unwrap_or_default(),
+            )
+            .unwrap_or(DEFAULT_UDP_TIMEOUT),
+        }
+    }
+
+    fn from_args(args: &[String]) -> Result<Self, String> {
+        if args.len() != 3 {
+            return Err(network_usage());
+        }
+        Ok(Self {
+            ipv6_mode: normalize_ipv6_mode(&args[0]).ok_or_else(network_usage)?,
+            mtu: normalize_mtu(&args[1]).ok_or_else(network_usage)?,
+            udp_timeout: normalize_udp_timeout(&args[2]).ok_or_else(network_usage)?,
+        })
+    }
+
+    fn write(&self, app: &App) -> Result<(), String> {
+        write_kv(
+            app,
+            Path::new(NETWORK_POLICY_CONF),
+            &[
+                ("MAGICNET_IPV6_MODE", self.ipv6_mode.to_string()),
+                ("MAGICNET_TUN_MTU", self.mtu.to_string()),
+                ("MAGICNET_UDP_TIMEOUT", self.udp_timeout.to_string()),
+            ],
+        )
+    }
+}
+
+fn normalize_ipv6_mode(value: &str) -> Option<&'static str> {
+    match value {
+        "ipv4_only" | "ipv4-only" | "compat" | "disabled" => Some("ipv4_only"),
+        "prefer_ipv4" | "prefer-ipv4" | "auto" | "dual" => Some("prefer_ipv4"),
+        "prefer_ipv6" | "prefer-ipv6" => Some("prefer_ipv6"),
+        _ => None,
+    }
+}
+
+fn normalize_mtu(value: &str) -> Option<u16> {
+    value
+        .parse::<u16>()
+        .ok()
+        .filter(|value| (1280..=1500).contains(value))
+}
+
+fn normalize_udp_timeout(value: &str) -> Option<&'static str> {
+    match value {
+        "1m" => Some("1m"),
+        "3m" => Some("3m"),
+        "5m" => Some("5m"),
+        "10m" => Some("10m"),
+        "15m" => Some("15m"),
+        "30m" => Some("30m"),
+        _ => None,
+    }
+}
+
+fn print_status(app: &App, policy: &NetworkPolicy) {
+    println!("ipv6_mode={}", policy.ipv6_mode);
+    println!("mtu={}", policy.mtu);
+    println!("udp_timeout={}", policy.udp_timeout);
+
+    let effective = fs::read_to_string(app.moddir.join(".config/sing-box/config.json"))
+        .ok()
+        .and_then(|text| serde_json::from_str::<Value>(&text).ok());
+    let tun = effective
+        .as_ref()
+        .and_then(|config| config.get("inbounds"))
+        .and_then(Value::as_array)
+        .and_then(|inbounds| {
+            inbounds
+                .iter()
+                .find(|inbound| inbound.get("type").and_then(Value::as_str) == Some("tun"))
+        });
+    let strategy = effective
+        .as_ref()
+        .and_then(|config| config.get("dns"))
+        .and_then(|dns| dns.get("strategy"))
+        .and_then(Value::as_str)
+        .unwrap_or("unavailable");
+    println!("effective_ipv6_mode={strategy}");
+    println!(
+        "effective_stack={}",
+        tun.and_then(|tun| tun.get("stack"))
+            .and_then(Value::as_str)
+            .unwrap_or("unavailable")
+    );
+    println!(
+        "effective_mtu={}",
+        tun.and_then(|tun| tun.get("mtu"))
+            .and_then(Value::as_u64)
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "unavailable".to_string())
+    );
+    println!(
+        "effective_udp_timeout={}",
+        tun.and_then(|tun| tun.get("udp_timeout"))
+            .and_then(Value::as_str)
+            .unwrap_or("unavailable")
+    );
+}
+
+fn network_usage() -> String {
+    "Usage: cli network {status|set <ipv4_only|prefer_ipv4|prefer_ipv6> <mtu:1280-1500> <udp-timeout:1m|3m|5m|10m|15m|30m>|apply}".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aliases_normalize_to_canonical_ipv6_modes() {
+        assert_eq!(normalize_ipv6_mode("compat"), Some("ipv4_only"));
+        assert_eq!(normalize_ipv6_mode("dual"), Some("prefer_ipv4"));
+        assert_eq!(normalize_ipv6_mode("prefer-ipv6"), Some("prefer_ipv6"));
+        assert_eq!(normalize_ipv6_mode("ipv6_only"), None);
+    }
+
+    #[test]
+    fn mtu_rejects_values_that_break_ipv6_or_exceed_common_links() {
+        assert_eq!(normalize_mtu("1280"), Some(1280));
+        assert_eq!(normalize_mtu("1400"), Some(1400));
+        assert_eq!(normalize_mtu("1500"), Some(1500));
+        assert_eq!(normalize_mtu("1279"), None);
+        assert_eq!(normalize_mtu("1501"), None);
+    }
+
+    #[test]
+    fn udp_timeout_uses_bounded_presets() {
+        assert_eq!(normalize_udp_timeout("5m"), Some("5m"));
+        assert_eq!(normalize_udp_timeout("30m"), Some("30m"));
+        assert_eq!(normalize_udp_timeout("0m"), None);
+        assert_eq!(normalize_udp_timeout("1h"), None);
+    }
+}

--- a/crates/magicnet-cli/src/webui_backup.rs
+++ b/crates/magicnet-cli/src/webui_backup.rs
@@ -322,6 +322,16 @@ fn sourced_conf_value_is_allowed(rel: &str, key: &str, value: &str) -> bool {
                 "tun" | "proxy" | "external" | "external-tun" | "hybrid"
             )
         }
+        (".config/magicnet/network-policy.conf", "MAGICNET_IPV6_MODE") => {
+            matches!(value, "ipv4_only" | "prefer_ipv4" | "prefer_ipv6")
+        }
+        (".config/magicnet/network-policy.conf", "MAGICNET_TUN_MTU") => value
+            .parse::<u16>()
+            .map(|mtu| (1280..=1500).contains(&mtu))
+            .unwrap_or(false),
+        (".config/magicnet/network-policy.conf", "MAGICNET_UDP_TIMEOUT") => {
+            matches!(value, "1m" | "3m" | "5m" | "10m" | "15m" | "30m")
+        }
         (".config/magicnet/wifi-policy.conf", "MAGICNET_WIFI_POLICY_ENABLED") => {
             matches!(value, "0" | "1")
         }
@@ -355,6 +365,7 @@ fn backup_files() -> &'static [&'static str] {
         ".config/magicnet/warp.conf",
         ".config/magicnet/warp-endpoint.json",
         ".config/magicnet/transparent-mode.conf",
+        ".config/magicnet/network-policy.conf",
         ".config/magicnet/wifi-policy.conf",
         ".config/magicnet/wifi-ssid.list",
         ".config/magicnet/wifi-bssid.list",
@@ -454,6 +465,20 @@ mod tests {
             block,
             "not a kv line\n"
         ));
+
+        let network = ".config/magicnet/network-policy.conf";
+        assert!(sourced_conf_content_matches_schema(
+            network,
+            "MAGICNET_IPV6_MODE=prefer_ipv4\nMAGICNET_TUN_MTU=1400\nMAGICNET_UDP_TIMEOUT=5m\n"
+        ));
+        for invalid in [
+            "MAGICNET_IPV6_MODE=ipv6_only\n",
+            "MAGICNET_TUN_MTU=1279\n",
+            "MAGICNET_TUN_MTU=1501\n",
+            "MAGICNET_UDP_TIMEOUT=1h\n",
+        ] {
+            assert!(!sourced_conf_content_matches_schema(network, invalid));
+        }
     }
 
     #[test]

--- a/scripts/fake-magisk-smoke.sh
+++ b/scripts/fake-magisk-smoke.sh
@@ -700,12 +700,13 @@ run sh "$MODDIR/service.sh"
 run sh "$MODDIR/boot-completed.sh"
 hotspot_policy_ready() {
     "$HOST_JQ" -e '
-    ([.outbounds[] | select(.tag == "hotspot")] == [{
-      "type": "selector",
-      "tag": "hotspot",
-      "outbounds": ["direct", "proxy"],
-      "default": "direct"
-    }])
+    ([.outbounds[] | select(.tag == "hotspot")] | length == 1)
+    and ([.outbounds[] | select(.tag == "hotspot")][0]
+      | .type == "selector"
+      and .outbounds == ["direct", "proxy"]
+      and .default == "direct"
+      and ((has("interrupt_exist_connections") | not) or .interrupt_exist_connections == true)
+    )
     and ([.route.rules[] | select(
       .inbound == ["tun-in"]
       and .source_ip_cidr == ["192.168.0.0/16", "10.42.0.0/16", "172.20.10.0/28"]
@@ -740,7 +741,7 @@ env -u MODDIR -u MODPATH \
     MAGICNET_FAKE_LOG="$MOCK_LOG" \
     MAGICNET_NOTIFY_ENABLED=0 \
     PATH="$MOCK_BIN:$TOYBOX_APPLET_BIN:$MODDIR/bin:$ORIGINAL_PATH" \
-    "$MODDIR/cli" diagnose >"$TMP/cli-autodetect-diagnose.log" 2>&1
+    "$MODDIR/bin/magicnet-cli" diagnose >"$TMP/cli-autodetect-diagnose.log" 2>&1
 if rg -q '\.kamfwrc|\.kamrc|No such file or directory' "$TMP/cli-autodetect-diagnose.log"; then
     echo "cli autodetect failed to locate module root" >&2
     cat "$TMP/cli-autodetect-diagnose.log" >&2

--- a/scripts/orchestrator-mode-smoke.sh
+++ b/scripts/orchestrator-mode-smoke.sh
@@ -38,9 +38,9 @@ import() { :; }
 info() { :; }
 warn() { printf '%s\n' "$*" >&2; }
 magicnet_warn() { warn "$@"; }
-magicnet_singbox_dns_strategy_for_mode() { printf '%s\n' "ipv4_only"; }
 singbox_prepare_route_config() { :; }
 . "$ROOT_DIR/src/MagicNet/lib/magicnet/common.sh"
+. "$ROOT_DIR/src/MagicNet/lib/magicnet/transparent_dns.sh"
 . "$MAGICNET_TRANSPARENT_SCRIPT"
 magicnet_singbox_apply_transparent_mode
 HARNESS
@@ -280,7 +280,7 @@ assert_mode() {
     fi
 
     if [ "$expect_tun" = "yes" ]; then
-        jq -e '.inbounds[] | select(.type == "tun" and .tag == "tun-in" and .interface_name == "magicnet0" and .stack == "mixed" and .mtu == 1400)' "$config" >/dev/null
+        jq -e '.inbounds[] | select(.type == "tun" and .tag == "tun-in" and .interface_name == "magicnet0" and .stack == "mixed" and .mtu == 1400 and .udp_timeout == "5m")' "$config" >/dev/null
         assert_tun_exclusions "$config" "$mode/$managed_variant second apply"
         jq -e '.route.rules[] | select(.action == "sniff" and (.inbound == ["mixed-in", "tun-in"]))' "$config" >/dev/null
     else
@@ -301,7 +301,59 @@ assert_mode() {
     jq -e '.dns.strategy == "ipv4_only"' "$config" >/dev/null
 }
 
+export MAGICNET_TEST_DNS_STRATEGY=ipv4_only
+export MAGICNET_TEST_TUN_MTU=1400
+export MAGICNET_TEST_UDP_TIMEOUT=5m
+export MAGICNET_IPV6_MODE="$MAGICNET_TEST_DNS_STRATEGY"
+export MAGICNET_TUN_MTU="$MAGICNET_TEST_TUN_MTU"
+export MAGICNET_UDP_TIMEOUT="$MAGICNET_TEST_UDP_TIMEOUT"
 assert_mode tun yes duplicate
+
+assert_dual_stack_policy() {
+    local strategy=$1
+    local mtu=$2
+    local udp_timeout=$3
+    local config="$MODDIR/.config/sing-box/config.json"
+    export MAGICNET_TEST_DNS_STRATEGY=$strategy
+    export MAGICNET_TEST_TUN_MTU=$mtu
+    export MAGICNET_TEST_UDP_TIMEOUT=$udp_timeout
+    export MAGICNET_IPV6_MODE=$strategy
+    export MAGICNET_TUN_MTU=$mtu
+    export MAGICNET_UDP_TIMEOUT=$udp_timeout
+    "$TMPDIR/harness.sh"
+    if ! jq -e --arg strategy "$strategy" --argjson mtu "$mtu" --arg timeout "$udp_timeout" '
+        def managed_guard:
+          . == {"ip_version": 6, "outbound": "block"}
+          or . == {"ip_version": 6, "action": "reject", "no_drop": true}
+          or . == {"ip_version": 6, "action": "reject", "method": "default", "no_drop": true};
+        .dns.strategy == $strategy
+        and ([.route.rules[]? | select(managed_guard)] | length) == 0
+        and ([.inbounds[]? | select(
+          .type == "tun"
+          and .tag == "tun-in"
+          and .stack == "mixed"
+          and .mtu == $mtu
+          and .udp_timeout == $timeout
+          and any(.address[]?; contains(":"))
+        )] | length) == 1
+    ' "$config" >/dev/null; then
+        echo "orchestrator smoke failed: invalid $strategy/$mtu/$udp_timeout policy output" >&2
+        jq '{dns:.dns.strategy,tun:(.inbounds[]? | select(.type == "tun")),ipv6:[.route.rules[]? | select(.ip_version == 6)]}' "$config" >&2
+        exit 1
+    fi
+    assert_singbox_check "$config" "$strategy/$mtu/$udp_timeout policy"
+}
+
+# A previous ipv4_only apply leaves a managed IPv6 guard. Switching back to
+# dual stack must remove it while retaining the IPv6 TUN address.
+assert_dual_stack_policy prefer_ipv4 1400 5m
+assert_dual_stack_policy prefer_ipv6 1280 10m
+export MAGICNET_TEST_DNS_STRATEGY=ipv4_only
+export MAGICNET_TEST_TUN_MTU=1400
+export MAGICNET_TEST_UDP_TIMEOUT=5m
+export MAGICNET_IPV6_MODE="$MAGICNET_TEST_DNS_STRATEGY"
+export MAGICNET_TUN_MTU="$MAGICNET_TEST_TUN_MTU"
+export MAGICNET_UDP_TIMEOUT="$MAGICNET_TEST_UDP_TIMEOUT"
 
 for legacy_mode in proxy external external-tun hybrid; do
     printf 'MAGICNET_TRANSPARENT_MODE=%s\n' "$legacy_mode" >"$MODDIR/.config/magicnet/transparent-mode.conf"
@@ -485,7 +537,7 @@ if ! jq -e . "$FALLBACK_CONFIG" >/dev/null; then
 fi
 jq -e '.inbounds[] | select(.type == "mixed" and .tag == "mixed-in" and .listen == "127.0.0.1" and .listen_port == 7892)' "$FALLBACK_CONFIG" >/dev/null
 jq -e '.inbounds[] | select(.type == "direct" and .tag == "magicnet-dns-in" and .listen == "127.0.0.1" and .listen_port == 1053)' "$FALLBACK_CONFIG" >/dev/null
-jq -e '.inbounds[] | select(.type == "tun" and .tag == "tun-in" and .stack == "mixed" and .mtu == 1400)' "$FALLBACK_CONFIG" >/dev/null
+jq -e '.inbounds[] | select(.type == "tun" and .tag == "tun-in" and .stack == "mixed" and .mtu == 1400 and .udp_timeout == "5m")' "$FALLBACK_CONFIG" >/dev/null
 assert_tun_exclusions "$FALLBACK_CONFIG" "no-jq fallback first apply"
 jq -e '.dns.strategy == "ipv4_only"' "$FALLBACK_CONFIG" >/dev/null
 jq -e '.route.rules[] | select(.action == "sniff" and (.inbound == ["mixed-in", "tun-in"]) and .network == "tcp")' "$FALLBACK_CONFIG" >/dev/null

--- a/scripts/package-smoke.sh
+++ b/scripts/package-smoke.sh
@@ -300,11 +300,28 @@ if len(packaged_tuns) != 1 or packaged_tuns[0].get("route_exclude_address") != c
         "packaged base TUN exclusions are not canonical or exactly ordered: "
         f"{[inbound.get('route_exclude_address') for inbound in packaged_tuns]}"
     )
+packaged_tun = packaged_tuns[0]
+if (
+    config.get("dns", {}).get("strategy") != "prefer_ipv4"
+    or packaged_tun.get("stack") != "mixed"
+    or packaged_tun.get("mtu") != 1400
+    or packaged_tun.get("udp_timeout") != "5m"
+    or 0 not in packaged_tun.get("exclude_uid", [])
+    or not any(":" in address for address in packaged_tun.get("address", []))
+):
+    raise SystemExit("packaged base UDP/IPv6 policy is not canonical dual stack")
 
 dns_rules = config.get("dns", {}).get("rules", [])
 dns_servers = config.get("dns", {}).get("servers", [])
 route_rules = config.get("route", {}).get("rules", [])
-if len(route_rules) != 67 or len(dns_rules) != 25:
+managed_ipv6_guards = [
+    {"ip_version": 6, "outbound": "block"},
+    {"ip_version": 6, "action": "reject", "no_drop": True},
+    {"ip_version": 6, "action": "reject", "method": "default", "no_drop": True},
+]
+if any(rule in managed_ipv6_guards for rule in route_rules):
+    raise SystemExit("packaged dual-stack config contains a managed IPv6 reject guard")
+if len(route_rules) != 66 or len(dns_rules) != 25:
     raise SystemExit(
         f"canonical rule counts changed: route={len(route_rules)} dns={len(dns_rules)}"
     )
@@ -419,20 +436,20 @@ legacy_early_local_msft_dns_rule = {
 }
 if legacy_early_local_msft_dns_rule in dns_rules:
     raise SystemExit("legacy early local Microsoft connectivity DNS rule must be absent")
-if route_rules[27] != {
+if route_rules[26] != {
     "domain_suffix": msft_network_test_suffixes,
     "outbound": "network-test",
 }:
-    raise SystemExit("route rule 27 Microsoft network-test suffixes changed")
-if route_rules[29] != {
+    raise SystemExit("route rule 26 Microsoft network-test suffixes changed")
+if route_rules[28] != {
     "domain_suffix": foreign_network_test_suffixes,
     "outbound": "network-test",
 }:
-    raise SystemExit("route rule 29 foreign network-test suffixes changed")
+    raise SystemExit("route rule 28 foreign network-test suffixes changed")
 if foreign_connectivity_rule["domain_suffix"] != (
-    route_rules[27]["domain_suffix"] + route_rules[29]["domain_suffix"]
+    route_rules[26]["domain_suffix"] + route_rules[28]["domain_suffix"]
 ):
-    raise SystemExit("foreign network-test DNS suffixes must equal route rules 27 + 29")
+    raise SystemExit("foreign network-test DNS suffixes must equal route rules 26 + 28")
 apple_icloud_rule = {
     "domain_suffix": [
         "apple.com",
@@ -1587,9 +1604,9 @@ foreign_priority_route_rule = {
     "domain_suffix": foreign_priority_domains,
     "outbound": "proxy-rule",
 }
-if route_rules[49] != foreign_priority_route_rule:
-    raise SystemExit("packaged exact 56-domain foreign-priority route must remain at index 49")
-if route_rules[49]["domain_suffix"] != dns_rules[20]["domain_suffix"]:
+if route_rules[48] != foreign_priority_route_rule:
+    raise SystemExit("packaged exact 56-domain foreign-priority route must remain at index 48")
+if route_rules[48]["domain_suffix"] != dns_rules[20]["domain_suffix"]:
     raise SystemExit("packaged foreign-priority route/DNS lists must remain identical")
 canonical_keyword_rule = {"domain_keyword": network_test_keywords, "outbound": "network-test"}
 keyword_routes = [
@@ -1864,12 +1881,12 @@ if recursively_effective_outbound(global_bing_route_rule["outbound"]) != "block"
     )
 
 if (
-    route_rules[31].get("outbound") != "cn-direct"
-    or not explicit_domain_matches(route_rules[31], "mmstat.com")
-    or any(explicit_domain_matches(rule, "mmstat.com") for rule in route_rules[:31])
-    or recursively_effective_outbound(route_rules[31]["outbound"]) != "direct"
+    route_rules[30].get("outbound") != "cn-direct"
+    or not explicit_domain_matches(route_rules[30], "mmstat.com")
+    or any(explicit_domain_matches(rule, "mmstat.com") for rule in route_rules[:30])
+    or recursively_effective_outbound(route_rules[30]["outbound"]) != "direct"
 ):
-    raise SystemExit("packaged mmstat.com route must first-match index 31 cn-direct/direct")
+    raise SystemExit("packaged mmstat.com route must first-match index 30 cn-direct/direct")
 
 download_probes = set(download_suffixes)
 for index, rule in enumerate(route_rules[:download_route_index]):

--- a/scripts/test-default-routing-policy.sh
+++ b/scripts/test-default-routing-policy.sh
@@ -38,6 +38,24 @@ jq -e '
 ' "$CONFIG_FILE" >/dev/null || fail "base TUN exclusions are not canonical or exactly ordered"
 
 jq -e '
+  .dns.strategy == "prefer_ipv4"
+    and ([.inbounds[] | select(
+      .type == "tun"
+      and .tag == "tun-in"
+      and .stack == "mixed"
+      and .mtu == 1400
+      and .udp_timeout == "5m"
+      and (.exclude_uid | index(0)) != null
+      and (.address | any(contains(":")))
+    )] | length) == 1
+    and ([.route.rules[] | select(
+      . == {"ip_version": 6, "action": "reject", "method": "default", "no_drop": true}
+      or . == {"ip_version": 6, "action": "reject", "no_drop": true}
+      or . == {"ip_version": 6, "outbound": "block"}
+    )] | length) == 0
+' "$CONFIG_FILE" >/dev/null || fail "base UDP/IPv6 policy is not canonical dual stack"
+
+jq -e '
   .dns.cache_capacity == 4096
     and (.dns.disable_cache? != true)
     and (.dns.independent_cache? != true)
@@ -218,7 +236,7 @@ proxy_dns_tags = {
     for server in config["dns"]["servers"]
     if server.get("detour") == "proxy"
 }
-if len(rules) != 67 or len(dns_rules) != 25:
+if len(rules) != 66 or len(dns_rules) != 25:
     raise AssertionError(
         f"canonical rule counts changed: route={len(rules)} dns={len(dns_rules)}"
     )
@@ -274,12 +292,12 @@ legacy_early_local_msft_dns_rule = {
 }
 if legacy_early_local_msft_dns_rule in dns_rules:
     raise AssertionError("legacy early local Microsoft connectivity DNS rule must be absent")
-if rules[27] != {"domain_suffix": msft_network_test_suffixes, "outbound": "network-test"}:
-    raise AssertionError("route rule 27 Microsoft network-test suffixes changed")
-if rules[29] != {"domain_suffix": foreign_network_test_suffixes, "outbound": "network-test"}:
-    raise AssertionError("route rule 29 foreign network-test suffixes changed")
+if rules[26] != {"domain_suffix": msft_network_test_suffixes, "outbound": "network-test"}:
+    raise AssertionError("route rule 26 Microsoft network-test suffixes changed")
+if rules[28] != {"domain_suffix": foreign_network_test_suffixes, "outbound": "network-test"}:
+    raise AssertionError("route rule 28 foreign network-test suffixes changed")
 if foreign_network_test_dns_rule["domain_suffix"] != (
-    rules[27]["domain_suffix"] + rules[29]["domain_suffix"]
+    rules[26]["domain_suffix"] + rules[28]["domain_suffix"]
 ):
     raise AssertionError("foreign network-test DNS suffixes must equal route rules 27 + 29")
 cn_bing_dns_rule = {
@@ -730,9 +748,9 @@ if (
     != karing_false_positive_domains
 ):
     raise AssertionError("foreign-priority domain sequence must preserve 51 entries and append 5")
-if rules[49] != foreign_priority_route_rule or dns_rules[20] != foreign_priority_dns_rule:
+if rules[48] != foreign_priority_route_rule or dns_rules[20] != foreign_priority_dns_rule:
     raise AssertionError("exact 56-domain foreign-priority route/DNS indexes changed")
-if rules[49]["domain_suffix"] != dns_rules[20]["domain_suffix"]:
+if rules[48]["domain_suffix"] != dns_rules[20]["domain_suffix"]:
     raise AssertionError("foreign-priority route/DNS domain lists must remain identical")
 flows = (
     {
@@ -966,16 +984,16 @@ google_play_proxy_rule = {
 google_play_proxy_indexes = [
     index for index, rule in enumerate(rules) if rule == google_play_proxy_rule
 ]
-if google_play_proxy_indexes != [9]:
+if google_play_proxy_indexes != [8]:
     raise AssertionError(
-        "Google Play package routing must have one early proxy owner at index 9: "
+        "Google Play package routing must have one early proxy owner at index 8: "
         f"indexes={google_play_proxy_indexes}"
     )
 for package_name in google_play_proxy_rule["package_name"]:
     for base_flow in flows:
         flow = dict(base_flow, package_name=package_name)
         index, rule, _ = first_matching_outbound("play.googleapis.com", flow)
-        if index != 9 or rule != google_play_proxy_rule:
+        if index != 8 or rule != google_play_proxy_rule:
             raise AssertionError(
                 f"{package_name} {base_flow['name']} must proxy before destination rules: "
                 f"index={index} rule={rule}"
@@ -1041,7 +1059,7 @@ for domain in karing_false_positive_domains:
         dns_index, dns_rule, _ = dns_match
         dns_server = dns_rule.get("server")
     if (
-        route_index != 49
+        route_index != 48
         or route_rule.get("outbound") != "proxy-rule"
         or dns_index != 20
         or dns_server != "doh-google"
@@ -1570,9 +1588,9 @@ mmstat_dns_index = mmstat_dns_indexes[0]
 route_index, route_rule, matching_rule_sets = first_matching_outbound("mmstat.com", flows[0])
 route_outbound = route_rule.get("outbound")
 route_effective = recursively_effective_outbound(route_outbound)
-if route_index != 31 or route_outbound != "cn-direct" or route_effective != "direct":
+if route_index != 30 or route_outbound != "cn-direct" or route_effective != "direct":
     raise AssertionError(
-        "mmstat.com route must remain index 31 cn-direct/direct: "
+        "mmstat.com route must remain index 30 cn-direct/direct: "
         f"index={route_index} outbound={route_outbound} effective={route_effective}"
     )
 mmstat_dns = first_matching_dns("mmstat.com", flows[0])
@@ -1752,7 +1770,7 @@ network_test_route_indexes = [
 if (
     rule.get("outbound") != "dns-guard"
     or recursively_effective_outbound(rule["outbound"]) != "block"
-    or network_test_route_indexes != [29]
+    or network_test_route_indexes != [28]
     or not index < network_test_route_indexes[0]
 ):
     raise AssertionError(

--- a/scripts/test-default-routing-policy.sh
+++ b/scripts/test-default-routing-policy.sh
@@ -2918,17 +2918,8 @@ jq -e '
   | .route.final == "final"
     and (($dns_hijack_rules | length) > 0)
     and (($icmp_block_rules | length) > 0)
-    and (($ipv6_rules | length) == 1)
-    and ($ipv6_rules[0].value == {
-      ip_version: 6,
-      action: "reject",
-      method: "default",
-      no_drop: true
-    })
-    and ($dns_hijack_rules | all(.key < $ipv6_rules[0].key))
-    and ($icmp_block_rules | all(.key < $ipv6_rules[0].key))
+    and (($ipv6_rules | length) == 0)
     and (($cn_direct_rules | length) > 0)
-    and ($cn_direct_rules | all(.key > $ipv6_rules[0].key))
     and ([.outbounds[] | select(.tag == "cn-direct")] == [
       {type: "selector", tag: "cn-direct", outbounds: ["direct", "proxy", "block"], default: "direct"}
     ])

--- a/src/MagicNet/.config/magicnet/network-policy.conf
+++ b/src/MagicNet/.config/magicnet/network-policy.conf
@@ -1,0 +1,5 @@
+# MagicNet managed TUN network policy.
+# ipv4_only is the compatibility fallback for networks or nodes without IPv6.
+MAGICNET_IPV6_MODE=prefer_ipv4
+MAGICNET_TUN_MTU=1400
+MAGICNET_UDP_TIMEOUT=5m

--- a/src/MagicNet/README.md
+++ b/src/MagicNet/README.md
@@ -117,6 +117,9 @@ MagicNet 新安装默认按节点名过滤 `免费`、`free`、`HK`、`香港`�
 
 MagicNet 目前只支持 `tun` 透明模式，使用 `sing-box` `magicnet0` TUN 接管透明流量。旧配置中的 `proxy`、`external-tun`、`hybrid` 会安全归一为 `tun`，CLI 不再接受这些模式。
 
+- 默认网络策略是双栈、DNS 优先 IPv4、`mixed` TUN 栈、MTU `1400` 和 UDP 会话超时 `5m`。
+- 可在 WebUI 的“UDP / IPv6”卡片切换，或执行 `cli network set <ipv4_only|prefer_ipv4|prefer_ipv6> <1280-1500> <1m|3m|5m|10m|15m|30m>`。
+- `ipv4_only` 是网络或代理节点不支持 IPv6 时的兼容回退；切回双栈会自动移除 MagicNet 管理的 IPv6 拦截规则。
 - 可用性以 `cli health` 和物理出口抓包为准。
 - 发布前请用 `tcpdump` 验证没有 `port 53 or port 853` 泄露。
 

--- a/src/MagicNet/lib/magicnet/transparent.sh
+++ b/src/MagicNet/lib/magicnet/transparent.sh
@@ -3,6 +3,8 @@ magicnet_singbox_apply_transparent_mode() {
     [ -f "$_config" ] || return 0
     _mode="$(magicnet_transparent_mode)"
     _dns_strategy="$(magicnet_singbox_dns_strategy_for_mode "$_config" "tun")"
+    _tun_mtu="$(magicnet_tun_mtu)"
+    _udp_timeout="$(magicnet_udp_timeout)"
     _jq="${MODDIR}/bin/jq"
     if [ ! -x "$_jq" ]; then
         _jq="$(command -v jq 2>/dev/null || true)"
@@ -10,7 +12,10 @@ magicnet_singbox_apply_transparent_mode() {
     _tmp="${_config}.transparent-mode.new"
     if [ -n "$_jq" ]; then
         # shellcheck disable=SC2016
-        if "$_jq" --arg dns_strategy "$_dns_strategy" '
+        if "$_jq" \
+            --arg dns_strategy "$_dns_strategy" \
+            --argjson tun_mtu "$_tun_mtu" \
+            --arg udp_timeout "$_udp_timeout" '
             def mixed_in:
               {
                 "type": "mixed",
@@ -55,7 +60,8 @@ magicnet_singbox_apply_transparent_mode() {
                   "fd7a:115c:a1e0::/48"
                 ],
                 "stack": "mixed",
-                "mtu": 1400
+                "mtu": $tun_mtu,
+                "udp_timeout": $udp_timeout
               };
             def managed_inbound:
               ((.type // "") as $type | ($type == "tun" or $type == "tproxy" or $type == "redirect"))
@@ -100,6 +106,7 @@ magicnet_singbox_apply_transparent_mode() {
             | .route.rules = (
               ((.route.rules // [])
                 | map(select(references_managed_inbound | not))
+                | map(select(is_managed_ipv6_guard | not))
                 | map(normalize_sniff_rule)) as $rules
               | ([dns_hijack_rule] + (if any($rules[]?; is_sniff_rule) then $rules else [sniff_rule] + $rules end)) as $managed_rules
               | if $dns_strategy == "ipv4_only" then
@@ -117,7 +124,7 @@ magicnet_singbox_apply_transparent_mode() {
             :
         else
             rm -f "$_tmp" 2>/dev/null || true
-            unset _dns_strategy _jq _mode
+            unset _dns_strategy _tun_mtu _udp_timeout _jq _mode
             return 1
         fi
     else
@@ -127,7 +134,7 @@ magicnet_singbox_apply_transparent_mode() {
         if [ -z "$_singbox" ]; then
             magicnet_warn "sing-box not found; cannot safely normalize config without jq"
             rm -f "$_tmp" "$_stage" "$_next" 2>/dev/null || true
-            unset _dns_strategy _jq _mode _singbox _stage _next
+            unset _dns_strategy _tun_mtu _udp_timeout _jq _mode _singbox _stage _next
             return 1
         fi
         if "$_singbox" format -c "$_config" -D "${_config%/*}" >"$_stage"; then
@@ -135,7 +142,7 @@ magicnet_singbox_apply_transparent_mode() {
         else
             magicnet_warn "sing-box format failed; refusing unsafe no-jq config rewrite"
             rm -f "$_tmp" "$_stage" "$_next" 2>/dev/null || true
-            unset _dns_strategy _jq _mode _singbox _stage _next
+            unset _dns_strategy _tun_mtu _udp_timeout _jq _mode _singbox _stage _next
             return 1
         fi
         if awk -v dns_strategy="$_dns_strategy" '
@@ -227,10 +234,10 @@ magicnet_singbox_apply_transparent_mode() {
             :
         else
             rm -f "$_tmp" "$_stage" "$_next" 2>/dev/null || true
-            unset _dns_strategy _jq _mode _singbox _stage _next
+            unset _dns_strategy _tun_mtu _udp_timeout _jq _mode _singbox _stage _next
             return 1
         fi
-        if awk '
+        if awk -v tun_mtu="$_tun_mtu" -v udp_timeout="$_udp_timeout" '
         function emit_mixed(comma) {
             print "    {"
             print "      \"type\": \"mixed\","
@@ -269,7 +276,8 @@ magicnet_singbox_apply_transparent_mode() {
             print "        \"fd7a:115c:a1e0::/48\""
             print "      ],"
             print "      \"stack\": \"mixed\","
-            print "      \"mtu\": 1400"
+            print "      \"mtu\": " tun_mtu ","
+            print "      \"udp_timeout\": \"" udp_timeout "\""
             printf "    }%s\n", comma
         }
         function emit_dns(comma) {
@@ -403,7 +411,7 @@ magicnet_singbox_apply_transparent_mode() {
             :
         else
             rm -f "$_tmp" "$_stage" "$_next" 2>/dev/null || true
-            unset _dns_strategy _jq _mode _singbox _stage _next
+            unset _dns_strategy _tun_mtu _udp_timeout _jq _mode _singbox _stage _next
             return 1
         fi
     fi
@@ -423,7 +431,7 @@ magicnet_singbox_apply_transparent_mode() {
             :
         else
             rm -f "$_tmp" "$_stage" "$_next" 2>/dev/null || true
-            unset _dns_strategy _jq _mode _singbox _stage _next
+            unset _dns_strategy _tun_mtu _udp_timeout _jq _mode _singbox _stage _next
             return 1
         fi
     fi
@@ -541,7 +549,7 @@ magicnet_singbox_apply_transparent_mode() {
             if (rule_action_sniff == 1) {
                 normalized = normalize_sniff_rule(normalized)
             }
-            if (dns_strategy == "ipv4_only" && is_managed_ipv6_guard()) return
+            if (is_managed_ipv6_guard()) return
             if (rule_action_sniff == 1) {
                 sniff_rules[++sniff_count] = normalized
             } else if (rule_action_hijack == 1) {
@@ -707,7 +715,7 @@ magicnet_singbox_apply_transparent_mode() {
         :
     elif [ -z "$_jq" ]; then
         rm -f "$_tmp" "$_stage" "$_next" 2>/dev/null || true
-        unset _dns_strategy _jq _mode _singbox _stage _next
+        unset _dns_strategy _tun_mtu _udp_timeout _jq _mode _singbox _stage _next
         return 1
     fi
     if [ -z "$_jq" ]; then
@@ -715,13 +723,13 @@ magicnet_singbox_apply_transparent_mode() {
             rm -f "$_next" 2>/dev/null || true
         else
             rm -f "$_stage" "$_next" 2>/dev/null || true
-            unset _dns_strategy _jq _mode _singbox _stage _next
+            unset _dns_strategy _tun_mtu _udp_timeout _jq _mode _singbox _stage _next
             return 1
         fi
     fi
     import __singbox__
     singbox_prepare_route_config "$_config" || true
-    unset _dns_strategy _jq _mode _singbox _stage _next
+    unset _dns_strategy _tun_mtu _udp_timeout _jq _mode _singbox _stage _next
 }
 
 magicnet_transparent_apply_unlocked() {

--- a/src/MagicNet/lib/magicnet/transparent_dns.sh
+++ b/src/MagicNet/lib/magicnet/transparent_dns.sh
@@ -1,3 +1,73 @@
+magicnet_network_policy_conf() {
+    printf '%s\n' "${MODDIR}/.config/magicnet/network-policy.conf"
+}
+
+magicnet_network_policy_value() {
+    _network_policy_key="$1"
+    _network_policy_conf="$(magicnet_network_policy_conf)"
+    [ -f "$_network_policy_conf" ] || {
+        unset _network_policy_key _network_policy_conf
+        return 1
+    }
+    if awk -F= -v key="$_network_policy_key" '
+        $1 == key {
+            value = substr($0, index($0, "=") + 1)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+            if (value ~ /^[A-Za-z0-9_-]+$/) {
+                print value
+                found = 1
+                exit
+            }
+        }
+        END { exit found ? 0 : 1 }
+    ' "$_network_policy_conf"; then
+        unset _network_policy_key _network_policy_conf
+        return 0
+    fi
+    unset _network_policy_key _network_policy_conf
+    return 1
+}
+
+magicnet_ipv6_mode() {
+    _ipv6_mode="${MAGICNET_IPV6_MODE:-}"
+    [ -n "$_ipv6_mode" ] || _ipv6_mode="$(magicnet_network_policy_value MAGICNET_IPV6_MODE 2>/dev/null || true)"
+    case "$_ipv6_mode" in
+        ipv4_only|prefer_ipv4|prefer_ipv6) ;;
+        ipv4-only|compat|disabled) _ipv6_mode="ipv4_only" ;;
+        prefer-ipv6) _ipv6_mode="prefer_ipv6" ;;
+        prefer-ipv4|auto|dual|"") _ipv6_mode="prefer_ipv4" ;;
+        *) _ipv6_mode="prefer_ipv4" ;;
+    esac
+    printf '%s\n' "$_ipv6_mode"
+    unset _ipv6_mode
+}
+
+magicnet_tun_mtu() {
+    _tun_mtu="${MAGICNET_TUN_MTU:-}"
+    [ -n "$_tun_mtu" ] || _tun_mtu="$(magicnet_network_policy_value MAGICNET_TUN_MTU 2>/dev/null || true)"
+    case "$_tun_mtu" in
+        ''|*[!0-9]*) _tun_mtu=1400 ;;
+        *)
+            if [ "$_tun_mtu" -lt 1280 ] || [ "$_tun_mtu" -gt 1500 ]; then
+                _tun_mtu=1400
+            fi
+            ;;
+    esac
+    printf '%s\n' "$_tun_mtu"
+    unset _tun_mtu
+}
+
+magicnet_udp_timeout() {
+    _udp_timeout="${MAGICNET_UDP_TIMEOUT:-}"
+    [ -n "$_udp_timeout" ] || _udp_timeout="$(magicnet_network_policy_value MAGICNET_UDP_TIMEOUT 2>/dev/null || true)"
+    case "$_udp_timeout" in
+        1m|3m|5m|10m|15m|30m) ;;
+        *) _udp_timeout="5m" ;;
+    esac
+    printf '%s\n' "$_udp_timeout"
+    unset _udp_timeout
+}
+
 magicnet_singbox_dns_strategy_for_mode() {
-    printf '%s\n' "ipv4_only"
+    magicnet_ipv6_mode
 }

--- a/webui/src/components/pages/NetworkPolicyCard.vue
+++ b/webui/src/components/pages/NetworkPolicyCard.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import { Network, RefreshCw, Save } from "lucide-vue-next";
+import Button from "@/components/ui/Button.vue";
+import Card from "@/components/ui/Card.vue";
+import { useActionLock } from "@/composables/useActionLock";
+import { useMagicNet } from "@/composables/useMagicNet";
+
+const { state, runCli } = useMagicNet();
+const { isRunning, withAction } = useActionLock();
+const ipv6Mode = ref("prefer_ipv4");
+const mtu = ref("1400");
+const udpTimeout = ref("5m");
+const effectiveMode = ref("unavailable");
+const effectiveStack = ref("unavailable");
+const effectiveMtu = ref("unavailable");
+const effectiveUdpTimeout = ref("unavailable");
+
+const modeHint = computed(() => {
+  if (ipv6Mode.value === "ipv4_only") return "兼容模式：屏蔽 IPv6，适合不支持 IPv6 的网络或代理节点。";
+  if (ipv6Mode.value === "prefer_ipv6") return "双栈模式：DNS 优先返回 IPv6，IPv4 仍可回退。";
+  return "推荐模式：保留完整双栈，DNS 优先返回 IPv4。";
+});
+
+function parseStatus(text: string): void {
+  const values = new Map<string, string>();
+  for (const line of text.split(/\r?\n/)) {
+    const separator = line.indexOf("=");
+    if (separator > 0) values.set(line.slice(0, separator), line.slice(separator + 1));
+  }
+  ipv6Mode.value = values.get("ipv6_mode") || "prefer_ipv4";
+  mtu.value = values.get("mtu") || "1400";
+  udpTimeout.value = values.get("udp_timeout") || "5m";
+  effectiveMode.value = values.get("effective_ipv6_mode") || "unavailable";
+  effectiveStack.value = values.get("effective_stack") || "unavailable";
+  effectiveMtu.value = values.get("effective_mtu") || "unavailable";
+  effectiveUdpTimeout.value = values.get("effective_udp_timeout") || "unavailable";
+}
+
+async function refreshStatus(silent = false): Promise<void> {
+  parseStatus(await runCli("network status", "读取 UDP / IPv6 策略", silent));
+}
+
+async function applyPolicy(): Promise<void> {
+  await withAction("network-policy", async () => {
+    const command = `network set ${ipv6Mode.value} ${mtu.value} ${udpTimeout.value}`;
+    const output = await runCli(command, "应用 UDP / IPv6 策略");
+    state.output = output;
+    if (!output.includes("[error]")) await refreshStatus(true);
+  });
+}
+
+onMounted(() => void refreshStatus(true));
+</script>
+
+<template>
+  <Card class="grid gap-3">
+    <div class="flex items-center justify-between gap-3">
+      <h3 class="inline-flex items-center gap-2 text-base font-semibold">
+        <Network :size="17" /> UDP / IPv6
+      </h3>
+      <Button size="sm" variant="outline" :loading="isRunning('network-refresh')" @click="withAction('network-refresh', () => refreshStatus())">
+        <RefreshCw :size="15" />刷新
+      </Button>
+    </div>
+    <p class="text-sm leading-6 text-[var(--mn-ink-muted)]">
+      调整 TUN 双栈、MTU 和 UDP 会话保持时间。应用会重建 sing-box 运行配置。
+    </p>
+    <label class="grid gap-1 text-xs text-[var(--mn-ink-muted)]">
+      IPv6 策略
+      <select v-model="ipv6Mode" class="h-10 rounded-md border bg-transparent px-3 text-sm text-[var(--mn-ink)]">
+        <option value="prefer_ipv4">双栈 · IPv4 优先（推荐）</option>
+        <option value="prefer_ipv6">双栈 · IPv6 优先</option>
+        <option value="ipv4_only">仅 IPv4 · 兼容模式</option>
+      </select>
+    </label>
+    <p class="rounded-md bg-[var(--mn-ivory)] px-3 py-2 text-xs leading-5 text-[var(--mn-ink-muted)]">
+      {{ modeHint }}
+    </p>
+    <div class="grid gap-3 sm:grid-cols-2">
+      <label class="grid gap-1 text-xs text-[var(--mn-ink-muted)]">
+        TUN MTU
+        <select v-model="mtu" class="h-10 rounded-md border bg-transparent px-3 text-sm text-[var(--mn-ink)]">
+          <option value="1280">1280 · IPv6 最稳妥</option>
+          <option value="1400">1400 · 推荐</option>
+          <option value="1500">1500 · 标准以太网</option>
+        </select>
+      </label>
+      <label class="grid gap-1 text-xs text-[var(--mn-ink-muted)]">
+        UDP 会话超时
+        <select v-model="udpTimeout" class="h-10 rounded-md border bg-transparent px-3 text-sm text-[var(--mn-ink)]">
+          <option value="1m">1 分钟</option>
+          <option value="3m">3 分钟</option>
+          <option value="5m">5 分钟 · 推荐</option>
+          <option value="10m">10 分钟</option>
+          <option value="15m">15 分钟</option>
+          <option value="30m">30 分钟</option>
+        </select>
+      </label>
+    </div>
+    <Button :loading="isRunning('network-policy')" @click="applyPolicy">
+      <Save :size="16" />保存并应用
+    </Button>
+    <pre class="overflow-auto rounded-md bg-[var(--mn-carrier-deep)] p-3 text-xs leading-6 text-[var(--mn-ink-soft)]">effective_ipv6_mode={{ effectiveMode }}
+effective_stack={{ effectiveStack }}
+effective_mtu={{ effectiveMtu }}
+effective_udp_timeout={{ effectiveUdpTimeout }}</pre>
+  </Card>
+</template>

--- a/webui/src/components/pages/ToolsPage.vue
+++ b/webui/src/components/pages/ToolsPage.vue
@@ -13,6 +13,7 @@ import ToolActionConfirmCard from "./ToolActionConfirmCard.vue";
 import DnsToolsCard from "./DnsToolsCard.vue";
 import EcaptureToolsCard from "./EcaptureToolsCard.vue";
 import McpToolsCard from "./McpToolsCard.vue";
+import NetworkPolicyCard from "./NetworkPolicyCard.vue";
 import NetworkSnapshotPanel from "./NetworkSnapshotPanel.vue";
 import WarpRouteRulesPanel from "./WarpRouteRulesPanel.vue";
 import { summarizeBackupPayload } from "./backupPayloadSummary";
@@ -313,6 +314,8 @@ function selectWarpGlobal(enabled: boolean): void {
     />
 
     <div class="grid min-w-0 gap-3 md:grid-cols-2">
+      <NetworkPolicyCard />
+
       <DnsToolsCard />
 
       <Card class="grid gap-3">


### PR DESCRIPTION
## Summary

- change the runtime default from hard-coded `ipv4_only` to dual stack with `prefer_ipv4`
- keep `mixed` TUN (`system` TCP + gVisor UDP), and make MTU/UDP timeout configurable
- add `cli network status|set|apply` with validated modes, MTU `1280..1500`, and bounded UDP timeout presets
- add a WebUI **UDP / IPv6** card with recommended and compatibility presets
- remove stale MagicNet-managed IPv6 guards when switching back to dual stack
- add `UDP/IPv6` health evidence and flag guard/strategy contradictions
- include the policy in encrypted configuration backup/restore with a strict allowlist
- update the MagicSingBox submodule to LIghtJUNction/MagicSingBox#7

## Defaults and rationale

- IPv6: `prefer_ipv4` (dual stack, IPv4-preferred DNS)
- compatibility fallback: `ipv4_only`
- TUN stack: `mixed`
- MTU: `1400` (allowed range `1280..1500`)
- UDP timeout: `5m`

Per the [sing-box 1.13 TUN documentation](https://sing-box.sagernet.org/configuration/inbound/tun/), `mixed` uses the system stack for TCP and gVisor for UDP. Endpoint-independent NAT is already the default outside the pure gVisor stack, so this change does not enable the performance-costly compatibility toggle.

## Verification

- `cargo test -p magicnet-cli -- --test-threads=1 --skip selector_store::tests::live_owner_never_expires_by_age` — 293 passed, 1 filtered (the filtered pre-existing `/proc` owner-liveness test is incompatible with this container)
- `cargo clippy -p magicnet-cli --all-targets` — no new warnings
- `npm run check` — 16 frontend tests, TypeScript check, and production build passed
- `scripts/orchestrator-mode-smoke.sh`
- `scripts/test-default-routing-policy.sh`
- `sing-box 1.13.14 check -D <config-dir> -c config.json`
- shell syntax checks and `git diff --check`

## Manual checks after install

```sh
cli network status
cli network set prefer_ipv4 1400 5m
cli network set ipv4_only 1400 5m
cli health
```

The second command should leave the IPv6 TUN address active without a global IPv6 reject rule; the third should add exactly one managed guard.

## Summary by Sourcery

通过 CLI、WebUI 和健康诊断公开一个可配置的 UDP/IPv6 网络策略（默认为双栈），并确保配置、测试以及打包流程统一执行该新策略。

New Features:
- 添加 `cli network` 命令，用于查看、设置并应用经过验证的 IPv6 模式、TUN MTU 和 UDP 超时预设。
- 暴露一个 UDP/IPv6 健康检查项，用于报告 sing-box 的有效网络策略，并标记策略不一致情况。
- 在 WebUI 中添加 UDP / IPv6 卡片，用于调节 IPv6 策略、TUN MTU 和 UDP 超时，并展示运行时生效的网络设置。
- 在加密的备份/恢复流程中纳入网络策略配置，并进行严格的模式（schema）校验。

Bug Fixes:
- 在双栈策略下，当残留或意外的由 MagicNet 管理的 IPv6 拒绝防护规则存在时，检测并使健康检查失败。
- 确保双栈默认和打包配置不再在 `ipv4_only` 兼容模式之外包含受管的 IPv6 拒绝防护规则。

Enhancements:
- 将默认设置改为双栈、IPv4 优先 DNS、混合 TUN 栈、MTU 1400 和 5 分钟 UDP 超时，并通过 CLI、脚本和 WebUI 流程强制执行这些默认值。
- 规范旧版 IPv6 模式别名，并在 shell 脚本、CLI 和测试之间统一 MTU/UDP 超时的校验逻辑。
- 增强诊断能力，详细展示 UDP/IPv6 策略相关信息，包括 DNS 策略、TUN 栈、MTU、UDP 超时、IPv6 地址存在情况以及防护规则状态。

Documentation:
- 文档化新的 UDP/IPv6 默认策略、CLI `network` 的用法，以及 WebUI 中用于在双栈和 `ipv4_only` 兼容模式之间切换的控制项。

Tests:
- 新增并更新 CLI、编排器、路由以及打包的冒烟测试，用于验证标准的双栈 UDP/IPv6 策略、MTU/超时边界、防护规则处理，以及调整后的路由规则索引。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce configurable UDP/IPv6 network policy with dual-stack defaults, exposed via CLI, WebUI, and health diagnostics, and ensure configs, tests, and packaging enforce the new policy.

New Features:
- Add a `cli network` command to view, set, and apply validated IPv6 mode, TUN MTU, and UDP timeout presets.
- Expose a UDP/IPv6 health check item that reports the effective sing-box network policy and flags policy inconsistencies.
- Add a WebUI UDP / IPv6 card to adjust IPv6 strategy, TUN MTU, and UDP timeout and display the effective runtime network settings.
- Include network-policy configuration in encrypted backup/restore with strict schema validation.

Bug Fixes:
- Detect and fail health checks when stale or unexpected MagicNet-managed IPv6 reject guards remain under dual-stack strategies.
- Ensure dual-stack default and packaged configs no longer include managed IPv6 IPv6-reject guards outside the ipv4_only compatibility mode.

Enhancements:
- Change defaults to dual-stack with IPv4-preferred DNS, mixed TUN stack, MTU 1400, and 5m UDP timeout, and enforce these via CLI, scripts, and WebUI flows.
- Normalize legacy IPv6 mode aliases and centralize MTU/UDP-timeout validation across shell scripts, CLI, and tests.
- Enhance diagnostics to surface detailed UDP/IPv6 policy evidence, including DNS strategy, TUN stack, MTU, UDP timeout, IPv6 address presence, and guard status.

Documentation:
- Document the new default UDP/IPv6 strategy, CLI `network` usage, and WebUI controls for switching between dual-stack and ipv4_only compatibility modes.

Tests:
- Add and update CLI, orchestrator, routing, and packaging smoke tests to validate the canonical dual-stack UDP/IPv6 policy, MTU/timeout bounds, guard handling, and adjusted routing rule indexes.

</details>

新特性：
- 新增 CLI `network` 命令，用于查看、设置并应用已验证的 IPv6 模式、TUN MTU 和 UDP 超时预设。
- 在健康诊断中暴露一个 UDP/IPv6 状态项，依据实际生效的 sing-box 网络策略进行报告。
- 在 WebUI 中提供一个 UDP / IPv6 卡片，用于调整 IPv6 策略、TUN MTU 和 UDP 超时，并展示当前运行时生效的网络策略。
- 将网络策略配置文件纳入加密备份/恢复流程，并进行严格的模式（schema）校验。

缺陷修复：
- 当在双栈策略下仍存在过期或意外的由 MagicNet 管理的 IPv6 拒绝防护规则时，在健康诊断中进行检测并使其失败。
- 确保在非 `ipv4_only` 兼容模式下，双栈默认配置和打包产物中不再包含受管的 IPv6 防护规则。

改进增强：
- 将默认值调整为双栈、IPv4 优先的 DNS 策略，混合 TUN 栈、MTU 1400、UDP 超时 5 分钟，并通过 CLI 和 WebUI 流程强制执行这些默认值。
- 规范旧有 IPv6 模式别名，并在 shell 脚本、CLI 和测试中统一校验 MTU 和 UDP 超时范围。
- 扩展诊断能力，报告更详细的网络策略证据，包括 DNS 策略、TUN 栈、MTU、UDP 超时、IPv6 地址是否存在，以及受管防护规则状态。

文档：
- 更新 README 指南，描述新的默认 UDP/IPv6 策略、CLI `network` 的使用方式，以及 WebUI 中在双栈和 `ipv4_only` 兼容模式之间切换的控制项。

测试：
- 新增 CLI 测试，用于验证网络策略和围绕双栈接受性及过期 IPv6 防护规则的健康检查。
- 更新编排器、默认路由以及打包冒烟测试，以断言规范的双栈 UDP/IPv6 策略、MTU/超时设置，以及调整后的路由规则索引。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过 CLI、WebUI 和健康诊断公开一个可配置的 UDP/IPv6 网络策略（默认为双栈），并确保配置、测试以及打包流程统一执行该新策略。

New Features:
- 添加 `cli network` 命令，用于查看、设置并应用经过验证的 IPv6 模式、TUN MTU 和 UDP 超时预设。
- 暴露一个 UDP/IPv6 健康检查项，用于报告 sing-box 的有效网络策略，并标记策略不一致情况。
- 在 WebUI 中添加 UDP / IPv6 卡片，用于调节 IPv6 策略、TUN MTU 和 UDP 超时，并展示运行时生效的网络设置。
- 在加密的备份/恢复流程中纳入网络策略配置，并进行严格的模式（schema）校验。

Bug Fixes:
- 在双栈策略下，当残留或意外的由 MagicNet 管理的 IPv6 拒绝防护规则存在时，检测并使健康检查失败。
- 确保双栈默认和打包配置不再在 `ipv4_only` 兼容模式之外包含受管的 IPv6 拒绝防护规则。

Enhancements:
- 将默认设置改为双栈、IPv4 优先 DNS、混合 TUN 栈、MTU 1400 和 5 分钟 UDP 超时，并通过 CLI、脚本和 WebUI 流程强制执行这些默认值。
- 规范旧版 IPv6 模式别名，并在 shell 脚本、CLI 和测试之间统一 MTU/UDP 超时的校验逻辑。
- 增强诊断能力，详细展示 UDP/IPv6 策略相关信息，包括 DNS 策略、TUN 栈、MTU、UDP 超时、IPv6 地址存在情况以及防护规则状态。

Documentation:
- 文档化新的 UDP/IPv6 默认策略、CLI `network` 的用法，以及 WebUI 中用于在双栈和 `ipv4_only` 兼容模式之间切换的控制项。

Tests:
- 新增并更新 CLI、编排器、路由以及打包的冒烟测试，用于验证标准的双栈 UDP/IPv6 策略、MTU/超时边界、防护规则处理，以及调整后的路由规则索引。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce configurable UDP/IPv6 network policy with dual-stack defaults, exposed via CLI, WebUI, and health diagnostics, and ensure configs, tests, and packaging enforce the new policy.

New Features:
- Add a `cli network` command to view, set, and apply validated IPv6 mode, TUN MTU, and UDP timeout presets.
- Expose a UDP/IPv6 health check item that reports the effective sing-box network policy and flags policy inconsistencies.
- Add a WebUI UDP / IPv6 card to adjust IPv6 strategy, TUN MTU, and UDP timeout and display the effective runtime network settings.
- Include network-policy configuration in encrypted backup/restore with strict schema validation.

Bug Fixes:
- Detect and fail health checks when stale or unexpected MagicNet-managed IPv6 reject guards remain under dual-stack strategies.
- Ensure dual-stack default and packaged configs no longer include managed IPv6 IPv6-reject guards outside the ipv4_only compatibility mode.

Enhancements:
- Change defaults to dual-stack with IPv4-preferred DNS, mixed TUN stack, MTU 1400, and 5m UDP timeout, and enforce these via CLI, scripts, and WebUI flows.
- Normalize legacy IPv6 mode aliases and centralize MTU/UDP-timeout validation across shell scripts, CLI, and tests.
- Enhance diagnostics to surface detailed UDP/IPv6 policy evidence, including DNS strategy, TUN stack, MTU, UDP timeout, IPv6 address presence, and guard status.

Documentation:
- Document the new default UDP/IPv6 strategy, CLI `network` usage, and WebUI controls for switching between dual-stack and ipv4_only compatibility modes.

Tests:
- Add and update CLI, orchestrator, routing, and packaging smoke tests to validate the canonical dual-stack UDP/IPv6 policy, MTU/timeout bounds, guard handling, and adjusted routing rule indexes.

</details>

</details>