### PR TITLE
feat: import local sing-box JSON configurations

### DIFF
--- a/src/MagicNet/README.md
+++ b/src/MagicNet/README.md
@@ -73,6 +73,8 @@ su -c '/data/adb/modules/MagicNet/cli sub user-agent clear'
 
 导入完成后，节点会写入 `sing-box` 配置的 `proxy` 选择器；节点选择、测速和切换在 `sing-box` WebUI 里完成。当前版本只维护 `sing-box`，Clash / mihomo 格式订阅也按 sing-box 来源导入。
 
+如果没有订阅 URL、而是已有完整的 sing-box JSON 配置，可以进入模块 WebUI 的“配置编辑器”，点击“导入本地 JSON”选择文件。导入只会把内容放进编辑器草稿；检查内容后点击“校验并保存”，MagicNet 会先执行 `sing-box check`，通过后才覆盖运行配置。文件不需要上传到服务器或转换成 URL。
+
 ## 常用 CLI
 
 ```bash

--- a/webui/config-file-import.test.mjs
+++ b/webui/config-file-import.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { MAX_LOCAL_CONFIG_BYTES, parseLocalConfigFile } from "./src/components/pages/configFileImport.ts";
+
+const encoder = new TextEncoder();
+const imported = parseLocalConfigFile("private-config.json", encoder.encode('{"route":{"rules":[]},"outbounds":[]}'));
+assert.equal(imported.fileName, "private-config.json");
+assert.equal(imported.sizeBytes > 0, true);
+assert.equal(imported.text, '{\n  "route": {\n    "rules": []\n  },\n  "outbounds": []\n}\n');
+
+assert.throws(() => parseLocalConfigFile("empty.json", new Uint8Array()), /文件为空/);
+assert.throws(() => parseLocalConfigFile("array.json", encoder.encode("[]")), /顶层必须是 JSON 对象/);
+assert.throws(() => parseLocalConfigFile("broken.json", encoder.encode("{")), /JSON 语法错误/);
+assert.throws(() => parseLocalConfigFile("binary.json", new Uint8Array([0xff, 0xfe])), /UTF-8/);
+assert.throws(
+  () => parseLocalConfigFile("large.json", new Uint8Array(MAX_LOCAL_CONFIG_BYTES + 1)),
+  /4 MiB/,
+);
+
+console.log("config file import tests passed");

--- a/webui/src/components/pages/ConfigPage.vue
+++ b/webui/src/components/pages/ConfigPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Braces, Copy, DownloadCloud, Github, ListTree, RefreshCw, Save } from "lucide-vue-next";
+import { Braces, Copy, DownloadCloud, FileUp, Github, ListTree, RefreshCw, Save } from "lucide-vue-next";
 import { computed, ref } from "vue";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
@@ -11,10 +11,12 @@ import { copyText } from "@/utils";
 import ToolActionConfirmCard from "./ToolActionConfirmCard.vue";
 import type { PendingToolAction } from "./toolActions";
 import { buildConfigAudit, buildConfigOutline, buildUnifiedConfigDiff, MAX_CONFIG_ISSUE_DIFF_BYTES, sanitizeConfigText } from "./configEditorInsights";
+import { MAX_LOCAL_CONFIG_BYTES, parseLocalConfigFile } from "./configFileImport";
 
 const { state, loadConfig, saveConfig, syncConfigTemplate, openExternal, REPO } = useMagicNet();
 const { isRunning, withAction } = useActionLock();
 const pendingConfigAction = ref<PendingToolAction | null>(null);
+const configFileInput = ref<HTMLInputElement | null>(null);
 const localJsonStatus = ref("");
 const configSyntaxValid = ref(true);
 const sanitizedCopied = ref(false);
@@ -100,6 +102,39 @@ function formatConfigJson(): void {
   }
 }
 
+function chooseLocalConfig(): void {
+  configFileInput.value?.click();
+}
+
+async function importLocalConfig(event: Event): Promise<void> {
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  input.value = "";
+  if (!file) return;
+
+  try {
+    if (file.size > MAX_LOCAL_CONFIG_BYTES) {
+      throw new Error("文件超过 4 MiB 限制。");
+    }
+    const imported = parseLocalConfigFile(file.name, new Uint8Array(await file.arrayBuffer()));
+    state.config.text = imported.text;
+    state.config.dirty = true;
+    state.config.status = `已导入 ${imported.fileName}，尚未保存`;
+    state.config.validation = {
+      status: "idle",
+      summary: "本地 JSON 已导入编辑器，点击“校验并保存”后才会写入运行配置。",
+      checkedAt: "",
+    };
+    configSyntaxValid.value = true;
+    localJsonStatus.value = `${imported.fileName} 已导入（${(imported.sizeBytes / 1024).toFixed(1)} KiB），尚未保存。`;
+    state.notice = "本地 JSON 已导入编辑器";
+    state.output = "导入完成，运行配置没有被修改；请检查内容后点击“校验并保存”。";
+  } catch (error) {
+    localJsonStatus.value = `导入错误：${error instanceof Error ? error.message : String(error)}`;
+    state.output = localJsonStatus.value;
+  }
+}
+
 async function copySanitizedConfig(): Promise<void> {
   if (!sanitizedConfig.value) return;
   sanitizedCopied.value = await copyText(sanitizedConfig.value);
@@ -159,9 +194,11 @@ async function openConfigIssue(): Promise<void> {
 
 <template>
   <div class="grid gap-4">
-    <PageHeader overline="Validated Editor" title="配置编辑器" description="高级配置入口：编辑 sing-box config.json；订阅链接请到订阅页填写。">
+    <PageHeader overline="Validated Editor" title="配置编辑器" description="可直接导入本地 sing-box JSON，无需 URL；订阅链接请到订阅页填写。">
       <div class="flex flex-wrap items-center gap-2">
+        <input ref="configFileInput" class="hidden" type="file" accept=".json,application/json" @change="importLocalConfig">
         <Button variant="outline" :loading="isRunning('load-config')" @click="withAction('load-config', loadConfigForEditing)"><RefreshCw :size="17" />{{ isRunning('load-config') ? '加载中' : '加载配置' }}</Button>
+        <Button variant="outline" @click="chooseLocalConfig"><FileUp :size="17" />导入本地 JSON</Button>
         <Button variant="outline" :loading="isRunning('sync-template')" @click="requestSyncTemplate"><DownloadCloud :size="17" />{{ isRunning('sync-template') ? '同步中' : '同步上游模板' }}</Button>
         <Button variant="outline" :disabled="!state.config.text" @click="formatConfigJson"><Braces :size="17" />格式化 JSON</Button>
         <Button variant="outline" :disabled="!state.config.text" @click="copySanitizedConfig"><Copy :size="17" />{{ sanitizedCopied ? '已复制脱敏' : '复制脱敏' }}</Button>
@@ -186,7 +223,7 @@ async function openConfigIssue(): Promise<void> {
         <span v-if="state.config.dirty" class="shrink-0 rounded bg-[color-mix(in_srgb,var(--mn-oat)_55%,var(--mn-carrier))] px-2 py-1 text-xs text-[var(--mn-warning)]">未保存</span>
       </div>
       <div class="rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] p-3 text-sm leading-6 text-[var(--mn-ink-muted)]">
-        <p>sing-box 配置文件是 JSON。点击“加载配置”读取真实文件，修改后点“校验并保存”，会先执行 sing-box check，通过后才覆盖。</p>
+        <p>sing-box 配置文件是 JSON。没有订阅 URL 时可选择自己的本地配置文件；导入只会替换编辑器草稿，点击“校验并保存”并通过 sing-box check 后才会覆盖运行配置。</p>
       </div>
       <div class="grid gap-2 rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] p-3 sm:grid-cols-[9rem_minmax(0,1fr)]">
         <div>
@@ -211,7 +248,7 @@ async function openConfigIssue(): Promise<void> {
         <span>{{ configStats.lines }} 行</span>
         <span>{{ configStats.chars }} 字符</span>
         <span>{{ configStats.sizeKiB }} KiB</span>
-        <span class="break-words" :class="localJsonStatus.includes('错误') ? 'text-[var(--mn-danger)]' : 'text-[var(--mn-ink-muted)]'">{{ localJsonStatus || "尚未执行本地格式化" }}</span>
+        <span class="break-words" :class="localJsonStatus.includes('错误') ? 'text-[var(--mn-danger)]' : 'text-[var(--mn-ink-muted)]'">{{ localJsonStatus || "尚未导入或格式化本地 JSON" }}</span>
       </div>
       <div class="grid gap-3 rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] p-3 text-sm text-[var(--mn-ink-muted)]">
         <div class="flex min-w-0 flex-wrap items-center gap-2">

--- a/webui/src/components/pages/configFileImport.ts
+++ b/webui/src/components/pages/configFileImport.ts
@@ -1,0 +1,39 @@
+export const MAX_LOCAL_CONFIG_BYTES = 4 * 1024 * 1024;
+
+export type LocalConfigImport = {
+  fileName: string;
+  text: string;
+  sizeBytes: number;
+};
+
+export function parseLocalConfigFile(fileName: string, bytes: Uint8Array): LocalConfigImport {
+  if (!bytes.byteLength) {
+    throw new Error("文件为空。");
+  }
+  if (bytes.byteLength > MAX_LOCAL_CONFIG_BYTES) {
+    throw new Error("文件超过 4 MiB 限制。");
+  }
+
+  let source: string;
+  try {
+    source = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error("文件不是有效的 UTF-8 文本。");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch (error) {
+    throw new Error(`JSON 语法错误：${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("配置顶层必须是 JSON 对象。");
+  }
+
+  return {
+    fileName: fileName || "config.json",
+    text: `${JSON.stringify(parsed, null, 2)}\n`,
+    sizeBytes: bytes.byteLength,
+  };
+}


### PR DESCRIPTION
## Summary

- add **Import local JSON** to the validated sing-box configuration editor
- allow users with a local configuration file to proceed without creating or hosting a subscription URL
- validate file size (maximum 4 MiB), UTF-8 encoding, JSON syntax, and a JSON object root before loading the draft
- keep imports non-destructive: selecting a file only replaces the editor draft; the existing confirmation and `sing-box check` must pass before the runtime configuration is overwritten
- document the no-URL workflow

## Privacy and safety

The browser reads the selected file locally. Its contents are not written until the user explicitly chooses **Validate and Save**, which uses the existing private staging and validation path. Error/status output does not include the configuration contents.

## Validation

- `npm run check`
  - 17/17 tests, including valid JSON, empty, array-root, syntax-error, invalid UTF-8, and oversized-file cases
  - TypeScript check
  - Vite production build
- `git diff --check`

## Summary by Sourcery

在无需订阅 URL 的前提下，为配置编辑器新增支持：可导入已经通过校验的本地 sing-box JSON 文件，同时仍然将运行时配置更新限制在现有验证机制之后。

新特性：
- 允许用户直接在 WebUI 配置编辑器中选择并导入本地 sing-box JSON 配置文件。
- 在将配置加载到编辑器之前，引入对 JSON 文件的大小、UTF-8 编码、语法以及对象根节点的验证。

增强改进：
- 更新配置编辑器的 UI 文案，以突出本地 JSON 导入流程及其对现有配置的非破坏性行为。
- 在编辑器中暴露导入状态和验证提示，以明确说明所有更改在明确通过验证并保存之前都只是草稿。

文档：
- 编写相关文档，说明在 WebUI 配置编辑器中通过本地 sing-box JSON 文件导入配置的无 URL 工作流程。

测试：
- 添加单元测试，覆盖本地 JSON 成功导入的情况，以及空文件、非对象根节点、语法错误、无效 UTF-8 编码和文件过大等失败场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for importing validated local sing-box JSON files into the configuration editor without requiring a subscription URL, while keeping runtime configuration updates gated behind existing validation.

New Features:
- Allow users to select and import a local sing-box JSON configuration file directly into the WebUI configuration editor.
- Introduce JSON file parsing with size, UTF-8, syntax, and object-root validation before loading the configuration into the editor.

Enhancements:
- Update the configuration editor UI copy to highlight the local JSON import workflow and its non-destructive behavior.
- Expose import status and validation hints in the editor to clarify that changes are drafts until explicitly validated and saved.

Documentation:
- Document the no-URL workflow for importing a local sing-box JSON file via the WebUI configuration editor.

Tests:
- Add unit tests covering successful local JSON import and failure cases for empty files, non-object roots, syntax errors, invalid UTF-8, and oversized files.

</details>