### PR TITLE
Fix node filters and prioritize AI proxy regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- Reapply subscription keyword filters while sanitizing cached/generated
+  outbounds so filtered nodes cannot survive through a repair or cache replay.
+- Order every AI selector with United States nodes first, Japan second, and
+  other eligible regions afterward, while excluding mainland China, Hong Kong,
+  and Taiwan labels from all AI groups.
+
 ## v1.1.27 (2026-07-28)
 
 - Add a persistent custom User-Agent for subscription downloads, configurable

--- a/scripts/test-anthropic-routing.sh
+++ b/scripts/test-anthropic-routing.sh
@@ -18,6 +18,8 @@ normalized_selector_tags_json=$(magicnet_selector_tags_json \
   fail "selector tag final-value deduplication mismatch: $normalized_selector_tags_json"
 cat >"$tmp_dir/nodes.json" <<'JSON'
 [
+ {"type":"vless","tag":"Germany edge","server":"de.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000030"},
+ {"type":"vless","tag":"日本 Tokyo","server":"jp.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000031"},
  {"type":"vless","tag":"US stable","server":"us.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000001"},
  {"type":"vless","tag":"上海 node","server":"cn.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000002"},
  {"type":"vless","tag":"CN node","server":"cn2.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000003"},
@@ -45,6 +47,14 @@ cat >"$tmp_dir/nodes.json" <<'JSON'
  ,{"type":"vless","tag":"hk_01 edge","server":"hk-underscore.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000025"}
  ,{"type":"vless","tag":"HKG01 edge","server":"hkg01.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000026"}
  ,{"type":"vless","tag":"HongKong01 edge","server":"hongkong01.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000027"}
+ ,{"type":"vless","tag":"台湾 edge","server":"tw.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000032"}
+ ,{"type":"vless","tag":"Taiwan edge","server":"taiwan.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000033"}
+ ,{"type":"vless","tag":"TW edge","server":"tw-code.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000034"}
+ ,{"type":"vless","tag":"TWN edge","server":"twn.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000035"}
+ ,{"type":"vless","tag":"Taipei edge","server":"taipei.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000036"}
+ ,{"type":"vless","tag":"🇹🇼 premium","server":"tw-flag.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000037"}
+ ,{"type":"vless","tag":"TWA edge","server":"twa.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000038"}
+ ,{"type":"vless","tag":"mytw edge","server":"mytw.invalid","server_port":443,"uuid":"00000000-0000-4000-8000-000000000039"}
 ]
 JSON
 magicnet_singbox_write_outbounds_from_json "$tmp_dir/nodes.json" "$tmp_dir/outbounds.fragment"
@@ -93,7 +103,7 @@ jq -e '
           then ($node_tags | index($selector.default)) != null
           else true
           end)))
-    and ($ai_proxy.default == "US stable" and $ai_proxy.outbounds == ["US stable", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "myhk edge"])
+    and ($ai_proxy.default == "US stable" and $ai_proxy.outbounds == ["US stable", "日本 Tokyo", "Germany edge", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "myhk edge", "TWA edge", "mytw edge"])
     and ($by_tag["cn-direct"] == {type: "selector", tag: "cn-direct", outbounds: ["direct", "proxy", "block"], default: "direct"})
     and ($by_tag.final == {type: "selector", tag: "final", outbounds: ["proxy", "direct", "block"], default: "proxy"})
     and ($services | all(. as $service
@@ -143,11 +153,28 @@ jq -e '
     and ([.outbounds[].tag] | length) == ([.outbounds[].tag] | unique | length)
 ' "$tmp_dir/adversarial-jq.json" >/dev/null || fail "jq adversarial tag filtering mismatch"
 magicnet_singbox_ai_selectors_canonical "$tmp_dir/generated.json" || fail "jq canonical validator rejected generated auto groups"
+printf '%s\n' 'opaque-42' >"$tmp_dir/custom-subscription-filter.list"
+cp "$tmp_dir/generated.json" "$tmp_dir/filter-repair.json"
+MAGICNET_SUB_FILTER_FILE="$tmp_dir/custom-subscription-filter.list" \
+  magicnet_singbox_sanitize_generated_config "$tmp_dir/filter-repair.json"
+jq -e '
+  (.outbounds | INDEX(.tag)) as $by_tag
+  | ($by_tag["opaque-42"] == null)
+    and ($by_tag.proxy.outbounds | index("opaque-42") == null)
+    and ($by_tag["proxy-auto"].outbounds | index("opaque-42") == null)
+    and ($by_tag["ai-proxy"].outbounds | index("opaque-42") == null)
+    and (["ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude"]
+      | all(. as $tag | $by_tag[$tag].outbounds | index("opaque-42") == null))
+' "$tmp_dir/filter-repair.json" >/dev/null ||
+  fail "sanitizer did not apply subscription filters to cached/generated nodes and selectors"
+MAGICNET_SUB_FILTER_FILE="$tmp_dir/custom-subscription-filter.list" \
+  magicnet_singbox_ai_selectors_canonical "$tmp_dir/filter-repair.json" ||
+  fail "filter-repaired config is not canonical"
 jq '(.outbounds[] | select(.tag == "proxy") | .interrupt_exist_connections) = true' \
   "$tmp_dir/generated.json" >"$tmp_dir/kamfw-proxy-runtime.json"
 magicnet_singbox_ai_selectors_canonical "$tmp_dir/kamfw-proxy-runtime.json" ||
   fail "jq canonical validator rejected kamfw proxy runtime field"
-special_tag='edge } { "quoted" \path,comma'
+special_tag='US edge } { "quoted" \path,comma'
 jq --arg special "$special_tag" '
   .outbounds |= map(
     (if .tag == "US stable" then
@@ -509,7 +536,7 @@ jq -e '
   fail "sanitizer did not migrate legacy proxy-auto probe policy without changing AI intervals"
 magicnet_singbox_ai_selectors_canonical "$tmp_dir/repaired-legacy-proxy-auto.json" ||
   fail "legacy proxy-auto repair is not canonical"
-printf '%s\n' 'US stable' '上海 node' 'CN node' 'CN2 premium' 'opaque-42' 'Mainland premium' 'Beijing edge' 'Shanghai edge' 'Guangzhou edge' 'Shenzhen edge' 'Sichuan edge' 'Inner-Mongolia edge' 'Xinjiang edge' '香港 edge' 'Hong Kong edge' 'Hong-Kong edge' 'Hong_Kong edge' 'HK edge' 'HKG edge' 'HKT edge' 'CHK edge' 'hk01 edge' 'myhk edge' 'hk-01 edge' 'hk_01 edge' 'HKG01 edge' 'HongKong01 edge' >"$tmp_dir/tags"
+printf '%s\n' 'Germany edge' '日本 Tokyo' 'US stable' '上海 node' 'CN node' 'CN2 premium' 'opaque-42' 'Mainland premium' 'Beijing edge' 'Shanghai edge' 'Guangzhou edge' 'Shenzhen edge' 'Sichuan edge' 'Inner-Mongolia edge' 'Xinjiang edge' '香港 edge' 'Hong Kong edge' 'Hong-Kong edge' 'Hong_Kong edge' 'HK edge' 'HKG edge' 'HKT edge' 'CHK edge' 'hk01 edge' 'myhk edge' 'hk-01 edge' 'hk_01 edge' 'HKG01 edge' 'HongKong01 edge' '台湾 edge' 'Taiwan edge' 'TW edge' 'TWN edge' 'Taipei edge' '🇹🇼 premium' 'TWA edge' 'mytw edge' >"$tmp_dir/tags"
 magicnet_singbox_emit_selector_block "$tmp_dir/tags" >"$tmp_dir/no-jq.fragment"
 {
   printf '{"outbounds":['
@@ -554,7 +581,7 @@ jq -e '
       outbounds: ["proxy-auto", "proxy", "direct", "block"],
       default: "proxy-auto"
     })
-    and ($ai_proxy.default == "US stable" and $ai_proxy.outbounds == ["US stable", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "myhk edge"])
+    and ($ai_proxy.default == "US stable" and $ai_proxy.outbounds == ["US stable", "日本 Tokyo", "Germany edge", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "myhk edge", "TWA edge", "mytw edge"])
     and ($by_tag["cn-direct"] == {type: "selector", tag: "cn-direct", outbounds: ["direct", "proxy", "block"], default: "direct"})
     and ($by_tag.final == {type: "selector", tag: "final", outbounds: ["proxy", "direct", "block"], default: "proxy"})
     and ([.outbounds[] | select(.type == "selector" and .tag != "network-test")] | all(. as $selector
@@ -795,6 +822,14 @@ done
 for tag in 'HKT edge' 'CHK edge' 'myhk edge'; do
   grep -Fxq "$tag" "$tmp_dir/pinned-ai-tags" || fail "Hong Kong boundary false positive: $tag"
 done
+for tag in '台湾 edge' 'Taiwan edge' 'TW edge' 'TWN edge' 'Taipei edge' '🇹🇼 premium'; do
+  ! grep -Fxq "$tag" "$tmp_dir/pinned-ai-tags" || fail "Taiwan label retained: $tag"
+done
+[[ "$(sed -n '1,3p' "$tmp_dir/pinned-ai-tags")" == $'US stable\n日本 Tokyo\nGermany edge' ]] ||
+  fail "AI node priority is not US, Japan, then other regions"
+for tag in 'TWA edge' 'mytw edge'; do
+  grep -Fxq "$tag" "$tmp_dir/pinned-ai-tags" || fail "Taiwan boundary false positive: $tag"
+done
 jq 'del(.outbounds[] | select(.tag == "ai-chatgpt" or .tag == "ai-gemini" or .tag == "ai-grok" or .tag == "ai-claude"
       or .tag == "ai-chatgpt-auto" or .tag == "ai-gemini-auto" or .tag == "ai-grok-auto" or .tag == "ai-claude-auto"))' \
   "$tmp_dir/generated.json" >"$tmp_dir/legacy-cached.json"
@@ -809,7 +844,7 @@ jq -e '
   ] as $services
   | (.outbounds | INDEX(.tag)) as $by_tag
   | (.outbounds[] | select(.tag == "ai-proxy")) as $ai_proxy
-  | ($ai_proxy.default == "US stable" and $ai_proxy.outbounds == ["US stable", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "myhk edge"])
+  | ($ai_proxy.default == "US stable" and $ai_proxy.outbounds == ["US stable", "日本 Tokyo", "Germany edge", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "myhk edge", "TWA edge", "mytw edge"])
     and ($services | all(. as $service
       | ($service.name + "-auto") as $auto
       | $by_tag[$service.name].type == "selector"
@@ -845,7 +880,7 @@ jq -e '
   | (.outbounds | INDEX(.tag)) as $by_tag
   | (.outbounds[] | select(.tag == "ai-proxy")) as $ai_proxy
   | ([.outbounds[] | select(.tag as $tag | ($expected_tags | index($tag)) != null)] | length) == 8
-    and ($ai_proxy.default == "US stable" and $ai_proxy.outbounds == ["US stable", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "myhk edge"])
+    and ($ai_proxy.default == "US stable" and $ai_proxy.outbounds == ["US stable", "日本 Tokyo", "Germany edge", "CN2 premium", "opaque-42", "HKT edge", "CHK edge", "myhk edge", "TWA edge", "mytw edge"])
     and ($services | all(. as $service
       | ($service.name + "-auto") as $auto
       | $by_tag[$service.name].type == "selector"

--- a/src/MagicNet/README.md
+++ b/src/MagicNet/README.md
@@ -113,7 +113,7 @@ su -c /data/adb/modules/MagicNet/cli sub update sing-box
 
 MagicNet 会抓取常见 Clash-style 节点 payload，并重新生成 `.config/sing-box/config.json` 里的 sing-box `outbounds`。旧的 mihomo 配置目录不会再被写入或启动。
 
-MagicNet 新安装默认按节点名过滤 `免费`、`free`、`HK`、`香港`、`TW`、`台湾`，可在 WebUI 的订阅页删除部分关键词，或清空并保存以关闭过滤。导入后的其余节点统一放进 `proxy` 选择器；规则选择器只在 `proxy`、`direct`、`block` 之间切换，不再生成固定的地区桶。如果节点数量明显少于订阅内容，也可能是订阅里包含当前 shell 导入器不支持的协议或字段；安装了 proxylink 时会优先用它生成 sing-box outbounds，以覆盖更多协议。
+MagicNet 新安装默认按节点名过滤 `免费`、`free`、`HK`、`香港`、`TW`、`台湾`，可在 WebUI 的订阅页删除部分关键词，或清空并保存以关闭过滤。过滤规则会同时作用于新下载、缓存回放与配置修复后的节点列表。导入后的其余节点统一放进 `proxy` 选择器；AI 选择器固定排除中国大陆、香港和台湾标签，并按美国、日本、其他地区的顺序排列候选节点。规则选择器只在 `proxy`、`direct`、`block` 之间切换，不再生成固定的地区桶。如果节点数量明显少于订阅内容，也可能是订阅里包含当前 shell 导入器不支持的协议或字段；安装了 proxylink 时会优先用它生成 sing-box outbounds，以覆盖更多协议。
 
 ## 透明代理边界
 

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh
@@ -30,8 +30,18 @@ magicnet_singbox_ai_selectors_canonical() {
         jq -e \
             --arg expected_proxy_url "$_ai_expected_proxy_url" \
             --arg expected_proxy_interval "$_ai_expected_proxy_interval" '
-          def mainland_node_tag:
-            test("中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:Hong[ _-]?Kong(?:[ _-]?[0-9]+)?|HKG?[ _-]?[0-9]+|China|Mainland|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
+          def blocked_ai_node_tag:
+            test("中国|大陆|内地|香港|台湾|臺灣|台北|臺北|台中|臺中|台南|臺南|高雄|新竹|🇭🇰|🇹🇼|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:Hong[ _-]?Kong(?:[ _-]?[0-9]+)?|HKG?[ _-]?[0-9]+|Taiwan|Taipei|Taichung|Tainan|Kaohsiung|Hsinchu|TW|TWN|China|Mainland|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
+          def us_node_tag:
+            test("美国|美國|美西|美东|美東|洛杉矶|洛杉磯|圣何塞|聖何塞|西雅图|西雅圖|达拉斯|達拉斯|纽约|紐約|芝加哥|迈阿密|邁阿密|凤凰城|鳳凰城|亚特兰大|亞特蘭大|波特兰|波特蘭|丹佛|拉斯维加斯|拉斯維加斯|硅谷|🇺🇸|(^|[^A-Za-z0-9])(?:US|USA|United[ _-]?States|America|Los[ _-]?Angeles|San[ _-]?Jose|Seattle|Dallas|New[ _-]?York|Chicago|Washington|Miami|Phoenix|Atlanta|Portland|Denver|Las[ _-]?Vegas|Silicon[ _-]?Valley)([^A-Za-z0-9]|$)"; "i");
+          def japan_node_tag:
+            test("日本|东京|東京|大阪|埼玉|名古屋|🇯🇵|(^|[^A-Za-z0-9])(?:JP|JPN|Japan|Tokyo|Osaka|Saitama|Nagoya)([^A-Za-z0-9]|$)"; "i");
+          def prioritize_ai_tags:
+            . as $tags
+            | ([$tags[]? | select(blocked_ai_node_tag | not)]) as $eligible
+            | ([$eligible[] | select(us_node_tag)])
+              + ([$eligible[] | select((us_node_tag | not) and japan_node_tag)])
+              + ([$eligible[] | select((us_node_tag | not) and (japan_node_tag | not))]);
           def proxy_node:
             .type == "shadowsocks" or .type == "vmess" or .type == "vless" or .type == "trojan"
               or .type == "hysteria2" or .type == "anytls" or .type == "tuic";
@@ -78,7 +88,7 @@ magicnet_singbox_ai_selectors_canonical() {
           | ([.outbounds[]? | select(.tag == "proxy-auto")]) as $proxy_autos
           | [.outbounds[]? | select(proxy_node)] as $nodes
           | [$nodes[] | .tag] as $node_tags
-          | ([ $node_tags[]? | select(mainland_node_tag | not) ]) as $ai_tags
+          | ($node_tags | prioritize_ai_tags) as $ai_tags
           | ([.outbounds[]?.tag] | unique) as $tags
           | ($groups | length) == 4
             and ($nodes | all(valid_proxy_node))
@@ -110,7 +120,8 @@ magicnet_singbox_ai_selectors_canonical() {
             and (($ai_proxies[0].outbounds == ["block"] and $ai_proxies[0].default == "block" and ($ai_tags | length) == 0)
               or (($ai_proxies[0].outbounds | length) > 0
                 and $ai_proxies[0].default == $ai_proxies[0].outbounds[0]
-                and ($ai_proxies[0].outbounds | all(. as $member | ($node_tags | index($member) != null) and ($member | mainland_node_tag | not)))))
+                and $ai_proxies[0].outbounds == $ai_tags
+                and ($ai_proxies[0].outbounds | all(. as $member | ($node_tags | index($member) != null) and ($member | blocked_ai_node_tag | not)))))
             and ($auto_groups | length) == (if ($ai_tags | length) > 0 then 4 else 0 end)
             and ($services | all(. as $service
               | ($service.name + "-auto") as $auto_name
@@ -128,7 +139,7 @@ magicnet_singbox_ai_selectors_canonical() {
                     and $service_auto_groups[0].type == "urltest"
                     and $service_auto_groups[0].outbounds == $ai_proxies[0].outbounds
                     and ($service_auto_groups[0].outbounds | all(. as $member
-                      | ($node_tags | index($member) != null) and ($member | mainland_node_tag | not)))
+                      | ($node_tags | index($member) != null) and ($member | blocked_ai_node_tag | not)))
                     and $service_auto_groups[0].url == $service.url
                     and $service_auto_groups[0].interval == "10m"
                     and $service_auto_groups[0].tolerance == 30
@@ -142,10 +153,23 @@ magicnet_singbox_ai_selectors_canonical() {
         awk \
             -v expected_proxy_url="$_ai_expected_proxy_url" \
             -v expected_proxy_interval="$_ai_expected_proxy_interval" '
-          function mainland(value, folded) {
+          function blocked_ai(value, folded) {
             folded = tolower(value)
-            return value ~ /中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西/ ||
-              folded ~ /(^|[^[:alnum:]])(hong[ _-]?kong([ _-]?[0-9]+)?|hkg?[ _-]?[0-9]+|china|mainland|hk|hkg|cn|beijing|shanghai|guangzhou|shenzhen|chongqing|tianjin|hebei|shanxi|liaoning|jilin|heilongjiang|jiangsu|zhejiang|anhui|fujian|jiangxi|shandong|henan|hubei|hunan|guangdong|hainan|sichuan|guizhou|yunnan|shaanxi|gansu|qinghai|inner[ _-]?mongolia|guangxi|tibet|ningxia|xinjiang)([^[:alnum:]]|$)/
+            return value ~ /中国|大陆|内地|香港|台湾|臺灣|台北|臺北|台中|臺中|台南|臺南|高雄|新竹|🇭🇰|🇹🇼|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西/ ||
+              folded ~ /(^|[^[:alnum:]])(hong[ _-]?kong([ _-]?[0-9]+)?|hkg?[ _-]?[0-9]+|taiwan|taipei|taichung|tainan|kaohsiung|hsinchu|tw|twn|china|mainland|hk|hkg|cn|beijing|shanghai|guangzhou|shenzhen|chongqing|tianjin|hebei|shanxi|liaoning|jilin|heilongjiang|jiangsu|zhejiang|anhui|fujian|jiangxi|shandong|henan|hubei|hunan|guangdong|hainan|sichuan|guizhou|yunnan|shaanxi|gansu|qinghai|inner[ _-]?mongolia|guangxi|tibet|ningxia|xinjiang)([^[:alnum:]]|$)/
+          }
+          function us_node(value, folded) {
+            folded = tolower(value)
+            return value ~ /美国|美國|美西|美东|美東|洛杉矶|洛杉磯|圣何塞|聖何塞|西雅图|西雅圖|达拉斯|達拉斯|纽约|紐約|芝加哥|迈阿密|邁阿密|凤凰城|鳳凰城|亚特兰大|亞特蘭大|波特兰|波特蘭|丹佛|拉斯维加斯|拉斯維加斯|硅谷|🇺🇸/ ||
+              folded ~ /(^|[^[:alnum:]])(us|usa|united[ _-]?states|america|los[ _-]?angeles|san[ _-]?jose|seattle|dallas|new[ _-]?york|chicago|washington|miami|phoenix|atlanta|portland|denver|las[ _-]?vegas|silicon[ _-]?valley)([^[:alnum:]]|$)/
+          }
+          function japan_node(value, folded) {
+            folded = tolower(value)
+            return value ~ /日本|东京|東京|大阪|埼玉|名古屋|🇯🇵/ ||
+              folded ~ /(^|[^[:alnum:]])(jp|jpn|japan|tokyo|osaka|saitama|nagoya)([^[:alnum:]]|$)/
+          }
+          function ai_priority(value) {
+            return us_node(value) ? 1 : (japan_node(value) ? 2 : 3)
           }
           function reserved_tag(value) {
             return value ~ /^(proxy-auto|proxy|select|lan|hotspot|ad-block|ad-allow|cn-direct|apple-cn|microsoft-cn|google-cn|icloud|bing|dns-guard|network-test|ai-proxy|ai-chatgpt|ai-chatgpt-auto|ai-gemini|ai-gemini-auto|ai-grok|ai-grok-auto|ai-claude|ai-claude-auto|proxy-rule|dev-proxy|social-proxy|media-proxy|game-proxy|telegram-proxy|download-direct|final|direct|block|warp)$/
@@ -494,11 +518,18 @@ magicnet_singbox_ai_selectors_canonical() {
                 } else {
                   node_tags[tag] = 1
                   node_order[++node_count] = tag
-                  if (!mainland(tag)) {
+                  if (!blocked_ai(tag)) {
                     eligible_nodes[tag] = 1
-                    eligible_count++
                   }
                 }
+              }
+            }
+            eligible_count = 0
+            for (priority = 1; priority <= 3; priority++) {
+              for (i = 1; i <= node_count; i++) {
+                tag = node_order[i]
+                if ((tag in eligible_nodes) && ai_priority(tag) == priority)
+                  eligible_order[++eligible_count] = tag
               }
             }
             if (duplicate_node_tag || invalid_node) bad = 1
@@ -525,9 +556,9 @@ magicnet_singbox_ai_selectors_canonical() {
                 if (ai_member_count == 1 && ai_member[1] == "block") {
                   if (default_member != "block" || eligible_count != 0) bad = 1
                 } else {
-                  if (ai_member_count < 1 || default_member != ai_member[1]) bad = 1
+                  if (ai_member_count != eligible_count || default_member != ai_member[1]) bad = 1
                   for (j = 1; j <= ai_member_count; j++) {
-                    if (!(ai_member[j] in eligible_nodes)) bad = 1
+                    if (!(ai_member[j] in eligible_nodes) || ai_member[j] != eligible_order[j]) bad = 1
                   }
                 }
                 continue

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
@@ -137,8 +137,18 @@ magicnet_singbox_build_outbounds_file_with_jq() {
         else {"type": "selector", "tag": "network-test",
               "outbounds": ["block"], "default": "block"}
         end;
-    def mainland_node_tag:
-      test("中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:Hong[ _-]?Kong(?:[ _-]?[0-9]+)?|HKG?[ _-]?[0-9]+|China|Mainland|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
+    def blocked_ai_node_tag:
+      test("中国|大陆|内地|香港|台湾|臺灣|台北|臺北|台中|臺中|台南|臺南|高雄|新竹|🇭🇰|🇹🇼|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:Hong[ _-]?Kong(?:[ _-]?[0-9]+)?|HKG?[ _-]?[0-9]+|Taiwan|Taipei|Taichung|Tainan|Kaohsiung|Hsinchu|TW|TWN|China|Mainland|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
+    def us_node_tag:
+      test("美国|美國|美西|美东|美東|洛杉矶|洛杉磯|圣何塞|聖何塞|西雅图|西雅圖|达拉斯|達拉斯|纽约|紐約|芝加哥|迈阿密|邁阿密|凤凰城|鳳凰城|亚特兰大|亞特蘭大|波特兰|波特蘭|丹佛|拉斯维加斯|拉斯維加斯|硅谷|🇺🇸|(^|[^A-Za-z0-9])(?:US|USA|United[ _-]?States|America|Los[ _-]?Angeles|San[ _-]?Jose|Seattle|Dallas|New[ _-]?York|Chicago|Washington|Miami|Phoenix|Atlanta|Portland|Denver|Las[ _-]?Vegas|Silicon[ _-]?Valley)([^A-Za-z0-9]|$)"; "i");
+    def japan_node_tag:
+      test("日本|东京|東京|大阪|埼玉|名古屋|🇯🇵|(^|[^A-Za-z0-9])(?:JP|JPN|Japan|Tokyo|Osaka|Saitama|Nagoya)([^A-Za-z0-9]|$)"; "i");
+    def prioritize_ai_tags:
+      . as $tags
+      | ([$tags[]? | select(blocked_ai_node_tag | not)]) as $eligible
+      | ([$eligible[] | select(us_node_tag)])
+        + ([$eligible[] | select((us_node_tag | not) and japan_node_tag)])
+        + ([$eligible[] | select((us_node_tag | not) and (japan_node_tag | not))]);
     def ai_proxy_selector($tags):
       if ($tags | length) > 0
         then {"type": "selector", "tag": "ai-proxy", "outbounds": $tags, "default": $tags[0]}
@@ -183,7 +193,7 @@ magicnet_singbox_build_outbounds_file_with_jq() {
             ([]; if (map(.tag) | index($node.tag)) != null then . else . + [$node] end)
       ) as $nodes
       | ([ $nodes[] | .tag ]) as $tags
-      | ([ $tags[]? | select(mainland_node_tag | not) ]) as $ai_tags
+      | ($tags | prioritize_ai_tags) as $ai_tags
       | (if ($tags | length) > 0
           then [urltest("proxy-auto"; "https://www.gstatic.com/generate_204"; "3m"; $tags)]
           else []
@@ -428,10 +438,30 @@ EOF
 magicnet_singbox_pinned_ai_tags() {
     _pinned_ai_tags_file="$1"
     awk '
+      function blocked_ai(value, folded) {
+        folded = tolower(value)
+        return value ~ /中国|大陆|内地|香港|台湾|臺灣|台北|臺北|台中|臺中|台南|臺南|高雄|新竹|🇭🇰|🇹🇼|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西/ ||
+          folded ~ /(^|[^[:alnum:]])(hong[ _-]?kong([ _-]?[0-9]+)?|hkg?[ _-]?[0-9]+|taiwan|taipei|taichung|tainan|kaohsiung|hsinchu|tw|twn|china|mainland|hk|hkg|cn|beijing|shanghai|guangzhou|shenzhen|chongqing|tianjin|hebei|shanxi|liaoning|jilin|heilongjiang|jiangsu|zhejiang|anhui|fujian|jiangxi|shandong|henan|hubei|hunan|guangdong|hainan|sichuan|guizhou|yunnan|shaanxi|gansu|qinghai|inner[ _-]?mongolia|guangxi|tibet|ningxia|xinjiang)([^[:alnum:]]|$)/
+      }
+      function us_node(value, folded) {
+        folded = tolower(value)
+        return value ~ /美国|美國|美西|美东|美東|洛杉矶|洛杉磯|圣何塞|聖何塞|西雅图|西雅圖|达拉斯|達拉斯|纽约|紐約|芝加哥|迈阿密|邁阿密|凤凰城|鳳凰城|亚特兰大|亞特蘭大|波特兰|波特蘭|丹佛|拉斯维加斯|拉斯維加斯|硅谷|🇺🇸/ ||
+          folded ~ /(^|[^[:alnum:]])(us|usa|united[ _-]?states|america|los[ _-]?angeles|san[ _-]?jose|seattle|dallas|new[ _-]?york|chicago|washington|miami|phoenix|atlanta|portland|denver|las[ _-]?vegas|silicon[ _-]?valley)([^[:alnum:]]|$)/
+      }
+      function japan_node(value, folded) {
+        folded = tolower(value)
+        return value ~ /日本|东京|東京|大阪|埼玉|名古屋|🇯🇵/ ||
+          folded ~ /(^|[^[:alnum:]])(jp|jpn|japan|tokyo|osaka|saitama|nagoya)([^[:alnum:]]|$)/
+      }
       {
-        folded = tolower($0)
-        if ($0 !~ /中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西/ &&
-            folded !~ /(^|[^[:alnum:]])(hong[ _-]?kong([ _-]?[0-9]+)?|hkg?[ _-]?[0-9]+|china|mainland|hk|hkg|cn|beijing|shanghai|guangzhou|shenzhen|chongqing|tianjin|hebei|shanxi|liaoning|jilin|heilongjiang|jiangsu|zhejiang|anhui|fujian|jiangxi|shandong|henan|hubei|hunan|guangdong|hainan|sichuan|guizhou|yunnan|shaanxi|gansu|qinghai|inner[ _-]?mongolia|guangxi|tibet|ningxia|xinjiang)([^[:alnum:]]|$)/) print
+        if (blocked_ai($0)) next
+        tag[++count] = $0
+        priority[count] = us_node($0) ? 1 : (japan_node($0) ? 2 : 3)
+      }
+      END {
+        for (wanted = 1; wanted <= 3; wanted++)
+          for (item = 1; item <= count; item++)
+            if (priority[item] == wanted) print tag[item]
       }
     ' "$_pinned_ai_tags_file"
     unset _pinned_ai_tags_file
@@ -440,14 +470,16 @@ magicnet_singbox_pinned_ai_tags() {
 magicnet_singbox_sanitize_generated_config() {
     _sanitize_config_file="$1"
     _sanitize_jq="$(command -v jq 2>/dev/null || true)"
+    _sanitize_filter_file=$(magicnet_singbox_subscription_filter_file)
+    [ -f "$_sanitize_filter_file" ] || _sanitize_filter_file=/dev/null
     [ -n "$_sanitize_jq" ] || {
         if magicnet_singbox_ai_selectors_canonical "$_sanitize_config_file"; then
-            unset _sanitize_config_file _sanitize_jq _sanitize_tmp_file _sanitize_rc _sanitize_return
+            unset _sanitize_config_file _sanitize_jq _sanitize_filter_file _sanitize_tmp_file _sanitize_rc _sanitize_return
             return 0
         fi
         magicnet_singbox_ai_selectors_canonical \
             "$_sanitize_config_file" "https://www.google.com/generate_204" "10m" || {
-            unset _sanitize_config_file _sanitize_jq _sanitize_tmp_file _sanitize_rc _sanitize_return
+            unset _sanitize_config_file _sanitize_jq _sanitize_filter_file _sanitize_tmp_file _sanitize_rc _sanitize_return
             return 1
         }
 
@@ -489,18 +521,28 @@ magicnet_singbox_sanitize_generated_config() {
             rm -f "$_sanitize_tmp_file" 2>/dev/null || true
         fi
         if [ "$_sanitize_rc" -eq 0 ]; then
-            unset _sanitize_config_file _sanitize_jq _sanitize_tmp_file _sanitize_rc _sanitize_return
+            unset _sanitize_config_file _sanitize_jq _sanitize_filter_file _sanitize_tmp_file _sanitize_rc _sanitize_return
             return 0
         fi
-        unset _sanitize_config_file _sanitize_jq _sanitize_tmp_file _sanitize_rc _sanitize_return
+        unset _sanitize_config_file _sanitize_jq _sanitize_filter_file _sanitize_tmp_file _sanitize_rc _sanitize_return
         return 1
     }
 
     _sanitize_tmp_file="${_sanitize_config_file}.sanitized"
     # shellcheck disable=SC2016
-    "$_sanitize_jq" '
-      def mainland_node_tag:
-        test("中国|大陆|内地|香港|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:Hong[ _-]?Kong(?:[ _-]?[0-9]+)?|HKG?[ _-]?[0-9]+|China|Mainland|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
+    "$_sanitize_jq" --rawfile configured_filters "$_sanitize_filter_file" '
+      def blocked_ai_node_tag:
+        test("中国|大陆|内地|香港|台湾|臺灣|台北|臺北|台中|臺中|台南|臺南|高雄|新竹|🇭🇰|🇹🇼|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:Hong[ _-]?Kong(?:[ _-]?[0-9]+)?|HKG?[ _-]?[0-9]+|Taiwan|Taipei|Taichung|Tainan|Kaohsiung|Hsinchu|TW|TWN|China|Mainland|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
+      def us_node_tag:
+        test("美国|美國|美西|美东|美東|洛杉矶|洛杉磯|圣何塞|聖何塞|西雅图|西雅圖|达拉斯|達拉斯|纽约|紐約|芝加哥|迈阿密|邁阿密|凤凰城|鳳凰城|亚特兰大|亞特蘭大|波特兰|波特蘭|丹佛|拉斯维加斯|拉斯維加斯|硅谷|🇺🇸|(^|[^A-Za-z0-9])(?:US|USA|United[ _-]?States|America|Los[ _-]?Angeles|San[ _-]?Jose|Seattle|Dallas|New[ _-]?York|Chicago|Washington|Miami|Phoenix|Atlanta|Portland|Denver|Las[ _-]?Vegas|Silicon[ _-]?Valley)([^A-Za-z0-9]|$)"; "i");
+      def japan_node_tag:
+        test("日本|东京|東京|大阪|埼玉|名古屋|🇯🇵|(^|[^A-Za-z0-9])(?:JP|JPN|Japan|Tokyo|Osaka|Saitama|Nagoya)([^A-Za-z0-9]|$)"; "i");
+      def prioritize_ai_tags:
+        . as $tags
+        | ([$tags[]? | select(blocked_ai_node_tag | not)]) as $eligible
+        | ([$eligible[] | select(us_node_tag)])
+          + ([$eligible[] | select((us_node_tag | not) and japan_node_tag)])
+          + ([$eligible[] | select((us_node_tag | not) and (japan_node_tag | not))]);
       def proxy_node_type:
         .type == "shadowsocks" or .type == "vmess" or .type == "vless" or .type == "trojan"
           or .type == "hysteria2" or .type == "anytls" or .type == "tuic";
@@ -611,12 +653,21 @@ magicnet_singbox_sanitize_generated_config() {
           "user",
           "user_id"
         ] | any(. as $key | $rule | has($key));
-      (.outbounds // []) as $outbounds
-      | ($outbounds | dedupe_proxy_nodes) as $deduped_outbounds
+      ($configured_filters
+        | split("\n")
+        | map(gsub("\r"; "") | select(length > 0) | ascii_downcase)) as $filters
+      | (.outbounds // []) as $outbounds
+      | ($outbounds
+          | map(select(
+              (proxy_node
+                and ((.tag // "" | ascii_downcase) as $tag
+                  | $filters | any(. as $filter | $tag | contains($filter)))) | not
+            ))
+          | dedupe_proxy_nodes) as $deduped_outbounds
       | ([$deduped_outbounds[]
           | select(proxy_node)
           | .tag // empty]) as $node_tags
-      | ([$node_tags[] | select(mainland_node_tag | not)]) as $ai_tags
+      | ($node_tags | prioritize_ai_tags) as $ai_tags
       | .outbounds = ($deduped_outbounds
           | map(select(.tag as $tag | [
               "proxy", "proxy-auto",
@@ -636,10 +687,10 @@ magicnet_singbox_sanitize_generated_config() {
     _sanitize_rc=$?
     [ "$_sanitize_rc" -eq 0 ] || rm -f "$_sanitize_tmp_file" 2>/dev/null || true
     if [ "$_sanitize_rc" -eq 0 ]; then
-        unset _sanitize_config_file _sanitize_jq _sanitize_tmp_file _sanitize_rc _sanitize_return
+        unset _sanitize_config_file _sanitize_jq _sanitize_filter_file _sanitize_tmp_file _sanitize_rc _sanitize_return
         return 0
     fi
-    unset _sanitize_config_file _sanitize_jq _sanitize_tmp_file _sanitize_rc _sanitize_return
+    unset _sanitize_config_file _sanitize_jq _sanitize_filter_file _sanitize_tmp_file _sanitize_rc _sanitize_return
     return 1
 }
 


### PR DESCRIPTION
## What changed

- reapply subscription keyword filters during generated/cached outbound sanitization, so filtered nodes cannot survive config repair or cache replay
- order AI candidates with United States nodes first, Japan second, then other eligible regions
- exclude mainland China, Hong Kong, and Taiwan labels from `ai-proxy` and every per-service AI selector
- keep the jq and pure-shell generators plus canonical validators aligned
- add regression coverage for Taiwan variants, boundary false positives, stable regional priority, and cached-node filtering

## Root cause

Fresh subscription conversion applied the configured filter list, but the later sanitizer/cache-replay path rebuilt selectors from existing outbounds without applying that list again. AI selectors also inherited provider order and treated Taiwan as eligible, so their first/default node was not deterministic.

## Impact

Newly generated and repaired configurations now remove filtered nodes consistently. `ai-chatgpt`, `ai-gemini`, `ai-grok`, `ai-claude`, and `ai-proxy` all start with the same US → Japan → other-region candidate order while excluding mainland China, Hong Kong, and Taiwan. Explicit saved selector choices remain subject to the existing replay rules.

## Validation

- `bash scripts/test-anthropic-routing.sh`
- `bash scripts/singbox-subscription-protocol-smoke.sh`
- `bash -n` for the modified shell scripts
- `git diff --check`

The broader default-routing test could not start in the local workspace because the `sing-box` executable was unavailable. Cargo and ShellCheck were also unavailable in the environment.

## Summary by Sourcery

在 sing-box 配置清理过程中应用订阅关键字过滤，并统一 AI 选择器候选的排序规则和区域排除策略。

New Features:
- 对缓存和修复后的 sing-box 出站连接应用用户配置的订阅关键字过滤，确保被过滤的节点能够被一致地移除。
- 在所有 AI 服务中强制使用统一的 AI 选择器排序规则：优先美国节点，其次日本节点，然后其他符合条件的地区节点。

Enhancements:
- 在基于 jq 和纯 shell 的生成器中，将中国大陆、香港和台湾标记的节点从 `ai-proxy` 以及所有按服务区分的 AI 选择器中排除。
- 使 jq 和 awk/规范化验证器与新的 AI 过滤与优先级规则保持一致，以确保生成的配置前后一致。
- 扩展 anthropic 路由测试，覆盖台湾标签处理、区域优先级稳定性，以及在启用订阅过滤时清理器的行为。

Documentation:
- 在 MagicNet 的 README 和变更日志中记录扩展后的订阅过滤行为和 AI 选择器的区域规则。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Apply subscription keyword filters during sing-box config sanitization and standardize AI selector candidate ordering and region exclusions.

New Features:
- Apply user-configured subscription keyword filters to cached and repaired sing-box outbounds so filtered nodes are consistently removed.
- Enforce a unified AI selector ordering that prioritizes United States nodes, then Japan, then other eligible regions across all AI services.

Enhancements:
- Exclude mainland China, Hong Kong, and Taiwan labeled nodes from ai-proxy and all per-service AI selectors in both jq-based and pure-shell generators.
- Align jq and awk/canonical validators with the new AI filtering and prioritization rules to keep generated configurations consistent.
- Extend anthropic routing tests to cover Taiwan label handling, regional priority stability, and sanitizer behavior with subscription filters.

Documentation:
- Document the extended subscription filtering behavior and AI selector regional rules in the MagicNet README and changelog.

</details>