### PR TITLE
fix: prevent sing-box subscription activation stalls

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -40,6 +40,8 @@ bash scripts/test-wechat-routing.sh
 bash scripts/test-action-routing.sh
 bash scripts/test-anthropic-routing.sh
 bash scripts/singbox-subscription-protocol-smoke.sh
+bash scripts/test-singbox-pid-discovery.sh
+bash scripts/test-subscription-activation-order.sh
 bash scripts/test-subscription-lifecycle.sh
 bash scripts/test-release-integrity.sh
 

--- a/scripts/test-singbox-pid-discovery.sh
+++ b/scripts/test-singbox-pid-discovery.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+
+export MODDIR="$fixture/module"
+mkdir -p "$MODDIR" "$fixture/bin" "$fixture/proc/101" "$fixture/proc/202" "$fixture/proc/303"
+
+magicnet_json_escape() { printf '%s' "$1"; }
+. "$ROOT/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh"
+
+pidof_log="$fixture/pidof.log"
+cat >"$fixture/bin/pidof" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >>"$PIDOF_LOG"
+printf '%s\n' "${PIDOF_RESULT:-202 101 invalid}"
+exit "${PIDOF_RC:-0}"
+EOF
+chmod +x "$fixture/bin/pidof"
+
+pid_output="$(
+  PIDOF_LOG="$pidof_log" PIDOF_RESULT='202 101 invalid' \
+    PATH="$fixture/bin:$PATH" magicnet_singbox_pids
+)"
+test "$pid_output" = $'202\n101'
+test "$(cat "$pidof_log")" = sing-box
+
+# An installed pidof is authoritative even when no process exists. Falling
+# through to /proc here would reintroduce a full scan in every stop-wait poll.
+printf 'sing-box\n' >"$fixture/proc/303/comm"
+: >"$pidof_log"
+pid_output="$(
+  PIDOF_LOG="$pidof_log" PIDOF_RESULT= PIDOF_RC=1 \
+    MAGICNET_SINGBOX_PROC_ROOT="$fixture/proc" \
+    PATH="$fixture/bin:$PATH" magicnet_singbox_pids
+)"
+test -z "$pid_output"
+test "$(cat "$pidof_log")" = sing-box
+
+# The fallback must use the shell read builtin. A cat override makes any
+# per-process external cat regression fail deterministically.
+printf 'sing-box\n' >"$fixture/proc/101/comm"
+printf 'sh\n' >"$fixture/proc/202/comm"
+pid_output="$(
+  cat() {
+    printf 'cat must not be used for proc comm discovery\n' >&2
+    return 99
+  }
+  PATH= MAGICNET_SINGBOX_PROC_ROOT="$fixture/proc" magicnet_singbox_pids
+)"
+test "$pid_output" = $'101\n303'
+
+printf 'sing-box pid discovery test passed\n'

--- a/scripts/test-subscription-activation-order.sh
+++ b/scripts/test-subscription-activation-order.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+
+export MODDIR="$fixture/module"
+mkdir -p "$MODDIR"
+events="$fixture/events"
+: >"$events"
+
+magicnet_json_escape() { printf '%s' "$1"; }
+. "$ROOT/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh"
+. "$ROOT/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh"
+
+# A subscription-owned restart records the prior fswatch state without
+# restoring it while the caller still owns the config transaction.
+magicnet_supervisors_stop() { :; }
+magicnet_singbox_owned_pids() { :; }
+magicnet_singbox_ensure_start_owned() { :; }
+ss() { :; }
+ip() { :; }
+magicnet_fswatch_start() { printf 'restore-lock=%s\n' "$CONFIG_LOCK_HELD" >>"$events"; }
+magicnet_fswatch_status() { return 0; }
+
+MAGICNET_SUB_FSWATCH_WAS_ACTIVE=1
+MAGICNET_SUB_DEFER_FSWATCH_RESTORE=1
+MAGICNET_SUB_FSWATCH_RESTORE_PENDING=0
+magicnet_singbox_restart_owned "$MODDIR/config.json"
+test "$MAGICNET_SUB_FSWATCH_RESTORE_PENDING" -eq 1
+test ! -s "$events"
+unset MAGICNET_SUB_FSWATCH_WAS_ACTIVE MAGICNET_SUB_DEFER_FSWATCH_RESTORE
+
+# The update wrapper restores fswatch after magicnet_with_config_lock returns.
+CONFIG_LOCK_HELD=0
+magicnet_singbox_update_lock_acquire() { :; }
+magicnet_singbox_update_lock_release() { :; }
+magicnet_singbox_transaction_reconcile() { :; }
+magicnet_singbox_cleanup_stale_candidates() { :; }
+magicnet_singbox_update_cleanup_stage() { :; }
+magicnet_singbox_update_status() { :; }
+error() { :; }
+magicnet_with_config_lock() {
+  CONFIG_LOCK_HELD=1
+  "$@"
+  local rc=$?
+  CONFIG_LOCK_HELD=0
+  return "$rc"
+}
+magicnet_singbox_update_subscription_unlocked() {
+  test "$MAGICNET_SUB_DEFER_FSWATCH_RESTORE" -eq 1
+  printf 'transaction-lock=%s\n' "$CONFIG_LOCK_HELD" >>"$events"
+  MAGICNET_SUB_FSWATCH_RESTORE_PENDING=1
+}
+
+MAGICNET_SUB_FSWATCH_RESTORE_PENDING=0
+magicnet_singbox_update_subscription
+test "$(tr '\n' ' ' <"$events")" = 'transaction-lock=1 restore-lock=0 '
+test -z "${MAGICNET_SUB_DEFER_FSWATCH_RESTORE+x}"
+test -z "${MAGICNET_SUB_FSWATCH_RESTORE_PENDING+x}"
+
+printf 'subscription activation order test passed\n'

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
@@ -752,13 +752,29 @@ magicnet_singbox_replay_cached_outbounds() {
 }
 
 magicnet_singbox_pids() {
-    for _proc_comm in /proc/[0-9]*/comm; do
+    if command -v pidof >/dev/null 2>&1; then
+        _singbox_pid_list=$(pidof sing-box 2>/dev/null) || _singbox_pid_list=
+        # shellcheck disable=SC2086 # pidof returns a whitespace-separated PID list.
+        for _pid in $_singbox_pid_list; do
+            case "$_pid" in
+                *[!0-9]* | '') continue ;;
+            esac
+            printf '%s\n' "$_pid"
+        done
+        unset _singbox_pid_list _pid
+        return 0
+    fi
+
+    _singbox_proc_root="${MAGICNET_SINGBOX_PROC_ROOT:-/proc}"
+    for _proc_comm in "$_singbox_proc_root"/[0-9]*/comm; do
         [ -r "$_proc_comm" ] || continue
-        if [ "$(cat "$_proc_comm" 2>/dev/null)" = "sing-box" ]; then
-            _pid=${_proc_comm#/proc/}
+        if IFS= read -r _proc_name <"$_proc_comm" 2>/dev/null &&
+            [ "$_proc_name" = "sing-box" ]; then
+            _pid=${_proc_comm#"$_singbox_proc_root"/}
             printf '%s\n' "${_pid%/comm}"
         fi
     done
+    unset _singbox_proc_root _proc_comm _proc_name _pid
 }
 
 magicnet_singbox_is_running() {
@@ -828,9 +844,19 @@ magicnet_singbox_listener_owned() {
 }
 
 magicnet_singbox_supervisor_restore() {
-    [ "${_owned_fswatch_active:-0}" -eq 1 ] || return 0
-    magicnet_fswatch_start >/dev/null 2>&1 || return 1
+    _restore_fswatch_active="${1:-${_owned_fswatch_active:-0}}"
+    [ "$_restore_fswatch_active" -eq 1 ] || {
+        unset _restore_fswatch_active
+        return 0
+    }
+    if ! magicnet_fswatch_start >/dev/null 2>&1; then
+        unset _restore_fswatch_active
+        return 1
+    fi
     magicnet_fswatch_status >/dev/null 2>&1
+    _restore_rc=$?
+    unset _restore_fswatch_active
+    return "$_restore_rc"
 }
 
 magicnet_singbox_ensure_start_owned() {
@@ -888,7 +914,13 @@ magicnet_singbox_restart_owned() {
         ip link delete tun0 2>/dev/null || true
         magicnet_singbox_ensure_start_owned "$_owned_config" || _restart_rc=1
     fi
-    magicnet_singbox_supervisor_restore || _restart_rc=1
+    if [ "${MAGICNET_SUB_DEFER_FSWATCH_RESTORE:-0}" -eq 1 ]; then
+        # Read by the subscription update wrapper after it releases the config lock.
+        # shellcheck disable=SC2034
+        MAGICNET_SUB_FSWATCH_RESTORE_PENDING="$_owned_fswatch_active"
+    else
+        magicnet_singbox_supervisor_restore "$_owned_fswatch_active" || _restart_rc=1
+    fi
     return "$_restart_rc"
 }
 

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
@@ -362,12 +362,24 @@ magicnet_singbox_update_subscription() {
         return 1
     fi
     magicnet_singbox_cleanup_stale_candidates "${MAGICNET_SUB_CANDIDATE_URL_FILE:-}"
+    # Read by magicnet_singbox_restart_owned in config.sh.
+    # shellcheck disable=SC2034
+    MAGICNET_SUB_DEFER_FSWATCH_RESTORE=1
+    MAGICNET_SUB_FSWATCH_RESTORE_PENDING=0
     magicnet_with_config_lock magicnet_singbox_update_subscription_unlocked
     _update_rc=$?
+    unset MAGICNET_SUB_DEFER_FSWATCH_RESTORE
     if [ "$_update_rc" -ne 0 ]; then
         magicnet_with_config_lock magicnet_singbox_transaction_reconcile >/dev/null 2>&1 || true
         magicnet_singbox_update_cleanup_stage
     fi
+    if [ "${MAGICNET_SUB_FSWATCH_RESTORE_PENDING:-0}" -eq 1 ] &&
+        ! magicnet_singbox_supervisor_restore 1; then
+        _update_rc=1
+        magicnet_singbox_update_status complete failed fswatch_restore_failed || true
+        error "fswatch failed to restart after subscription update"
+    fi
+    unset MAGICNET_SUB_FSWATCH_RESTORE_PENDING
     trap - EXIT HUP INT TERM
     magicnet_singbox_update_lock_release
     return "$_update_rc"


### PR DESCRIPTION
## Summary

- prefer Android `pidof` for sing-box process discovery
- use the shell `read` builtin for the `/proc/*/comm` fallback, avoiding one `cat` process per PID
- restore fswatch only after the subscription transaction releases the config lock
- add regression coverage for both PID discovery paths and fswatch restoration order

## Root cause

The activation path repeatedly called `magicnet_singbox_pids` while waiting for the old core to stop. Each call scanned all process entries and spawned an external `cat` for every readable `/proc/<pid>/comm`, multiplying process creation across the stop/kill polling loops and making `cli sub update sing-box` appear stuck.

fswatch was also restored from inside the core restart while the surrounding subscription transaction still held the config lock, allowing a concurrent config apply during the remaining commit steps.

## Validation

- `bash scripts/test-singbox-pid-discovery.sh`
- `bash scripts/test-subscription-activation-order.sh`
- POSIX/Bash syntax checks for changed scripts
- `git diff --check`

The full Rust/KAM suite is left to GitHub Actions because `cargo`, `kam`, and `shellcheck` are unavailable in the local runner.

Fixes #75

## Summary by Sourcery

优化 sing-box 订阅激活流程，避免进程发现阻塞，并确保仅在订阅配置事务完成后才恢复 fswatch。

Bug Fixes:
- 通过减少核心重启轮询期间的重复进程扫描和外部命令调用，防止 sing-box 订阅激活看起来卡住不动。
- 确保仅在订阅事务释放配置锁后才重新启动 fswatch，避免在提交步骤期间出现并发配置更改。

Enhancements:
- 改进 sing-box PID 发现机制，在可用时优先使用 Android 的 `pidof`，并收紧 PID 校验逻辑，同时提供可配置的 `/proc` 根目录回退方案。
- 优化 supervisor 恢复处理逻辑，接受显式的 fswatch 激活标志，并向调用方准确传播状态码。

Tests:
- 添加 bash 测试，覆盖通过 `pidof` 和 `/proc` 回退两种方式进行的 sing-box PID 发现，并包含针对外部 `cat` 使用的回归检查。
- 添加订阅激活顺序测试，以验证 fswatch 恢复操作发生在配置锁释放之后，并确认相关环境标志已被清理。
- 扩展 pre-commit 脚本以运行新的 sing-box PID 发现测试和订阅激活顺序测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize sing-box subscription activation to avoid process discovery stalls and ensure fswatch is restored only after the subscription config transaction completes.

Bug Fixes:
- Prevent sing-box subscription activation from appearing stuck by reducing repeated process scans and external command spawning during core restart polling.
- Ensure fswatch is restarted only after the subscription transaction releases the config lock, avoiding concurrent configuration changes during commit steps.

Enhancements:
- Improve sing-box PID discovery by preferring Android pidof when available and tightening PID validation, with a configurable /proc root fallback.
- Refine supervisor restore handling to accept an explicit fswatch-active flag and propagate accurate status codes back to callers.

Tests:
- Add bash tests covering sing-box PID discovery via both pidof and /proc fallback, including regression checks against external cat usage.
- Add a subscription activation order test to verify fswatch restoration occurs after the config lock is released and that related environment flags are cleaned up.
- Extend the pre-commit script to run the new sing-box PID discovery and subscription activation order tests.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化 sing-box 订阅激活流程，避免进程发现阻塞，并确保仅在订阅配置事务完成后才恢复 fswatch。

Bug Fixes:
- 通过减少核心重启轮询期间的重复进程扫描和外部命令调用，防止 sing-box 订阅激活看起来卡住不动。
- 确保仅在订阅事务释放配置锁后才重新启动 fswatch，避免在提交步骤期间出现并发配置更改。

Enhancements:
- 改进 sing-box PID 发现机制，在可用时优先使用 Android 的 `pidof`，并收紧 PID 校验逻辑，同时提供可配置的 `/proc` 根目录回退方案。
- 优化 supervisor 恢复处理逻辑，接受显式的 fswatch 激活标志，并向调用方准确传播状态码。

Tests:
- 添加 bash 测试，覆盖通过 `pidof` 和 `/proc` 回退两种方式进行的 sing-box PID 发现，并包含针对外部 `cat` 使用的回归检查。
- 添加订阅激活顺序测试，以验证 fswatch 恢复操作发生在配置锁释放之后，并确认相关环境标志已被清理。
- 扩展 pre-commit 脚本以运行新的 sing-box PID 发现测试和订阅激活顺序测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize sing-box subscription activation to avoid process discovery stalls and ensure fswatch is restored only after the subscription config transaction completes.

Bug Fixes:
- Prevent sing-box subscription activation from appearing stuck by reducing repeated process scans and external command spawning during core restart polling.
- Ensure fswatch is restarted only after the subscription transaction releases the config lock, avoiding concurrent configuration changes during commit steps.

Enhancements:
- Improve sing-box PID discovery by preferring Android pidof when available and tightening PID validation, with a configurable /proc root fallback.
- Refine supervisor restore handling to accept an explicit fswatch-active flag and propagate accurate status codes back to callers.

Tests:
- Add bash tests covering sing-box PID discovery via both pidof and /proc fallback, including regression checks against external cat usage.
- Add a subscription activation order test to verify fswatch restoration occurs after the config lock is released and that related environment flags are cleaned up.
- Extend the pre-commit script to run the new sing-box PID discovery and subscription activation order tests.

</details>

</details>