### PR TITLE
fix: allow public IP subscription URLs

### DIFF
--- a/crates/magicnet-cli/src/subscriptions.rs
+++ b/crates/magicnet-cli/src/subscriptions.rs
@@ -143,7 +143,7 @@ pub fn sub_resolve_host(args: &[String]) -> Result<(), String> {
     if host.is_empty() || port.is_empty() {
         return Err("Usage: cli sub resolve-host <hostname> <port>".to_string());
     }
-    validate_subscription_hostname(host)?;
+    validate_subscription_host(host)?;
     let port = parse_subscription_port(port)?;
     let resolved = (host, port)
         .to_socket_addrs()
@@ -644,7 +644,7 @@ fn parse_subscription_authority(url: &str) -> Result<SubscriptionAuthority<'_>, 
         if host.contains(':') {
             return Err("Subscription URL has an invalid authority".to_string());
         }
-        validate_subscription_hostname(host)?;
+        validate_subscription_host(host)?;
         (host, parse_subscription_port(port_suffix)?)
     };
 
@@ -668,7 +668,14 @@ fn parse_subscription_port(suffix: &str) -> Result<u16, String> {
     Ok(port)
 }
 
-fn validate_subscription_hostname(host: &str) -> Result<(), String> {
+fn validate_subscription_host(host: &str) -> Result<(), String> {
+    if let Ok(address) = IpAddr::from_str(host) {
+        return if is_public_subscription_address(address) {
+            Ok(())
+        } else {
+            Err("Subscription URL must not target a private or special-use address".to_string())
+        };
+    }
     if host.is_empty()
         || host.len() > 253
         || host.starts_with('.')
@@ -765,11 +772,29 @@ mod tests {
     fn subscription_url_validation_requires_public_https_without_credentials() {
         validate_subscription_url("https://example.com/sub?profile=abc").unwrap();
         validate_subscription_url("https://example.com:8443/sub").unwrap();
+        validate_subscription_url("https://1.1.1.1/sub").unwrap();
+        validate_subscription_url("https://8.8.8.8:8443/sub").unwrap();
+        validate_subscription_url("https://[2606:4700:4700::1111]/sub").unwrap();
         assert!(validate_subscription_url("http://example.com/sub").is_err());
         assert!(validate_subscription_url("https://user:secret@example.com/sub").is_err());
         assert!(validate_subscription_url("https://127.0.0.1:8080/sub").is_err());
+        assert!(validate_subscription_url("https://[::1]/sub").is_err());
+        assert!(validate_subscription_url("https://1.1/sub").is_err());
         assert!(validate_subscription_url("ftp://example.com/sub").is_err());
         assert!(validate_subscription_url("https://example.com/a b").is_err());
+    }
+
+    #[test]
+    fn subscription_host_validation_accepts_public_ip_literals_only() {
+        for host in ["1.1.1.1", "2606:4700:4700::1111", "example.com"] {
+            validate_subscription_host(host).unwrap();
+        }
+        for host in ["127.0.0.1", "::1", "192.168.1.1", "1.1", "0x7f000001"] {
+            assert!(
+                validate_subscription_host(host).is_err(),
+                "{host} must be rejected"
+            );
+        }
     }
 
     #[test]

--- a/scripts/test-subscription-fetch-policy.sh
+++ b/scripts/test-subscription-fetch-policy.sh
@@ -74,6 +74,12 @@ if grep -q -- '--proxy' "$tmp/log"; then
 fi
 test "$(cat "$tmp/direct")" = ok
 : >"$tmp/log"
+PATH="$tmp/bin:$PATH" \
+  magicnet_singbox_try_fetch_subscription https://1.1.1.1:8443/sub "$tmp/public-ip" 2 7
+grep -q '^resolver sub resolve-host 1.1.1.1 8443$' "$tmp/log"
+grep -q 'curl .*--resolve 1.1.1.1:8443:1.1.1.1' "$tmp/log"
+test "$(cat "$tmp/public-ip")" = ok
+: >"$tmp/log"
 if MAGICNET_RESOLVE_RESULT=private PATH="$tmp/bin:$PATH" \
   magicnet_singbox_try_fetch_subscription https://example.invalid/sub "$tmp/private" 2 7; then
   exit 1


### PR DESCRIPTION
## Summary

- accept canonical public IPv4 and bracketed IPv6 literals in HTTPS subscription URLs
- route literal addresses through the existing public-address policy so private, loopback, link-local, multicast, and other blocked ranges remain rejected
- add URL-policy and downloader regression coverage for public IP subscriptions with explicit ports

## Root cause

The URL parser sent every unbracketed host through a hostname-only validator. Canonical IPv4 literals were therefore rejected as numeric hostnames before the existing public-address check could approve them. The resolver path had the same hostname-only restriction, so literal IPv6 addresses could validate initially but fail during refresh.

## Validation

- `git diff --check`
- `bash -n scripts/test-subscription-fetch-policy.sh`
- `bash -n src/MagicNet/lib/magicnet/singbox_subscribe/fetch.sh`
- the new public-IP downloader regression completed successfully during the fetch-policy run
- the container does not include Cargo; the full Rust suite is left to GitHub Actions
- the full shell script later encountered its pre-existing `/proc/<pid>/exe` ownership fixture limitation in this container

Closes #73

## Summary by Sourcery

允许 HTTPS 订阅 URL 使用规范的公共 IP 字面量，同时继续阻止私有和特殊用途地址。

New Features:
- 在 HTTPS URL 中支持将公共 IPv4 和加括号的 IPv6 字面量作为订阅主机。

Bug Fixes:
- 确保订阅主机校验在处理 IP 字面量时，正确走公共地址策略，而不是将其作为无效主机名拒绝。

Enhancements:
- 为订阅主机校验添加测试，并为带显式端口的公共 IP 订阅添加抓取策略回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow HTTPS subscription URLs to use canonical public IP literals while keeping private and special-use addresses blocked.

New Features:
- Support public IPv4 and bracketed IPv6 literals as subscription hosts in HTTPS URLs.

Bug Fixes:
- Ensure subscription host validation correctly routes IP literals through the public-address policy instead of rejecting them as invalid hostnames.

Enhancements:
- Add subscription host validation tests and fetch-policy regression coverage for public IP subscriptions with explicit ports.

</details>