### PR TITLE
feat: distinguish Direct routing from Bypass TUN

### DIFF
--- a/crates/magicnet-cli/src/main.rs
+++ b/crates/magicnet-cli/src/main.rs
@@ -189,7 +189,7 @@ const COMMAND_HELP: &[CommandHelp] = &[
     },
     CommandHelp {
         command: "app",
-        usage: "cli app {list|packages [query]|mode <blacklist|whitelist>|add <package> [proxy|bypass]|add-many <proxy|bypass> <package...>|remove <package>|apply}",
+        usage: "cli app {list|packages [query]|mode <blacklist|whitelist>|add <package> [proxy|direct|bypass]|add-many <proxy|direct|bypass> <package...>|remove <package> [proxy|direct|bypass]|apply}",
     },
     CommandHelp {
         command: "diagnose",
@@ -557,7 +557,7 @@ mod command_help_tests {
     fn app_help_lists_implemented_package_commands() {
         let usage = usage_for("app");
         assert!(usage.contains("packages [query]"));
-        assert!(usage.contains("add-many <proxy|bypass> <package...>"));
+        assert!(usage.contains("add-many <proxy|direct|bypass> <package...>"));
     }
 
     #[test]

--- a/crates/magicnet-cli/src/rules.rs
+++ b/crates/magicnet-cli/src/rules.rs
@@ -76,7 +76,7 @@ pub(crate) fn app_cmd(app: &App, args: &[String]) -> Result<(), String> {
         "remove" => app_remove(app, args),
         "packages" => app_packages(args),
         "apply" => app_apply_and_restart(app),
-        _ => Err("Usage: cli app {list|packages [query]|mode <blacklist|whitelist>|add <package> [proxy|bypass]|add-many <proxy|bypass> <package...>|remove <package>|apply}".to_string()),
+        _ => Err("Usage: cli app {list|packages [query]|mode <blacklist|whitelist>|add <package> [proxy|direct|bypass]|add-many <proxy|direct|bypass> <package...>|remove <package> [proxy|direct|bypass]|apply}".to_string()),
     }
 }
 
@@ -85,6 +85,8 @@ fn app_list(app: &App) -> Result<(), String> {
     println!("mode={mode}");
     println!("proxy apps:");
     print_app_list_lines(&app_list_lines(app, "proxy")?);
+    println!("direct apps:");
+    print_app_list_lines(&app_list_lines(app, "direct")?);
     println!("bypass apps:");
     print_app_list_lines(&app_list_lines(app, "bypass")?);
     Ok(())
@@ -109,17 +111,19 @@ fn app_add(app: &App, args: &[String]) -> Result<(), String> {
     let package = args.get(1).map(String::as_str).unwrap_or_default();
     let target = args.get(2).map(String::as_str).unwrap_or("proxy");
     if package.is_empty() {
-        return Err("Usage: cli app add <package> [proxy|bypass]".to_string());
+        return Err("Usage: cli app add <package> [proxy|direct|bypass]".to_string());
     }
     if !valid_package_name(package) {
         return Err(format!("invalid package name: {package}"));
     }
-    let opposite = match target {
-        "proxy" => "bypass",
-        "bypass" => "proxy",
-        _ => return Err("Target must be proxy or bypass".to_string()),
-    };
-    update_app_list_line(app, opposite, package, false)?;
+    if !matches!(target, "proxy" | "direct" | "bypass") {
+        return Err("Target must be proxy, direct, or bypass".to_string());
+    }
+    for other in ["proxy", "direct", "bypass"] {
+        if other != target {
+            update_app_list_line(app, other, package, false)?;
+        }
+    }
     update_app_list_line(app, target, package, true)?;
     app_apply_and_restart(app)?;
     println!("[info] Added {package} to {target} app list");
@@ -128,16 +132,14 @@ fn app_add(app: &App, args: &[String]) -> Result<(), String> {
 
 fn app_add_many(app: &App, args: &[String]) -> Result<(), String> {
     let target = args.get(1).map(String::as_str).unwrap_or_default();
-    if !matches!(target, "proxy" | "bypass") || args.len() < 3 {
-        return Err("Usage: cli app add-many <proxy|bypass> <package...>".to_string());
+    if !matches!(target, "proxy" | "direct" | "bypass") || args.len() < 3 {
+        return Err("Usage: cli app add-many <proxy|direct|bypass> <package...>".to_string());
     }
-    let opposite = if target == "proxy" { "bypass" } else { "proxy" };
     let target_relative = app_file_relative(target)?;
-    let opposite_relative = app_file_relative(opposite)?;
     let mut lines = app_list_lines(app, target)?;
-    let mut opposite_lines = app_list_lines(app, opposite)?;
+    let packages = args.iter().skip(2).map(String::as_str).collect::<Vec<_>>();
     let mut added = 0usize;
-    for package in args.iter().skip(2).map(String::as_str) {
+    for &package in &packages {
         if !valid_package_name(package) {
             return Err(format!("invalid package name: {package}"));
         }
@@ -145,15 +147,22 @@ fn app_add_many(app: &App, args: &[String]) -> Result<(), String> {
             lines.push(package.to_string());
             added += 1;
         }
-        opposite_lines.retain(|line| line != package);
     }
-    crate::utils::replace_module_text_files_transactionally(
-        app,
-        Path::new(opposite_relative),
-        &unique_lines_text(&opposite_lines),
-        Path::new(target_relative),
-        &unique_lines_text(&lines),
-    )?;
+    for other in ["proxy", "direct", "bypass"] {
+        if other == target {
+            continue;
+        }
+        let filtered = app_list_lines(app, other)?
+            .into_iter()
+            .filter(|line| !packages.iter().any(|package| *package == line))
+            .collect::<Vec<_>>();
+        write_text_file(
+            app,
+            Path::new(app_file_relative(other)?),
+            &unique_lines_text(&filtered),
+        )?;
+    }
+    write_text_file(app, Path::new(target_relative), &unique_lines_text(&lines))?;
     app_apply_and_restart(app)?;
     println!("[info] Added {added} packages to {target} app list");
     Ok(())
@@ -163,18 +172,19 @@ fn app_remove(app: &App, args: &[String]) -> Result<(), String> {
     let package = args.get(1).map(String::as_str).unwrap_or_default();
     let target = args.get(2).map(String::as_str);
     if package.is_empty() {
-        return Err("Usage: cli app remove <package> [proxy|bypass]".to_string());
+        return Err("Usage: cli app remove <package> [proxy|direct|bypass]".to_string());
     }
     if !valid_package_name(package) {
         return Err(format!("invalid package name: {package}"));
     }
     match target {
-        Some("proxy" | "bypass") => {
+        Some("proxy" | "direct" | "bypass") => {
             update_app_list_line(app, target.unwrap(), package, false)?;
         }
-        Some(_) => return Err("Target must be proxy or bypass".to_string()),
+        Some(_) => return Err("Target must be proxy, direct, or bypass".to_string()),
         None => {
             update_app_list_line(app, "proxy", package, false)?;
+            update_app_list_line(app, "direct", package, false)?;
             update_app_list_line(app, "bypass", package, false)?;
         }
     }
@@ -277,8 +287,9 @@ pub(super) fn conf_dir(app: &App) -> PathBuf {
 fn app_file_relative(target: &str) -> Result<&'static str, String> {
     match target {
         "proxy" => Ok(".config/magicnet/app-proxy.list"),
+        "direct" => Ok(".config/magicnet/app-direct.list"),
         "bypass" => Ok(".config/magicnet/app-bypass.list"),
-        _ => Err("Target must be proxy or bypass".to_string()),
+        _ => Err("Target must be proxy, direct, or bypass".to_string()),
     }
 }
 

--- a/crates/magicnet-cli/src/webui_backup.rs
+++ b/crates/magicnet-cli/src/webui_backup.rs
@@ -353,6 +353,7 @@ fn backup_files() -> &'static [&'static str] {
         ".config/sing-box/subscription-filter.list",
         ".config/magicnet/app-mode.conf",
         ".config/magicnet/app-proxy.list",
+        ".config/magicnet/app-direct.list",
         ".config/magicnet/app-bypass.list",
         ".config/magicnet/block.conf",
         ".config/magicnet/block-domain-suffix.list",

--- a/scripts/test-app-routing-policy.sh
+++ b/scripts/test-app-routing-policy.sh
@@ -79,16 +79,27 @@ assert_proxy_rule_and_order() {
           | select((.package_name // []) | index("__magicnet_app_proxy__"))][0]
          | .package_name == ["__magicnet_app_proxy__", "com.example.proxy"]
            and .outbound == "proxy")
+    and ([.route.rules[]
+          | select((.package_name // []) | index("__magicnet_app_direct__"))][0]
+         | .package_name == ["__magicnet_app_direct__", "com.example.direct-force"]
+           and .outbound == "direct")
     and (([.route.rules | to_entries[]
             | select(.value | (has("action") or (.protocol == "icmp" and .outbound == "block")))
             | .key] | max) as $guard
          | ([.route.rules | to_entries[]
+              | select((.value.package_name // []) | index("__magicnet_app_direct__"))
+              | .key][0]) as $direct
+         | ([.route.rules | to_entries[]
               | select((.value.package_name // []) | index("__magicnet_app_proxy__"))
               | .key][0]) as $proxy
          | ([.route.rules | to_entries[]
-              | select(.value.outbound == "direct" and ((.value.package_name // .value.domain_suffix // []) | length) > 0)
+              | select(
+                  .value.outbound == "direct"
+                  and ((.value.package_name // []) | index("__magicnet_app_direct__")) == null
+                  and ((.value.package_name // .value.domain_suffix // []) | length) > 0
+                )
               | .key] | min) as $business
-         | $guard < $proxy and $proxy < $business)
+         | $guard < $direct and $direct < $proxy and $proxy < $business)
     and (([.route.rules | to_entries[]
             | select(.value == {"domain_suffix": ["local", "home.arpa", "lan"], "outbound": "lan"})
             | .key]) as $lan
@@ -110,7 +121,7 @@ assert_blacklist() {
 assert_whitelist() {
   "$JQ_BIN" -e '
     (.inbounds[] | select(.type == "tun")
-      | .include_package == ["com.example.proxy"] and (has("exclude_package") | not))
+      | .include_package == ["com.example.direct-force", "com.example.proxy"] and (has("exclude_package") | not))
   ' "$MODDIR/.config/sing-box/config.json" >/dev/null
   assert_proxy_rule_and_order
 }
@@ -136,6 +147,10 @@ run_case() {
 com.example.proxy
 com.example.proxy
 EOF
+  cat >"$MODDIR/.config/magicnet/app-direct.list" <<'EOF'
+com.example.direct-force
+com.example.direct-force
+EOF
   cat >"$MODDIR/.config/magicnet/app-bypass.list" <<'EOF'
 com.example.bypass
 com.example.bypass
@@ -153,7 +168,8 @@ EOF
   apply_policy "$implementation"
   apply_policy "$implementation"
   "$JQ_BIN" -e '
-    [.route.rules[] | select((.package_name // []) | index("__magicnet_app_proxy__"))] | length == 0
+    ([.route.rules[] | select((.package_name // []) | index("__magicnet_app_proxy__"))] | length) == 0
+    and ([.route.rules[] | select((.package_name // []) | index("__magicnet_app_direct__"))] | length) == 1
   ' "$MODDIR/.config/sing-box/config.json" >/dev/null
 
   printf '%s\n' 'MAGICNET_APP_MODE=whitelist' >"$MODDIR/.config/magicnet/app-mode.conf"

--- a/src/MagicNet/.config/magicnet/app-direct.list
+++ b/src/MagicNet/.config/magicnet/app-direct.list
@@ -1,0 +1,6 @@
+# Packages that stay inside MagicNet TUN but always use the direct outbound.
+# One package name per line.
+#
+# Use this when an app must avoid proxy nodes while remaining observable and
+# controlled by MagicNet. Use app-bypass.list only when the app must leave the
+# TUN entirely, for example another VPN client.

--- a/src/MagicNet/README.md
+++ b/src/MagicNet/README.md
@@ -117,6 +117,9 @@ MagicNet 新安装默认按节点名过滤 `免费`、`free`、`HK`、`香港`�
 
 MagicNet 目前只支持 `tun` 透明模式，使用 `sing-box` `magicnet0` TUN 接管透明流量。旧配置中的 `proxy`、`external-tun`、`hybrid` 会安全归一为 `tun`，CLI 不再接受这些模式。
 
+- 分应用策略分为三类：`Proxy` 强制走代理；`Direct` 仍进入 TUN，但强制走 `direct` 出站；`Bypass TUN` 则让应用完全离开 MagicNet。
+- `Bypass TUN` 不等于断网或阻止访问。应用离开 MagicNet 后会使用系统上游网络；如果上游网络或另一个 VPN 能访问 Google，加入 Bypass 后的 Chrome 仍然可以访问。
+- 要验证 Chrome 没有使用 MagicNet 代理，请在 WebUI“应用策略”中选择 `Direct`，或执行 `cli app add com.android.chrome direct`。只有多 VPN 共存或明确需要完全避开 MagicNet 时才选择 `Bypass TUN`。
 - 默认网络策略是双栈、DNS 优先 IPv4、`mixed` TUN 栈、MTU `1400` 和 UDP 会话超时 `5m`。
 - 可在 WebUI 的“UDP / IPv6”卡片切换，或执行 `cli network set <ipv4_only|prefer_ipv4|prefer_ipv6> <1280-1500> <1m|3m|5m|10m|15m|30m>`。
 - `ipv4_only` 是网络或代理节点不支持 IPv6 时的兼容回退；切回双栈会自动移除 MagicNet 管理的 IPv6 拦截规则。

--- a/src/MagicNet/lib/magicnet/apps.sh
+++ b/src/MagicNet/lib/magicnet/apps.sh
@@ -16,6 +16,7 @@ magicnet_app_policy_mode() {
 # App package policy is NOT the primary domestic/foreign split.
 # - Blacklist mode: most apps enter TUN; geosite/geoip (+ domain lists) choose cn-direct vs proxy.
 # - app-bypass.list: multi-VPN coexistence and optional user opt-outs only.
+# - app-direct.list: keep selected packages in TUN but force the direct outbound.
 # - app-proxy.list: force selected packages onto MagicNet proxy.
 # Do not auto-seed large “domestic app catalogs” into bypass — that does not scale and
 # duplicates work already done by rule-sets (lyc/metacubex geosite-cn / geoip-cn).
@@ -71,6 +72,7 @@ magicnet_app_proxy_packages() {
 # Idempotent rewrites strip rules containing this marker, then re-inject one
 # authoritative rule from app-proxy.list — single source of truth for that list.
 MAGICNET_APP_PROXY_MARKER="__magicnet_app_proxy__"
+MAGICNET_APP_DIRECT_MARKER="__magicnet_app_direct__"
 
 magicnet_app_proxy_rule() {
     _proxy_rule_packages="$(magicnet_app_proxy_packages "$1")"
@@ -96,6 +98,30 @@ magicnet_app_proxy_rule() {
     unset _proxy_rule_packages _proxy_rule_count _proxy_rule_idx _proxy_rule_package _proxy_rule_comma
 }
 
+magicnet_app_direct_rule() {
+    _direct_rule_packages="$(magicnet_app_proxy_packages "$1")"
+    if [ -z "$_direct_rule_packages" ]; then
+        unset _direct_rule_packages
+        return 0
+    fi
+    printf '      {\n'
+    printf '        "package_name": [\n'
+    printf '          "%s",\n' "$MAGICNET_APP_DIRECT_MARKER"
+    _direct_rule_count=$(printf '%s\n' "$_direct_rule_packages" | wc -l | tr -d ' ')
+    _direct_rule_idx=0
+    printf '%s\n' "$_direct_rule_packages" | while IFS= read -r _direct_rule_package; do
+        [ -n "$_direct_rule_package" ] || continue
+        _direct_rule_idx=$((_direct_rule_idx + 1))
+        _direct_rule_comma=","
+        [ "$_direct_rule_idx" -eq "$_direct_rule_count" ] && _direct_rule_comma=""
+        printf '          "%s"%s\n' "$(magicnet_json_escape "$_direct_rule_package")" "$_direct_rule_comma"
+    done
+    printf '        ],\n'
+    printf '        "outbound": "direct"\n'
+    printf '      }\n'
+    unset _direct_rule_packages _direct_rule_count _direct_rule_idx _direct_rule_package _direct_rule_comma
+}
+
 magicnet_singbox_apply_app_policy() {
     _config="${MODDIR}/.config/sing-box/config.json"
     [ -f "$_config" ] || return 0
@@ -103,28 +129,37 @@ magicnet_singbox_apply_app_policy() {
     _dir="$(magicnet_app_policy_dir)"
     _mode="$(magicnet_app_policy_mode)"
     _proxy_file="${_dir}/app-proxy.list"
+    _direct_file="${_dir}/app-direct.list"
     _bypass_file="${_dir}/app-bypass.list"
 
     _include_block=""
     _exclude_block=""
+    _include_packages_tmp="${_config}.include-packages.tmp"
     if [ "$_mode" = "whitelist" ]; then
-        _include_block="$(magicnet_package_array_block include_package "$_proxy_file" "," 1)"
+        {
+            magicnet_app_proxy_packages "$_direct_file"
+            magicnet_app_proxy_packages "$_proxy_file"
+        } | awk 'NF && !seen[$0]++' >"$_include_packages_tmp"
+        _include_block="$(magicnet_package_array_block include_package "$_include_packages_tmp" "," 1)"
     else
         _exclude_block="$(magicnet_package_array_block exclude_package "$_bypass_file" ",")"
+        rm -f "$_include_packages_tmp" 2>/dev/null || true
     fi
 
     _tmp="${_config}.app-policy.new"
     _include_tmp="${_config}.include-package.tmp"
     _exclude_tmp="${_config}.exclude-package.tmp"
     _proxy_rule_tmp="${_config}.app-proxy-rule.tmp"
+    _direct_rule_tmp="${_config}.app-direct-rule.tmp"
     _jq="${MODDIR}/bin/jq"
     if [ ! -x "$_jq" ]; then
         _jq="$(command -v jq 2>/dev/null || true)"
     fi
     if [ -n "$_jq" ]; then
         [ -f "$_proxy_file" ] || : >"$_proxy_file"
+        [ -f "$_direct_file" ] || : >"$_direct_file"
         [ -f "$_bypass_file" ] || : >"$_bypass_file"
-        if "$_jq" --arg mode "$_mode" --rawfile proxy "$_proxy_file" --rawfile bypass "$_bypass_file" '
+        if "$_jq" --arg mode "$_mode" --rawfile proxy "$_proxy_file" --rawfile direct "$_direct_file" --rawfile bypass "$_bypass_file" '
             def packages($text):
               $text
               | split("\n")
@@ -132,13 +167,14 @@ magicnet_singbox_apply_app_policy() {
               | map(select(. != "" and (startswith("#") | not)))
               | unique;
             (packages($proxy)) as $proxy_packages
+            | (packages($direct)) as $direct_packages
             | (packages($bypass)) as $bypass_packages
             | .inbounds = (
                 (.inbounds // []) | map(
                   if (.type // "") == "tun" then
                     del(.include_package, .exclude_package)
                     | if $mode == "whitelist" then
-                        .include_package = $proxy_packages
+                        .include_package = (($proxy_packages + $direct_packages) | unique)
                       elif ($bypass_packages | length) > 0 then
                         .exclude_package = $bypass_packages
                       else
@@ -151,8 +187,11 @@ magicnet_singbox_apply_app_policy() {
               )
             | .route.rules = (
                 ((.route.rules // [])
-                  | map(select(((.package_name // []) | index("__magicnet_app_proxy__")) == null))) as $rules
-                | if ($proxy_packages | length) == 0 then
+                  | map(select(
+                      ((.package_name // []) | index("__magicnet_app_proxy__")) == null
+                      and ((.package_name // []) | index("__magicnet_app_direct__")) == null
+                    ))) as $rules
+                | if (($proxy_packages | length) == 0 and ($direct_packages | length) == 0) then
                     $rules
                   else
                     ($rules
@@ -160,15 +199,20 @@ magicnet_singbox_apply_app_policy() {
                     | ($rules
                       | map(select((has("action") or (((.protocol // "") == "icmp") and ((.outbound // "") == "block"))) | not))) as $business_rules
                     | $protocol_guards
-                      + [{
+                      + (if ($direct_packages | length) == 0 then [] else [{
+                          "package_name": (["__magicnet_app_direct__"] + $direct_packages),
+                          "outbound": "direct"
+                        }] end)
+                      + (if ($proxy_packages | length) == 0 then [] else [{
                           "package_name": (["__magicnet_app_proxy__"] + $proxy_packages),
                           "outbound": "proxy"
-                        }]
+                        }] end)
                       + $business_rules
                   end
               )
         ' "$_config" >"$_tmp" && mv -f "$_tmp" "$_config"; then
-            unset _config _dir _mode _proxy_file _bypass_file _include_block _exclude_block _tmp _include_tmp _exclude_tmp _proxy_rule_tmp _jq
+            rm -f "$_include_packages_tmp" 2>/dev/null || true
+            unset _config _dir _mode _proxy_file _direct_file _bypass_file _include_block _exclude_block _include_packages_tmp _tmp _include_tmp _exclude_tmp _proxy_rule_tmp _direct_rule_tmp _jq
             return 0
         fi
         rm -f "$_tmp" 2>/dev/null || true
@@ -193,8 +237,14 @@ magicnet_singbox_apply_app_policy() {
         rm -f "$_proxy_rule_tmp" 2>/dev/null || true
         _proxy_rule_tmp=""
     fi
+    if magicnet_app_proxy_packages "$_direct_file" | grep -q .; then
+        magicnet_app_direct_rule "$_direct_file" >"$_direct_rule_tmp"
+    else
+        rm -f "$_direct_rule_tmp" 2>/dev/null || true
+        _direct_rule_tmp=""
+    fi
 
-    if awk -v include_file="$_include_tmp" -v exclude_file="$_exclude_tmp" -v proxy_rule_file="$_proxy_rule_tmp" '
+    if awk -v include_file="$_include_tmp" -v exclude_file="$_exclude_tmp" -v proxy_rule_file="$_proxy_rule_tmp" -v direct_rule_file="$_direct_rule_tmp" '
         function emit_file(path, line) {
             if (path == "") {
                 return
@@ -221,13 +271,30 @@ magicnet_singbox_apply_app_policy() {
             }
             proxy_inserted = 1
         }
+        function emit_direct_rule(comma, line, previous) {
+            if (direct_rule_file == "") {
+                return
+            }
+            previous = ""
+            while ((getline line < direct_rule_file) > 0) {
+                if (previous != "") {
+                    print previous
+                }
+                previous = line
+            }
+            close(direct_rule_file)
+            if (previous != "") {
+                print previous comma
+            }
+            direct_inserted = 1
+        }
         function route_rule_is_guard(rule) {
             return rule ~ /"action"[[:space:]]*:/ ||
                 (rule ~ /"protocol"[[:space:]]*:[[:space:]]*"icmp"/ &&
                  rule ~ /"outbound"[[:space:]]*:[[:space:]]*"block"/)
         }
         function flush_route_rule() {
-            if (route_buffer !~ /"__magicnet_app_proxy__"/) {
+            if (route_buffer !~ /"__magicnet_app_(proxy|direct)__"/) {
                 route_rule_count++
                 route_rules[route_rule_count] = route_buffer
             }
@@ -251,13 +318,17 @@ magicnet_singbox_apply_app_policy() {
                     business_count++
                 }
             }
-            output_count = guard_count + business_count + (proxy_rule_file != "" ? 1 : 0)
+            output_count = guard_count + business_count + (direct_rule_file != "" ? 1 : 0) + (proxy_rule_file != "" ? 1 : 0)
             emitted = 0
             for (i = 1; i <= route_rule_count; i++) {
                 if (route_rule_is_guard(route_rules[i])) {
                     emitted++
                     emit_route_rule(route_rules[i], emitted < output_count ? "," : "")
                 }
+            }
+            if (direct_rule_file != "") {
+                emitted++
+                emit_direct_rule(emitted < output_count ? "," : "")
             }
             if (proxy_rule_file != "") {
                 emitted++
@@ -279,6 +350,7 @@ magicnet_singbox_apply_app_policy() {
             route_buffer = ""
             route_rule_count = 0
             proxy_inserted = 0
+            direct_inserted = 0
         }
         route_buffering {
             route_buffer = route_buffer $0 "\n"
@@ -338,10 +410,10 @@ magicnet_singbox_apply_app_policy() {
         :
     else
         rm -f "$_tmp" 2>/dev/null || true
-        rm -f "$_include_tmp" "$_exclude_tmp" "$_proxy_rule_tmp" 2>/dev/null || true
+        rm -f "$_include_packages_tmp" "$_include_tmp" "$_exclude_tmp" "$_proxy_rule_tmp" "$_direct_rule_tmp" 2>/dev/null || true
         return 1
     fi
-    rm -f "$_include_tmp" "$_exclude_tmp" "$_proxy_rule_tmp" 2>/dev/null || true
+    rm -f "$_include_packages_tmp" "$_include_tmp" "$_exclude_tmp" "$_proxy_rule_tmp" "$_direct_rule_tmp" 2>/dev/null || true
 }
 
 magicnet_app_policy_apply_unlocked() {

--- a/webui/src/components/pages/AppsPage.vue
+++ b/webui/src/components/pages/AppsPage.vue
@@ -25,6 +25,7 @@ type PendingAppAction = {
   plan: AppPolicyChangePlan;
   run: () => Promise<void>;
 };
+type AppTarget = "proxy" | "direct" | "bypass";
 
 const recycledBypass = computed(() => {
   const active = new Set(state.appPolicy.bypass);
@@ -43,7 +44,7 @@ const filteredPackages = computed(() => {
 });
 
 const availableRecommendedBypass = computed(() => {
-  const active = new Set([...state.appPolicy.proxy, ...state.appPolicy.bypass]);
+  const active = new Set([...state.appPolicy.proxy, ...state.appPolicy.direct, ...state.appPolicy.bypass]);
   const installed = installedNames.value;
   return recommendedBypass.filter((pkg) => {
     if (active.has(pkg)) return false;
@@ -54,6 +55,7 @@ const availableRecommendedBypass = computed(() => {
 const policySummary = computed(() => buildAppPolicySummary(
   state.appPolicy.mode,
   state.appPolicy.proxy,
+  state.appPolicy.direct,
   state.appPolicy.bypass,
   installedNames.value,
   availableRecommendedBypass.value.length
@@ -63,6 +65,7 @@ function actionPlan(operation: AppPolicyChangeOperation): AppPolicyChangePlan {
   return buildAppPolicyChangePlan({
     mode: state.appPolicy.mode,
     proxy: state.appPolicy.proxy,
+    direct: state.appPolicy.direct,
     bypass: state.appPolicy.bypass,
     installedPackages: installedNames.value
   }, operation);
@@ -80,12 +83,23 @@ function forgetRemovedBypass(pkg: string): void {
   removedBypass.value = removedBypass.value.filter((item) => item !== pkg);
 }
 
-function validateAppPackage(pkg: string, target: "proxy" | "bypass"): boolean {
+function targetList(target: AppTarget): string[] {
+  return state.appPolicy[target];
+}
+
+function moveLocalPackage(pkg: string, target: AppTarget): void {
+  state.appPolicy.proxy = state.appPolicy.proxy.filter((item) => item !== pkg);
+  state.appPolicy.direct = state.appPolicy.direct.filter((item) => item !== pkg);
+  state.appPolicy.bypass = state.appPolicy.bypass.filter((item) => item !== pkg);
+  targetList(target).push(pkg);
+}
+
+function validateAppPackage(pkg: string, target: AppTarget): boolean {
   if (!isValidPackageName(pkg)) {
     state.output = "包名格式不对。示例：com.android.chrome";
     return false;
   }
-  const list = target === "proxy" ? state.appPolicy.proxy : state.appPolicy.bypass;
+  const list = targetList(target);
   if (list.includes(pkg)) {
     state.output = `${pkg} 已存在，已自动去重。`;
     state.packageInput = "";
@@ -94,18 +108,16 @@ function validateAppPackage(pkg: string, target: "proxy" | "bypass"): boolean {
   return true;
 }
 
-function addApp(target: "proxy" | "bypass"): void {
+function addApp(target: AppTarget): void {
   requestAddPackage(state.packageInput.trim(), target, `add-${target}`);
 }
 
-async function addPackage(pkg: string, target: "proxy" | "bypass", key = `add-${target}`): Promise<void> {
+async function addPackage(pkg: string, target: AppTarget, key = `add-${target}`): Promise<void> {
   await withAction(key, async () => {
     const previousProxy = [...state.appPolicy.proxy];
+    const previousDirect = [...state.appPolicy.direct];
     const previousBypass = [...state.appPolicy.bypass];
-    const list = target === "proxy" ? state.appPolicy.proxy : state.appPolicy.bypass;
-    if (target === "proxy") state.appPolicy.bypass = state.appPolicy.bypass.filter((item) => item !== pkg);
-    else state.appPolicy.proxy = state.appPolicy.proxy.filter((item) => item !== pkg);
-    list.push(pkg);
+    moveLocalPackage(pkg, target);
     state.packageInput = "";
     if (target === "bypass") forgetRemovedBypass(pkg);
     state.output = `已加入界面，正在保存 ${pkg}...`;
@@ -113,6 +125,7 @@ async function addPackage(pkg: string, target: "proxy" | "bypass", key = `add-${
     if (commandFailed(text)) {
       state.output = text;
       state.appPolicy.proxy = previousProxy;
+      state.appPolicy.direct = previousDirect;
       state.appPolicy.bypass = previousBypass;
       return;
     }
@@ -120,25 +133,30 @@ async function addPackage(pkg: string, target: "proxy" | "bypass", key = `add-${
   });
 }
 
-function requestAddPackage(pkg: string, target: "proxy" | "bypass", key = `add-${target}`): void {
+function requestAddPackage(pkg: string, target: AppTarget, key = `add-${target}`): void {
   if (!validateAppPackage(pkg, target)) return;
   pendingAppAction.value = {
     key,
     command: `app add ${pkg} ${target}`,
     message: target === "proxy"
-      ? `确认把 ${pkg} 加入 Proxy 名单？该应用将强制走 MagicNet proxy。`
-      : `确认把 ${pkg} 加入 Bypass 名单？该应用将绕过 MagicNet TUN。`,
+      ? `确认把 ${pkg} 加入 Proxy？该应用将强制走 MagicNet proxy。`
+      : target === "direct"
+        ? `确认把 ${pkg} 加入 Direct？该应用保留在 MagicNet TUN 内并强制直连。`
+        : `确认把 ${pkg} 加入 Bypass TUN？该应用将完全离开 MagicNet，其他 VPN 或上游网络仍可能提供访问能力。`,
     plan: actionPlan({ type: "add", target, packages: [pkg] }),
     run: () => addPackage(pkg, target, key)
   };
 }
 
-async function removeApp(pkg: string, target: "proxy" | "bypass"): Promise<void> {
+async function removeApp(pkg: string, target: AppTarget): Promise<void> {
   await withAction(`remove-${target}-${pkg}`, async () => {
     const previousProxy = [...state.appPolicy.proxy];
+    const previousDirect = [...state.appPolicy.direct];
     const previousBypass = [...state.appPolicy.bypass];
     if (target === "proxy") {
       state.appPolicy.proxy = state.appPolicy.proxy.filter((item) => item !== pkg);
+    } else if (target === "direct") {
+      state.appPolicy.direct = state.appPolicy.direct.filter((item) => item !== pkg);
     } else {
       state.appPolicy.bypass = state.appPolicy.bypass.filter((item) => item !== pkg);
       rememberRemovedBypass(pkg);
@@ -148,6 +166,7 @@ async function removeApp(pkg: string, target: "proxy" | "bypass"): Promise<void>
     if (commandFailed(text)) {
       state.output = text;
       state.appPolicy.proxy = previousProxy;
+      state.appPolicy.direct = previousDirect;
       state.appPolicy.bypass = previousBypass;
       return;
     }
@@ -158,14 +177,15 @@ async function removeApp(pkg: string, target: "proxy" | "bypass"): Promise<void>
 async function restoreBypass(pkg: string): Promise<void> {
   await withAction(`restore-bypass-${pkg}`, async () => {
     const previousProxy = [...state.appPolicy.proxy];
+    const previousDirect = [...state.appPolicy.direct];
     const previousBypass = [...state.appPolicy.bypass];
-    if (!state.appPolicy.bypass.includes(pkg)) state.appPolicy.bypass.push(pkg);
-    state.appPolicy.proxy = state.appPolicy.proxy.filter((item) => item !== pkg);
+    moveLocalPackage(pkg, "bypass");
     state.output = `正在把 ${pkg} 加回 Bypass...`;
     const text = await runCli(`app add ${shellQuote(pkg)} bypass`, `恢复 Bypass 应用 ${pkg}`, true);
     if (commandFailed(text)) {
       state.output = text;
       state.appPolicy.proxy = previousProxy;
+      state.appPolicy.direct = previousDirect;
       state.appPolicy.bypass = previousBypass;
       return;
     }
@@ -199,6 +219,7 @@ async function copyAppPolicyReport(): Promise<void> {
   appReportCopied.value = await copyText(formatAppPolicyFullReport({
     mode: state.appPolicy.mode,
     proxy: state.appPolicy.proxy,
+    direct: state.appPolicy.direct,
     bypass: state.appPolicy.bypass,
     summary: policySummary.value
   }));
@@ -209,6 +230,7 @@ async function copyAppPolicySafeReport(): Promise<void> {
   safeReportCopied.value = await copyText(formatAppPolicySafeReport({
     mode: state.appPolicy.mode,
     proxy: state.appPolicy.proxy,
+    direct: state.appPolicy.direct,
     bypass: state.appPolicy.bypass,
     summary: policySummary.value
   }));
@@ -225,6 +247,7 @@ async function applyRecommendedBypass(): Promise<void> {
     packages.forEach((pkg) => {
       if (!state.appPolicy.bypass.includes(pkg)) state.appPolicy.bypass.push(pkg);
       state.appPolicy.proxy = state.appPolicy.proxy.filter((item) => item !== pkg);
+      state.appPolicy.direct = state.appPolicy.direct.filter((item) => item !== pkg);
       forgetRemovedBypass(pkg);
     });
     const quoted = packages.map((pkg) => shellQuote(pkg)).join(" ");
@@ -249,7 +272,7 @@ function requestRecommendedBypass(): void {
   };
 }
 
-function requestRemoveApp(pkg: string, target: "proxy" | "bypass"): void {
+function requestRemoveApp(pkg: string, target: AppTarget): void {
   pendingAppAction.value = {
     key: `remove-${target}-${pkg}`,
     command: `app remove ${pkg} ${target}`,
@@ -291,7 +314,7 @@ onMounted(() => {
 
 <template>
   <div class="grid gap-4">
-    <PageHeader overline="Per App Policy" title="应用名单" description="Proxy 强制应用走 MagicNet proxy；Bypass 让应用绕过 TUN；模式控制未列出应用是否进入 TUN。">
+    <PageHeader overline="Per App Policy" title="应用名单" description="Proxy 强制代理；Direct 在 TUN 内强制直连；Bypass TUN 让应用完全离开 MagicNet。">
       <div class="flex flex-wrap gap-2">
         <Button variant="outline" :loading="isRunning('refresh-apps')" @click="withAction('refresh-apps', () => refreshApps())"><RefreshCw :size="17" />读取名单</Button>
         <Button variant="outline" :loading="isRunning('search-packages')" @click="searchPackages"><ListFilter :size="17" />重新读取应用</Button>
@@ -339,12 +362,13 @@ onMounted(() => {
           <button class="min-h-12 rounded px-3 text-sm font-medium text-[var(--mn-ink-muted)] transition-colors disabled:cursor-progress disabled:opacity-60" :disabled="isRunning('mode-blacklist') || state.appPolicy.mode === 'blacklist'" :class="{ 'bg-[var(--mn-cactus)] text-[var(--mn-on-accent)]': state.appPolicy.mode === 'blacklist' }" @click="requestSetMode('blacklist')">黑名单</button>
           <button class="min-h-12 rounded px-3 text-sm font-medium text-[var(--mn-ink-muted)] transition-colors disabled:cursor-progress disabled:opacity-60" :disabled="isRunning('mode-whitelist') || state.appPolicy.mode === 'whitelist'" :class="{ 'bg-[var(--mn-cactus)] text-[var(--mn-on-accent)]': state.appPolicy.mode === 'whitelist' }" @click="requestSetMode('whitelist')">白名单</button>
         </div>
-        <span class="text-sm text-[var(--mn-ink-muted)]">Proxy 始终强制走 MagicNet proxy；Bypass 始终绕过 TUN；黑/白名单模式只控制未列出应用。</span>
+        <span class="text-sm text-[var(--mn-ink-muted)]">想验证应用没有使用代理，请选 Direct。Bypass TUN 不等于断网；上游网络或其他 VPN 仍可能让应用访问 Google。</span>
       </div>
-      <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
+      <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto_auto_auto]">
         <Input v-model="state.packageInput" placeholder="com.android.chrome" spellcheck="false" />
         <Button variant="secondary" :loading="isRunning('add-proxy')" @click="addApp('proxy')"><Plus :size="16" />{{ isRunning('add-proxy') ? '保存中' : 'Proxy' }}</Button>
-        <Button variant="secondary" :loading="isRunning('add-bypass')" @click="addApp('bypass')"><Plus :size="16" />{{ isRunning('add-bypass') ? '保存中' : 'Bypass' }}</Button>
+        <Button variant="secondary" :loading="isRunning('add-direct')" @click="addApp('direct')"><Plus :size="16" />{{ isRunning('add-direct') ? '保存中' : 'Direct' }}</Button>
+        <Button variant="secondary" :loading="isRunning('add-bypass')" @click="addApp('bypass')"><Plus :size="16" />{{ isRunning('add-bypass') ? '保存中' : 'Bypass TUN' }}</Button>
       </div>
     </Card>
 
@@ -391,10 +415,11 @@ onMounted(() => {
           <Button variant="secondary" :loading="isRunning('search-packages')" @click="searchPackages">重新读取</Button>
         </div>
         <div class="grid max-h-72 gap-2 overflow-auto">
-          <div v-for="app in filteredPackages" :key="app.packageName" class="grid gap-2 rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] px-3 py-2 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:items-center">
+          <div v-for="app in filteredPackages" :key="app.packageName" class="grid gap-2 rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] px-3 py-2 sm:grid-cols-[minmax(0,1fr)_auto_auto_auto] sm:items-center">
             <span class="min-w-0 break-all text-sm text-[var(--mn-ink-soft)]">{{ app.packageName }}</span>
             <Button size="sm" variant="outline" :loading="isRunning(`pick-proxy-${app.packageName}`)" @click="requestAddPackage(app.packageName, 'proxy', `pick-proxy-${app.packageName}`)">Proxy</Button>
-            <Button size="sm" variant="outline" :loading="isRunning(`pick-bypass-${app.packageName}`)" @click="requestAddPackage(app.packageName, 'bypass', `pick-bypass-${app.packageName}`)">Bypass</Button>
+            <Button size="sm" variant="outline" :loading="isRunning(`pick-direct-${app.packageName}`)" @click="requestAddPackage(app.packageName, 'direct', `pick-direct-${app.packageName}`)">Direct</Button>
+            <Button size="sm" variant="outline" :loading="isRunning(`pick-bypass-${app.packageName}`)" @click="requestAddPackage(app.packageName, 'bypass', `pick-bypass-${app.packageName}`)">Bypass TUN</Button>
           </div>
           <em v-if="!filteredPackages.length" class="text-sm not-italic text-[var(--mn-ink-muted)]">暂无结果，点“列出应用”或输入关键字过滤。</em>
         </div>
@@ -403,7 +428,7 @@ onMounted(() => {
       <Card class="grid gap-3">
         <div class="flex items-start justify-between gap-3">
           <div>
-            <h3 class="text-base font-semibold">推荐 Bypass</h3>
+            <h3 class="text-base font-semibold">推荐 Bypass TUN</h3>
             <p class="mt-1 text-sm leading-6 text-[var(--mn-ink-muted)]">支付、银行、运营商、常用国内服务优先绕过，减少验证码、风控和国内服务误伤。</p>
           </div>
           <CheckCircle2 class="shrink-0 text-[var(--mn-ink-muted)]" :size="18" />
@@ -415,7 +440,7 @@ onMounted(() => {
       </Card>
     </div>
 
-    <div class="grid gap-3 md:grid-cols-2">
+    <div class="grid gap-3 md:grid-cols-3">
       <Card>
         <h3 class="mb-2 text-base font-semibold">Proxy</h3>
         <div class="flex max-h-80 flex-wrap gap-2 overflow-auto">
@@ -427,7 +452,17 @@ onMounted(() => {
         </div>
       </Card>
       <Card>
-        <h3 class="mb-2 text-base font-semibold">Bypass</h3>
+        <h3 class="mb-2 text-base font-semibold">Direct（TUN 内直连）</h3>
+        <div class="flex max-h-80 flex-wrap gap-2 overflow-auto">
+          <span v-for="pkg in state.appPolicy.direct" :key="pkg" class="inline-flex max-w-full items-center gap-1 rounded-full border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] px-2 py-1 text-xs break-all">
+            {{ pkg }}
+            <button class="grid size-6 place-items-center rounded-full bg-[var(--mn-cactus)] text-[var(--mn-on-accent)] disabled:cursor-progress disabled:opacity-60" :disabled="isRunning(`remove-direct-${pkg}`)" type="button" title="移除" @click="requestRemoveApp(pkg, 'direct')"><X :size="14" /></button>
+          </span>
+          <em v-if="!state.appPolicy.direct.length" class="text-sm not-italic text-[var(--mn-ink-muted)]">暂无应用</em>
+        </div>
+      </Card>
+      <Card>
+        <h3 class="mb-2 text-base font-semibold">Bypass TUN</h3>
         <div class="flex max-h-80 flex-wrap gap-2 overflow-auto">
           <span v-for="pkg in state.appPolicy.bypass" :key="pkg" class="inline-flex max-w-full items-center gap-1 rounded-full border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] px-2 py-1 text-xs break-all">
             {{ pkg }}

--- a/webui/src/components/pages/appPolicyChangePlan.ts
+++ b/webui/src/components/pages/appPolicyChangePlan.ts
@@ -3,14 +3,15 @@ import type { AppPolicyMode } from "./appPolicyInsights";
 export type AppPolicyChangeInput = {
   mode: AppPolicyMode;
   proxy: string[];
+  direct: string[];
   bypass: string[];
   installedPackages: Set<string>;
 };
 
 export type AppPolicyChangeOperation =
   | { type: "mode"; mode: AppPolicyMode }
-  | { type: "add"; target: "proxy" | "bypass"; packages: string[] }
-  | { type: "remove"; target: "proxy" | "bypass"; packages: string[] };
+  | { type: "add"; target: "proxy" | "direct" | "bypass"; packages: string[] }
+  | { type: "remove"; target: "proxy" | "direct" | "bypass"; packages: string[] };
 
 export type AppPolicyChangePlan = {
   title: string;
@@ -19,15 +20,19 @@ export type AppPolicyChangePlan = {
 };
 
 export function buildAppPolicyChangePlan(input: AppPolicyChangeInput, operation: AppPolicyChangeOperation): AppPolicyChangePlan {
-  const before = normalizeState(input.mode, input.proxy, input.bypass);
+  const before = normalizeState(input.mode, input.proxy, input.direct, input.bypass);
   const after = applyOperation(before, operation);
   const listChanged = changedPackages(before, after);
   const routingChanged = effectiveRoutingChanges(before, after, input.installedPackages);
-  const conflicts = after.proxy.filter((pkg) => after.bypass.includes(pkg));
+  const conflicts = unique([
+    ...after.proxy.filter((pkg) => after.direct.includes(pkg) || after.bypass.includes(pkg)),
+    ...after.direct.filter((pkg) => after.bypass.includes(pkg))
+  ]);
   const title = operationTitle(operation);
   const items = [
     item("模式", `${before.mode} -> ${after.mode}`, before.mode === after.mode ? "neutral" : "warning"),
     item("Proxy", `${before.proxy.length} -> ${after.proxy.length}`, after.proxy.length >= before.proxy.length ? "success" : "warning"),
+    item("Direct", `${before.direct.length} -> ${after.direct.length}`, after.direct.length >= before.direct.length ? "success" : "warning"),
     item("Bypass", `${before.bypass.length} -> ${after.bypass.length}`, after.bypass.length >= before.bypass.length ? "success" : "warning"),
     item("名单变化", `${listChanged.length} 个`, listChanged.length ? "warning" : "neutral"),
     item("路由变化", routingChanged === null ? "未读取应用" : `${routingChanged} 个`, routingChanged === null ? "warning" : routingChanged ? "warning" : "neutral")
@@ -36,76 +41,93 @@ export function buildAppPolicyChangePlan(input: AppPolicyChangeInput, operation:
     ...(routingChanged === null ? ["未读取已安装应用，只能预览名单变化，无法计算实际路由影响。"] : []),
     ...modeWarnings(before.mode, after),
     ...movedPackageWarnings(before, after),
-    ...(conflicts.length ? [`操作后仍有 ${conflicts.length} 个包同时存在于 Proxy 和 Bypass。`] : [])
+    ...(conflicts.length ? [`操作后仍有 ${conflicts.length} 个包同时存在于多个应用策略名单。`] : [])
   ];
   return { title, items, warnings };
 }
 
-function normalizeState(mode: AppPolicyMode, proxy: string[], bypass: string[]): { mode: AppPolicyMode; proxy: string[]; bypass: string[] } {
-  return { mode, proxy: unique(proxy), bypass: unique(bypass) };
+function normalizeState(mode: AppPolicyMode, proxy: string[], direct: string[], bypass: string[]) {
+  return { mode, proxy: unique(proxy), direct: unique(direct), bypass: unique(bypass) };
 }
 
 function applyOperation(
-  state: { mode: AppPolicyMode; proxy: string[]; bypass: string[] },
+  state: { mode: AppPolicyMode; proxy: string[]; direct: string[]; bypass: string[] },
   operation: AppPolicyChangeOperation
-): { mode: AppPolicyMode; proxy: string[]; bypass: string[] } {
+): { mode: AppPolicyMode; proxy: string[]; direct: string[]; bypass: string[] } {
   if (operation.type === "mode") return { ...state, mode: operation.mode };
   const proxy = [...state.proxy];
+  const direct = [...state.direct];
   const bypass = [...state.bypass];
   for (const pkg of unique(operation.packages)) {
     if (operation.type === "add") {
       if (operation.target === "proxy") {
         addUnique(proxy, pkg);
+        removeValue(direct, pkg);
+        removeValue(bypass, pkg);
+      } else if (operation.target === "direct") {
+        addUnique(direct, pkg);
+        removeValue(proxy, pkg);
         removeValue(bypass, pkg);
       } else {
         addUnique(bypass, pkg);
         removeValue(proxy, pkg);
+        removeValue(direct, pkg);
       }
     } else if (operation.target === "proxy") {
       removeValue(proxy, pkg);
+    } else if (operation.target === "direct") {
+      removeValue(direct, pkg);
     } else {
       removeValue(bypass, pkg);
     }
   }
-  return { mode: state.mode, proxy, bypass };
+  return { mode: state.mode, proxy, direct, bypass };
 }
 
 function changedPackages(
-  before: { proxy: string[]; bypass: string[] },
-  after: { proxy: string[]; bypass: string[] }
+  before: { proxy: string[]; direct: string[]; bypass: string[] },
+  after: { proxy: string[]; direct: string[]; bypass: string[] }
 ): string[] {
-  const all = unique([...before.proxy, ...before.bypass, ...after.proxy, ...after.bypass]);
-  return all.filter((pkg) => before.proxy.includes(pkg) !== after.proxy.includes(pkg) || before.bypass.includes(pkg) !== after.bypass.includes(pkg));
+  const all = unique([...before.proxy, ...before.direct, ...before.bypass, ...after.proxy, ...after.direct, ...after.bypass]);
+  return all.filter((pkg) =>
+    before.proxy.includes(pkg) !== after.proxy.includes(pkg)
+    || before.direct.includes(pkg) !== after.direct.includes(pkg)
+    || before.bypass.includes(pkg) !== after.bypass.includes(pkg));
 }
 
-function modeWarnings(beforeMode: AppPolicyMode, after: { mode: AppPolicyMode; proxy: string[]; bypass: string[] }): string[] {
+function modeWarnings(beforeMode: AppPolicyMode, after: { mode: AppPolicyMode; proxy: string[]; direct: string[]; bypass: string[] }): string[] {
   if (beforeMode === after.mode) return [];
-  if (after.mode === "whitelist" && !after.proxy.length) return ["白名单模式下 Proxy 为空，未列出应用将绕过 TUN。"];
+  if (after.mode === "whitelist" && !after.proxy.length && !after.direct.length) {
+    return ["白名单模式下 Proxy 和 Direct 均为空，所有应用都将绕过 TUN。"];
+  }
   if (after.mode === "blacklist" && !after.bypass.length) return ["黑名单模式下 Bypass 为空，除系统排除外应用会默认进入 TUN。"];
   return [];
 }
 
 function effectiveRoutingChanges(
-  before: { mode: AppPolicyMode; proxy: string[]; bypass: string[] },
-  after: { mode: AppPolicyMode; proxy: string[]; bypass: string[] },
+  before: { mode: AppPolicyMode; proxy: string[]; direct: string[]; bypass: string[] },
+  after: { mode: AppPolicyMode; proxy: string[]; direct: string[]; bypass: string[] },
   installedPackages: Set<string>
 ): number | null {
   if (!installedPackages.size) return null;
   return Array.from(installedPackages).filter((pkg) => effectiveRoute(before, pkg) !== effectiveRoute(after, pkg)).length;
 }
 
-function effectiveRoute(state: { mode: AppPolicyMode; proxy: string[]; bypass: string[] }, pkg: string): "proxy" | "tun" | "bypass" {
+function effectiveRoute(state: { mode: AppPolicyMode; proxy: string[]; direct: string[]; bypass: string[] }, pkg: string): "proxy" | "direct" | "tun" | "bypass" {
   if (state.proxy.includes(pkg)) return "proxy";
+  if (state.direct.includes(pkg)) return "direct";
   if (state.bypass.includes(pkg) || state.mode === "whitelist") return "bypass";
   return "tun";
 }
 
-function movedPackageWarnings(before: { proxy: string[]; bypass: string[] }, after: { proxy: string[]; bypass: string[] }): string[] {
-  const toProxy = after.proxy.filter((pkg) => before.bypass.includes(pkg));
-  const toBypass = after.bypass.filter((pkg) => before.proxy.includes(pkg));
+function movedPackageWarnings(before: { proxy: string[]; direct: string[]; bypass: string[] }, after: { proxy: string[]; direct: string[]; bypass: string[] }): string[] {
+  const toProxy = after.proxy.filter((pkg) => before.direct.includes(pkg) || before.bypass.includes(pkg));
+  const toDirect = after.direct.filter((pkg) => before.proxy.includes(pkg) || before.bypass.includes(pkg));
+  const toBypass = after.bypass.filter((pkg) => before.proxy.includes(pkg) || before.direct.includes(pkg));
   return [
-    ...(toProxy.length ? [`${toProxy.length} 个包会从 Bypass 移到 Proxy。`] : []),
-    ...(toBypass.length ? [`${toBypass.length} 个包会从 Proxy 移到 Bypass。`] : [])
+    ...(toProxy.length ? [`${toProxy.length} 个包会从其他名单移到 Proxy。`] : []),
+    ...(toDirect.length ? [`${toDirect.length} 个包会移到 Direct。`] : []),
+    ...(toBypass.length ? [`${toBypass.length} 个包会从其他名单移到 Bypass TUN。`] : [])
   ];
 }
 

--- a/webui/src/components/pages/appPolicyInsights.ts
+++ b/webui/src/components/pages/appPolicyInsights.ts
@@ -11,12 +11,14 @@ export type AppPolicySummary = {
   items: AppPolicyInsight[];
   conflicts: string[];
   installedProxy: string[];
+  installedDirect: string[];
   installedBypass: string[];
 };
 
 export type AppPolicySafeReportInput = {
   mode: AppPolicyMode;
   proxy: string[];
+  direct: string[];
   bypass: string[];
   summary: AppPolicySummary;
 };
@@ -107,30 +109,37 @@ export function isValidPackageName(pkg: string): boolean {
 export function buildAppPolicySummary(
   mode: AppPolicyMode,
   proxy: string[],
+  direct: string[],
   bypass: string[],
   installedPackages: Set<string>,
   availableRecommendedCount: number
 ): AppPolicySummary {
-  const proxySet = new Set(proxy);
+  const directSet = new Set(direct);
   const bypassSet = new Set(bypass);
-  const conflicts = proxy.filter((pkg) => bypassSet.has(pkg));
+  const conflicts = Array.from(new Set([
+    ...proxy.filter((pkg) => directSet.has(pkg) || bypassSet.has(pkg)),
+    ...direct.filter((pkg) => bypassSet.has(pkg))
+  ]));
   const installedProxy = installedPackages.size ? proxy.filter((pkg) => installedPackages.has(pkg)) : [];
+  const installedDirect = installedPackages.size ? direct.filter((pkg) => installedPackages.has(pkg)) : [];
   const installedBypass = installedPackages.size ? bypass.filter((pkg) => installedPackages.has(pkg)) : [];
   const installedKnown = installedPackages.size > 0;
   const unlisted = mode === "whitelist" ? "绕过 TUN" : "进入 TUN";
   return {
     summary: mode === "whitelist"
-      ? "Proxy 名单强制走 MagicNet proxy；未列出应用绕过 TUN。"
-      : "Proxy 名单强制走 MagicNet proxy；Bypass 名单绕过 TUN，未列出应用正常进入 TUN。",
+      ? "Proxy 强制代理；Direct 在 TUN 内强制直连；未列出应用绕过 TUN。"
+      : "Proxy 强制代理；Direct 在 TUN 内强制直连；Bypass 完全绕过 TUN。",
     conflicts,
     installedProxy,
+    installedDirect,
     installedBypass,
     items: [
       insight("Proxy 强制", `${proxy.length} 个`, proxy.length ? "success" : "neutral"),
-      insight("Bypass 绕过", `${bypass.length} 个`, bypass.length ? "success" : "neutral"),
+      insight("Direct 直连", `${direct.length} 个`, direct.length ? "success" : "neutral"),
+      insight("Bypass TUN", `${bypass.length} 个`, bypass.length ? "warning" : "neutral"),
       insight("未列出应用", unlisted, mode === "blacklist" ? "success" : "neutral"),
       insight("名单冲突", conflicts.length ? `${conflicts.length} 个` : "无", conflicts.length ? "danger" : "success"),
-      insight("当前列表命中", installedKnown ? `Proxy ${installedProxy.length} / Bypass ${installedBypass.length}` : "未读取应用", installedKnown ? "success" : "warning"),
+      insight("当前列表命中", installedKnown ? `P ${installedProxy.length} / D ${installedDirect.length} / B ${installedBypass.length}` : "未读取应用", installedKnown ? "success" : "warning"),
       insight("可应用推荐", `${availableRecommendedCount} 个`, availableRecommendedCount ? "neutral" : "success")
     ]
   };
@@ -142,12 +151,15 @@ export function formatAppPolicySafeReport(input: AppPolicySafeReportInput): stri
     "privacy_note=package names omitted; fingerprints are weak change markers, not privacy proof",
     `mode=${input.mode}`,
     `proxy_count=${input.proxy.length}`,
+    `direct_count=${input.direct.length}`,
     `bypass_count=${input.bypass.length}`,
     `summary=${input.summary.summary}`,
     `conflict_count=${input.summary.conflicts.length}`,
     `current_list_proxy=${input.summary.installedProxy.length}`,
+    `current_list_direct=${input.summary.installedDirect.length}`,
     `current_list_bypass=${input.summary.installedBypass.length}`,
     `proxy_fingerprint=${fingerprintList(input.proxy)}`,
+    `direct_fingerprint=${fingerprintList(input.direct)}`,
     `bypass_fingerprint=${fingerprintList(input.bypass)}`,
     `conflict_fingerprint=${fingerprintList(input.summary.conflicts)}`,
     "",
@@ -162,10 +174,12 @@ export function formatAppPolicyFullReport(input: AppPolicySafeReportInput): stri
     "privacy_note=contains package names from app policy lists",
     `mode=${input.mode}`,
     `proxy_count=${input.proxy.length}`,
+    `direct_count=${input.direct.length}`,
     `bypass_count=${input.bypass.length}`,
     `summary=${input.summary.summary}`,
     `conflict_count=${input.summary.conflicts.length}`,
     `current_list_proxy=${input.summary.installedProxy.length}`,
+    `current_list_direct=${input.summary.installedDirect.length}`,
     `current_list_bypass=${input.summary.installedBypass.length}`,
     "",
     "[insights]",
@@ -173,6 +187,9 @@ export function formatAppPolicyFullReport(input: AppPolicySafeReportInput): stri
     "",
     "[proxy]",
     ...input.proxy,
+    "",
+    "[direct]",
+    ...input.direct,
     "",
     "[bypass]",
     ...input.bypass

--- a/webui/src/composables/parsers.ts
+++ b/webui/src/composables/parsers.ts
@@ -340,13 +340,14 @@ export function parseHealth(text: string): HealthItem[] {
 }
 
 export function parseApps(text: string): AppPolicy {
-  const policy: AppPolicy = { mode: "blacklist", proxy: [], bypass: [] };
-  let section: "proxy" | "bypass" | null = null;
+  const policy: AppPolicy = { mode: "blacklist", proxy: [], direct: [], bypass: [] };
+  let section: "proxy" | "direct" | "bypass" | null = null;
   text.split(/\r?\n/).forEach((raw) => {
     const line = raw.trim();
     if (!line) return;
     if (line.startsWith("mode=")) policy.mode = line.includes("whitelist") ? "whitelist" : "blacklist";
     else if (line === "proxy apps:") section = "proxy";
+    else if (line === "direct apps:") section = "direct";
     else if (line === "bypass apps:") section = "bypass";
     else if (section) policy[section].push(line);
   });

--- a/webui/src/composables/useMagicNet.ts
+++ b/webui/src/composables/useMagicNet.ts
@@ -92,7 +92,7 @@ const state = reactive({
   runtime: { ...runtimeDefaults },
   health: [] as HealthItem[],
   pingtest: "",
-  appPolicy: { mode: "blacklist", proxy: [], bypass: [] } as AppPolicy,
+  appPolicy: { mode: "blacklist", proxy: [], direct: [], bypass: [] } as AppPolicy,
   packages: [] as PackageInfo[],
   packageQuery: "",
   packageInput: "",

--- a/webui/src/types.ts
+++ b/webui/src/types.ts
@@ -9,6 +9,7 @@ export type ExecResult = {
 export type AppPolicy = {
   mode: "blacklist" | "whitelist";
   proxy: string[];
+  direct: string[];
   bypass: string[];
 };
 


### PR DESCRIPTION
## Summary

- add a third per-app policy, **Direct**, which keeps an Android package inside the MagicNet TUN and forces the sing-box `direct` outbound
- rename and explain the existing behavior as **Bypass TUN** so it is clear that leaving MagicNet does not block the app's network access
- apply the new policy in both jq and no-jq configuration paths, CLI commands, WebUI state/reporting, and backup/restore
- document why Chrome can still reach Google after being added to Bypass TUN

## Root cause

The existing Bypass list is translated to sing-box TUN `exclude_package`. That means the package leaves MagicNet; it does not lose network access. If the Android upstream network or another VPN can reach Google, Chrome can still reach it.

The new Direct policy is the correct choice when the user wants to verify that an app is not using the MagicNet proxy while keeping routing observable inside the TUN.

## Validation

- `bash scripts/test-app-routing-policy.sh`
- `bash scripts/test-policy-architecture.sh`
- `bash -n src/MagicNet/lib/magicnet/apps.sh scripts/test-app-routing-policy.sh`
- `npm run check` (16/16 tests, TypeScript check, Vite production build)
- `git diff --check`

Rust tooling was not available in this workspace; the repository CI remains the source of truth for the Rust build.

## Summary by Sourcery

在现有的 Proxy 和 Bypass TUN 基础上，引入第三种按应用路由策略（Direct），并将其贯穿接入到 MagicNet 的 shell 逻辑、CLI、WebUI、测试、备份以及文档中。

新特性：
- 新增 Direct 按应用策略，使选定的 Android 包保持在 MagicNet TUN 内，同时强制使用直连的出站路由。
- 在 WebUI 和 CLI 中将 Direct 作为一等公民目标，支持添加、移除和列出应用路由策略。

增强内容：
- 更新应用策略摘要、冲突检测和变更规划逻辑，以支持 Direct，并澄清 Bypass TUN 的行为。
- 扩展路由规则生成逻辑，使 Direct 应用获得专属 sing-box 规则，并被包含在白名单模式的包列表中。
- 在备份/恢复流程中包含新的 app-direct 列表文件，并默认对其进行初始化。

文档：
- 记录三种应用策略类型（Proxy、Direct、Bypass TUN），并澄清 Bypass TUN 不会阻断上游网络访问，也不会影响 Chrome 连接 Google 的能力。

测试：
- 扩展应用路由策略测试，覆盖 Direct 的行为、规则排序，以及与白名单/包含包模式的交互。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a third per-app routing policy (Direct) alongside Proxy and Bypass TUN and plumb it through MagicNet’s shell logic, CLI, WebUI, tests, backup, and documentation.

New Features:
- Add a Direct per-app policy that keeps selected Android packages inside the MagicNet TUN while forcing direct outbound routing.
- Expose Direct as a first-class target in the WebUI and CLI for adding, removing, and listing app routing policies.

Enhancements:
- Update app policy summaries, conflict detection, and change-planning logic to account for Direct and clarify behavior of Bypass TUN.
- Extend routing rule generation so Direct apps get dedicated sing-box rules and are included in whitelist mode package lists.
- Include the new app-direct list file in backup/restore flows and initialize it by default.

Documentation:
- Document the three app policy types (Proxy, Direct, Bypass TUN) and clarify that Bypass TUN does not block upstream network access or Chrome’s ability to reach Google.

Tests:
- Expand app routing policy tests to cover Direct behavior, rule ordering, and whitelist/include-package interactions.

</details>