### PR TITLE
feat: add category-aware issue diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ su -c /data/adb/modules/MagicNet/cli health
 - 通过 `magicnet0` TUN 接管设备应用流量。
 - 用 `sing-box` 导入订阅、选择节点和执行路由规则。
 - 拦截物理出口上的直连 DNS/DoT（53/853），减少 DNS 绕过。
+- 为已经进入 TUN 的热点转发流量选择 Direct 或 Proxy 出口。
+- 按应用设置代理、直连或 Bypass TUN，便于与外部 VPN 共存。
 - 提供 WebUI、CLI、MCP 和支持包，便于日常控制与排查。
 
-当前主线只维护 `sing-box` 和 TUN。不会维护 TProxy、多核心切换、热点代理或 VPN 共存模式。
+当前主线只维护 `sing-box` 和 `magicnet0` TUN，不恢复 TProxy 或多核心路径。热点功能只选择已经进入 TUN 的转发流量出口；应用的 `bypass` 策略会把指定应用排除在 TUN 之外，MagicNet 仍不会占用或管理 Android 的系统 VPN slot。
 
 ## 安装
 
@@ -103,6 +105,16 @@ su -c /data/adb/modules/MagicNet/cli network status
 # 网络或节点不支持 IPv6 时切换兼容模式
 su -c '/data/adb/modules/MagicNet/cli network set ipv4_only 1400 5m'
 
+# 查看热点流量当前走 Direct 还是 Proxy
+su -c /data/adb/modules/MagicNet/cli hotspot status
+
+# 允许热点流量使用 Proxy；disable 可恢复 Direct
+su -c /data/adb/modules/MagicNet/cli hotspot enable
+
+# 让指定应用走代理、直连或绕过 MagicNet TUN
+su -c '/data/adb/modules/MagicNet/cli app add com.example.app proxy'
+su -c '/data/adb/modules/MagicNet/cli app add com.example.vpn bypass'
+
 # 重启 sing-box
 su -c /data/adb/modules/MagicNet/cli service restart sing-box
 
@@ -125,7 +137,18 @@ adb shell 'su -M -c "timeout 10 tcpdump -ni rmnet_data0 \"port 53 or port 853\""
 
 不同设备的蜂窝接口不一定叫 `rmnet_data0`，请以第一条命令的输出为准。
 
-MagicNet 只管理自身的数据面，不接管热点转发、外部 VPN overlay 或厂商 tethering 规则。
+MagicNet 只管理自身的数据面，不创建热点、不配置厂商 tethering/NAT，也不接管外部 VPN overlay。系统热点把转发流量送入 `magicnet0` 后，可以用 `cli hotspot {status|enable|disable}` 在 Direct 和 Proxy 之间切换。
+
+## 反馈问题
+
+WebUI 的“反馈问题 / 创建 Issue”会先选择问题类型，再收集对应的脱敏上下文：
+
+- App 无法联网：近期连接的进程、规则、代理链和 sing-box 日志尾部；目标地址、连接 ID 与私有节点名会被过滤。
+- 命令或操作报错：上一条命令的安全分类、执行阶段、后台状态和错误输出。
+- 订阅或节点异常：订阅状态、选择器摘要和相关日志。
+- DNS、TUN 或分流异常：健康检查、DNS、网络与透明代理状态。
+
+生成的正文会复制到剪贴板，并以同一份内容打开 GitHub。提交前仍建议快速检查一次正文。
 
 ## 文档
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -15,6 +15,8 @@ scripts/package-install-smoke.sh dist/MagicNet.zip
 - `.config/kamfw/.envrc` 中的 `MAGIC_MIHOMO`、`MAGIC_HOTSPOT_FORWARD`、`MAGIC_VPN_COEXIST` 等旧运行时导出。
 - mihomo、TProxy、抓包代理和旧透明路径相关文件。
 
+这里拒绝的是旧版 `.envrc` 运行时导出。当前热点策略由 `cli hotspot {status|enable|disable}` 管理 sing-box 的 `hotspot` selector，不依赖 `MAGIC_HOTSPOT_FORWARD`。
+
 ## 本地私有配置
 
 仓库根目录的 `.env` 只用于本机私有变量，例如订阅地址或构建机私有参数。不要把 `.env`、订阅 URL、token、secret 或 password 写入文档、测试夹具、提交记录或发布包。
@@ -28,6 +30,8 @@ scripts/package-install-smoke.sh dist/MagicNet.zip
 ## 注意
 
 `MAGIC_SINGBOX=0` 只应作为开发者临时调试构建钩子的开关使用，不是发布包或运行时禁用 sing-box 的设计。默认构建必须包含 `bin/sing-box` 和默认 `.config/sing-box/config.json`。
+
+WebUI 构建钩子会运行 `npm run check` 或 `bun run check`，依次执行前端单元测试、TypeScript 类型检查和生产构建。任何一项失败都会中止模块打包。
 
 ## 发布依赖锁
 

--- a/docs/local-simulation.md
+++ b/docs/local-simulation.md
@@ -79,6 +79,8 @@ scripts/fake-magisk-smoke.sh dist/MagicNet.zip
 scripts/pre-commit.sh
 ```
 
+这个入口也会检查仓库卫生、路由架构、应用分流、广告规则、配置解析安全、MCP 启动配置和 WebUI。WebUI 测试覆盖 Issue 类型选择、按类型收集上下文、连接目标脱敏和命令错误摘要；构建模块时同样会通过 WebUI `check` 执行这些测试。
+
 `fake-magisk-smoke.sh` 会：
 
 - 解包 zip 到临时模块目录。

--- a/hooks/pre-build/2000.BUILD_WEBUI.sh
+++ b/hooks/pre-build/2000.BUILD_WEBUI.sh
@@ -13,11 +13,11 @@ if [ ! -f "${WEBUI_ROOT}/package.json" ]; then
 fi
 
 if command -v bun >/dev/null 2>&1; then
-    log_info "Building MagicNet WebUI with bun"
-    (cd "$WEBUI_ROOT" && bun install --frozen-lockfile && bun run build)
+    log_info "Testing and building MagicNet WebUI with bun"
+    (cd "$WEBUI_ROOT" && bun install --frozen-lockfile && bun run check)
 elif command -v npm >/dev/null 2>&1; then
-    log_info "Building MagicNet WebUI with npm"
-    (cd "$WEBUI_ROOT" && npm install && npm run build)
+    log_info "Testing and building MagicNet WebUI with npm"
+    (cd "$WEBUI_ROOT" && npm install && npm run check)
 else
     log_error "bun or npm is required to build MagicNet WebUI"
     exit 1

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -34,11 +34,18 @@ mapfile -t posix_shell_files < <(
 shellcheck -s sh -e SC1091,SC1090,SC2329,SC2059 "${posix_shell_files[@]}"
 
 jq empty src/MagicNet/.config/sing-box/config.json
+bash scripts/test-repository-hygiene.sh
 sh scripts/test-kamfw-i18n.sh
 bash scripts/test-default-routing-policy.sh
+bash scripts/test-policy-architecture.sh
+bash scripts/test-ad-routing.sh
+bash scripts/test-app-routing-policy.sh
+bash scripts/test-block-conf-safety.sh
 bash scripts/test-wechat-routing.sh
 bash scripts/test-action-routing.sh
 bash scripts/test-anthropic-routing.sh
+bash scripts/test-mcp-phase-config.sh
+bash scripts/test-rule-hash-retry.sh
 bash scripts/singbox-subscription-protocol-smoke.sh
 bash scripts/test-singbox-pid-discovery.sh
 bash scripts/test-subscription-activation-order.sh

--- a/scripts/test-repository-hygiene.sh
+++ b/scripts/test-repository-hygiene.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+fail() {
+    printf 'repository hygiene failed: %s\n' "$*" >&2
+    exit 1
+}
+
+tracked_garbage="$(
+    git ls-files | grep -E \
+        '(^|/)(target|dist|node_modules|__pycache__|\.pytest_cache|\.mypy_cache)(/|$)|(^|/)(\.DS_Store|Thumbs\.db)$|(\.log|\.tmp|\.swp|~)$' \
+        || true
+)"
+[[ -z "$tracked_garbage" ]] || fail "tracked build/cache/editor artifacts found:
+$tracked_garbage"
+
+for sensitive in .env .tokensave; do
+    if git ls-files --error-unmatch "$sensitive" >/dev/null 2>&1; then
+        fail "private local file is tracked: $sensitive"
+    fi
+done
+
+allowed_empty_files=(
+    "src/MagicNet/.config/magicnet/route-block-domain-suffix.list"
+    "src/MagicNet/.config/magicnet/route-direct-domain-suffix.list"
+    "src/MagicNet/.config/magicnet/route-proxy-domain-suffix.list"
+)
+
+empty_tracked=()
+while IFS= read -r -d '' file; do
+    [[ -f "$file" && ! -s "$file" ]] || continue
+    allowed=0
+    for expected in "${allowed_empty_files[@]}"; do
+        if [[ "$file" == "$expected" ]]; then
+            allowed=1
+            break
+        fi
+    done
+    [[ "$allowed" -eq 1 ]] || empty_tracked+=("$file")
+done < <(git ls-files -z)
+
+if [[ "${#empty_tracked[@]}" -gt 0 ]]; then
+    printf 'repository hygiene failed: unexpected empty tracked files:\n' >&2
+    printf '  %s\n' "${empty_tracked[@]}" >&2
+    exit 1
+fi
+
+grep -Fq 'cli hotspot status' README.md \
+    || fail "README must document the supported hotspot selector"
+if grep -Fq '不会维护 TProxy、多核心切换、热点代理或 VPN 共存模式' README.md; then
+    fail "README still claims that the supported hotspot selector is not maintained"
+fi
+grep -Fq '先选择问题类型' README.md \
+    || fail "README must document category-aware Issue context collection"
+
+printf 'repository hygiene tests passed\n'

--- a/webui/issue-reporter-dialog.test.mjs
+++ b/webui/issue-reporter-dialog.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const dialog = readFileSync(
+  new URL("./src/components/IssueReporterDialog.vue", import.meta.url),
+  "utf8",
+);
+const reporter = readFileSync(
+  new URL("./src/composables/issueReporter.ts", import.meta.url),
+  "utf8",
+);
+const magicnet = readFileSync(
+  new URL("./src/composables/useMagicNet.ts", import.meta.url),
+  "utf8",
+);
+const app = readFileSync(new URL("./src/App.vue", import.meta.url), "utf8");
+
+assert.match(dialog, /你遇到了哪类问题？/);
+assert.match(dialog, /v-for="option in ISSUE_KIND_OPTIONS"/);
+assert.match(dialog, /type="radio"/);
+assert.match(dialog, /将收集：\{\{ option\.context \}\}/);
+assert.match(dialog, /订阅地址、token、IP、目标域名和本地路径会被过滤/);
+assert.match(dialog, /role="dialog"/);
+assert.match(dialog, /aria-modal="true"/);
+assert.match(dialog, /@keydown\.esc\.prevent\.stop/);
+
+assert.match(reporter, /kind === "app-connectivity"/);
+assert.match(reporter, /runCli\("api conns", "读取近期活动连接", true\)/);
+assert.match(reporter, /runCli\("service logs sing-box 160", "读取近期连接日志", true\)/);
+assert.match(reporter, /kind === "command-error"/);
+assert.match(reporter, /commandFailureContext\(operation\)/);
+assert.match(reporter, /kind === "subscription-node"/);
+assert.match(reporter, /runCli\("sub status", "读取订阅状态", true\)/);
+assert.match(reporter, /kind === "dns-routing"/);
+for (const command of ["health", "dns status", "network status", "transparent status"]) {
+  assert.match(reporter, new RegExp(`runCli\\("${command}"`));
+}
+
+assert.match(magicnet, /state\.issueReporter\.open = true/);
+assert.match(magicnet, /createMagicNetIssue\(\{ state, runShell, runCli \}, kind\)/);
+assert.match(app, /<IssueReporterDialog/);
+assert.match(app, /@confirm="submitIssue"/);
+
+console.log("issue reporter dialog tests passed");

--- a/webui/issue-reporter.test.mjs
+++ b/webui/issue-reporter.test.mjs
@@ -1,5 +1,14 @@
 import assert from "node:assert/strict";
-import { buildIssueBody, buildIssueUrl, classifyOperationCommand, sanitizeDiagnosticText } from "./src/composables/issueDrafts.ts";
+import {
+  ISSUE_KIND_OPTIONS,
+  buildIssueBody,
+  buildIssueUrl,
+  classifyOperationCommand,
+  commandFailureContext,
+  sanitizeConnectionLog,
+  sanitizeDiagnosticText,
+  summarizeConnectionsForIssue,
+} from "./src/composables/issueDrafts.ts";
 
 const canaries = [
   "https://node.example.invalid/private/path?token=URL-CANARY",
@@ -10,12 +19,15 @@ const canaries = [
   "NODE-CANARY",
 ];
 const parts = {
+  kind: "command-error",
   moduleProp: `version=v-test\nupdateJson=${canaries[0]}`,
   device: `model=test\nemail=${canaries[2]}\nip=${canaries[3]}\npath=${canaries[4]}`,
   support: `token=${canaries[1]}\nnode=${canaries[5]}\n${"safe event\n".repeat(800)}`,
+  focusedContext: "captured failure errno=1",
   operation: {
     phase: "error",
     lastCommand: `magicnet sub apply-file sing-box ${canaries[0]}`,
+    lastOutput: `$ magicnet sub apply-file sing-box ${canaries[0]}\n[error] token=${canaries[1]}`,
     backgroundLabel: "refresh",
     backgroundArgs: `node=${canaries[5]}`,
     backgroundStatus: "timeout",
@@ -27,7 +39,9 @@ assert.equal(body, buildIssueBody(parts), "canonical body must be deterministic"
 assert.ok(body.length <= 5200, "canonical body must fit the URL budget");
 assert.match(body, /## Module/);
 assert.match(body, /## Device/);
-assert.match(body, /## Support Bundle/);
+assert.match(body, /问题类型：命令或操作报错/);
+assert.match(body, /## Focused Context/);
+assert.match(body, /## Support Summary/);
 assert.match(body, /## UI Operation/);
 assert.doesNotMatch(body, /Service Status|## Health|## MCP|Network Probe/);
 for (const canary of canaries) assert.equal(body.includes(canary), false, `leaked ${canary}`);
@@ -57,6 +71,12 @@ for (const command of sensitiveCommands) {
 }
 const passwordBody = buildIssueBody({
   ...parts,
+  focusedContext: commandFailureContext({
+    ...parts.operation,
+    lastCommand: sensitiveCommands[0],
+    lastOutput: `$ ${sensitiveCommands[0]}\n[error] backup failed password=${reviewerBarePassword}`,
+    backgroundArgs: sensitiveCommands[1],
+  }),
   operation: { ...parts.operation, lastCommand: sensitiveCommands[0], backgroundArgs: sensitiveCommands[1] },
 });
 const passwordUrl = buildIssueUrl("https://github.com/example/repo", "password regression", passwordBody);
@@ -102,5 +122,58 @@ const sanitizedDeviceKeys = sanitizeDiagnosticText(deviceKeyInput);
 for (const sensitive of Object.values(deviceCanaries)) {
   assert.equal(sanitizedDeviceKeys.includes(sensitive), false, `device-key sanitizer leaked ${sensitive}`);
 }
+
+assert.deepEqual(
+  ISSUE_KIND_OPTIONS.map(({ value }) => value),
+  ["app-connectivity", "command-error", "subscription-node", "dns-routing", "other"],
+);
+assert.ok(ISSUE_KIND_OPTIONS.every(({ context }) => context.startsWith("附带")));
+
+const connections = JSON.stringify({
+  connections: [
+    {
+      id: "private-connection-id",
+      metadata: {
+        host: "private.example.invalid",
+        destinationIP: "192.0.2.44",
+        sourceIP: "10.0.0.9",
+        processPackageName: "com.example.browser",
+        network: "tcp",
+      },
+      inbound: "tun-in",
+      rule: "RuleSet",
+      rulePayload: "private.example.invalid",
+      chains: ["ai-proxy", "US-Private-Node"],
+      upload: 1234,
+      download: 5678,
+    },
+  ],
+});
+const connectionSummary = summarizeConnectionsForIssue(connections);
+assert.match(connectionSummary, /active_connection_count=1/);
+assert.match(connectionSummary, /process=com\.example\.browser/);
+assert.match(connectionSummary, /inbound=tun-in/);
+assert.match(connectionSummary, /rule=RuleSet/);
+assert.match(connectionSummary, /chain=ai-proxy -> \[selected-node\]/);
+for (const sensitive of ["private-connection-id", "private.example.invalid", "192.0.2.44", "10.0.0.9", "US-Private-Node", "1234", "5678"]) {
+  assert.equal(connectionSummary.includes(sensitive), false, `connection summary leaked ${sensitive}`);
+}
+
+const sanitizedLog = sanitizeConnectionLog(
+  "INFO inbound/tun connection from 10.0.0.9:41234 to private.example.invalid:443 outbound=ai-proxy",
+);
+assert.match(sanitizedLog, /from \[filtered-endpoint\] to \[filtered-endpoint\]/);
+assert.match(sanitizedLog, /outbound=ai-proxy/);
+assert.doesNotMatch(sanitizedLog, /private\.example\.invalid|10\.0\.0\.9/);
+const selectedNodeLog = sanitizeConnectionLog("INFO selector=US-Private-Node selected node is JP-Secret");
+assert.match(selectedNodeLog, /selector=\[selected-node\]/);
+assert.match(selectedNodeLog, /selected node is \[selected-node\]/);
+assert.doesNotMatch(selectedNodeLog, /US-Private-Node|JP-Secret/);
+
+const commandContext = commandFailureContext(parts.operation);
+assert.match(commandContext, /captured_command=command=sub\.apply-file arguments=filtered/);
+assert.match(commandContext, /\[captured output\]/);
+assert.doesNotMatch(commandContext, /^\$\s/m);
+for (const sensitive of canaries) assert.equal(commandContext.includes(sensitive), false, `command context leaked ${sensitive}`);
 
 console.log("issue reporter tests passed");

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -23,6 +23,7 @@ import { computed, defineAsyncComponent, nextTick, onMounted, onUnmounted, ref, 
 import { MAGICNET_LOGO_URL } from "@/branding";
 import Badge from "@/components/ui/Badge.vue";
 import Button from "@/components/ui/Button.vue";
+import IssueReporterDialog from "@/components/IssueReporterDialog.vue";
 import { useMagicNet } from "@/composables/useMagicNet";
 import { useTheme } from "@/composables/useTheme";
 
@@ -65,6 +66,8 @@ const {
   refreshDns,
   refreshWarp,
   createIssue,
+  closeIssueReporter,
+  submitIssue,
   openExternal,
   REPO,
   AUTHOR_WHISPER_URL,
@@ -156,6 +159,11 @@ function setTab(tab: TabKey): void {
     ).find((item) => item.offsetParent !== null);
     target?.scrollIntoView({ block: "nearest", inline: "center" });
   });
+}
+
+async function requestIssue(): Promise<void> {
+  if (showAdvancedNav.value) closeAdvancedNav(false);
+  await createIssue();
 }
 
 async function openAdvancedNav(event: MouseEvent): Promise<void> {
@@ -512,7 +520,7 @@ onUnmounted(() => {
             <Button
               class="min-h-11"
               :loading="state.task === '创建 GitHub issue'"
-              @click="createIssue"
+              @click="requestIssue"
             >
               <Bug :size="18" />反馈问题
             </Button>
@@ -527,6 +535,13 @@ onUnmounted(() => {
         </div>
       </div>
     </Transition>
+
+    <IssueReporterDialog
+      v-if="state.issueReporter.open"
+      :loading="state.task === '创建 GitHub issue'"
+      @cancel="closeIssueReporter"
+      @confirm="submitIssue"
+    />
 
     <Transition name="toast">
       <aside v-if="easterEggVisible" class="mn-chrome fixed bottom-28 right-3 z-50 max-w-[calc(100vw-1.5rem)] rounded-md p-1 md:bottom-8 md:right-8 md:max-w-sm" role="status" aria-live="polite">

--- a/webui/src/components/IssueReporterDialog.vue
+++ b/webui/src/components/IssueReporterDialog.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import { nextTick, onMounted, onUnmounted, ref } from "vue";
+import { Bug, ShieldCheck, X } from "lucide-vue-next";
+import Button from "@/components/ui/Button.vue";
+import {
+  ISSUE_KIND_OPTIONS,
+  type IssueKind,
+} from "@/composables/issueDrafts";
+
+defineProps<{
+  loading?: boolean;
+}>();
+
+const emit = defineEmits<{
+  cancel: [];
+  confirm: [kind: IssueKind];
+}>();
+
+const dialog = ref<HTMLElement | null>(null);
+const selected = ref<IssueKind>("app-connectivity");
+let previousBodyOverflow = "";
+
+function confirm(): void {
+  emit("confirm", selected.value);
+}
+
+function trapFocus(event: KeyboardEvent): void {
+  if (event.key !== "Tab" || !dialog.value) return;
+  const focusable = Array.from(
+    dialog.value.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter((element) => element.getClientRects().length > 0);
+  if (!focusable.length) {
+    event.preventDefault();
+    dialog.value.focus();
+    return;
+  }
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement;
+  if (event.shiftKey && (active === first || !dialog.value.contains(active))) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
+onMounted(() => {
+  previousBodyOverflow = document.body.style.overflow;
+  document.body.style.overflow = "hidden";
+  void nextTick(() => {
+    dialog.value?.querySelector<HTMLInputElement>('input[type="radio"]:checked')?.focus();
+  });
+});
+
+onUnmounted(() => {
+  document.body.style.overflow = previousBodyOverflow;
+});
+</script>
+
+<template>
+  <div class="fixed inset-0 z-[70] grid place-items-end p-3 sm:place-items-center sm:p-6">
+    <button
+      class="absolute inset-0 size-full bg-[color-mix(in_srgb,var(--mn-ink)_42%,transparent)]"
+      type="button"
+      aria-label="取消创建 Issue"
+      @click="emit('cancel')"
+    />
+    <section
+      ref="dialog"
+      class="mn-chrome relative z-10 grid max-h-[calc(100dvh-1.5rem)] w-full max-w-2xl gap-4 overflow-y-auto rounded-md p-1.5"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="issue-reporter-title"
+      aria-describedby="issue-reporter-description"
+      tabindex="-1"
+      @keydown="trapFocus"
+      @keydown.esc.prevent.stop="emit('cancel')"
+    >
+      <div class="rounded-[5px] bg-[var(--mn-ivory)] p-4 sm:p-5">
+        <div class="flex items-start justify-between gap-4">
+          <div class="min-w-0">
+            <span class="inline-flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--mn-clay)]">
+              <Bug :size="14" /> Issue Context
+            </span>
+            <h2 id="issue-reporter-title" class="mt-2 text-xl font-semibold tracking-[-0.03em] text-[var(--mn-ink)]">
+              你遇到了哪类问题？
+            </h2>
+            <p id="issue-reporter-description" class="mt-1 text-sm leading-6 text-[var(--mn-ink-muted)]">
+              选择一项后，MagicNet 只收集与该问题最相关的诊断上下文，并在打开 GitHub 前完成脱敏。
+            </p>
+          </div>
+          <Button variant="ghost" size="icon" aria-label="取消创建 Issue" @click="emit('cancel')">
+            <X :size="18" />
+          </Button>
+        </div>
+
+        <fieldset class="mt-4 grid gap-2">
+          <legend class="sr-only">问题类型</legend>
+          <label
+            v-for="option in ISSUE_KIND_OPTIONS"
+            :key="option.value"
+            :class="[
+              'grid cursor-pointer grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 rounded-md border p-3 transition-colors',
+              selected === option.value
+                ? 'border-[var(--mn-cactus)] bg-[color-mix(in_srgb,var(--mn-cactus)_12%,var(--mn-ivory))]'
+                : 'border-[var(--mn-border)] bg-[var(--mn-carrier)] hover:bg-[var(--mn-carrier-deep)]',
+            ]"
+          >
+            <input
+              v-model="selected"
+              class="mt-1 size-4 accent-[var(--mn-cactus)]"
+              type="radio"
+              name="issue-kind"
+              :value="option.value"
+            />
+            <span class="min-w-0">
+              <strong class="block text-sm font-semibold text-[var(--mn-ink)]">{{ option.label }}</strong>
+              <span class="mt-0.5 block text-xs leading-5 text-[var(--mn-ink-muted)]">{{ option.description }}</span>
+              <span class="mt-1.5 block text-xs leading-5 text-[var(--mn-ink-soft)]">
+                将收集：{{ option.context }}
+              </span>
+            </span>
+          </label>
+        </fieldset>
+
+        <div class="mt-4 flex flex-col gap-3 border-t border-[var(--mn-border)] pt-4 sm:flex-row sm:items-center sm:justify-between">
+          <p class="inline-flex items-center gap-2 text-xs leading-5 text-[var(--mn-ink-muted)]">
+            <ShieldCheck :size="16" class="shrink-0 text-[var(--mn-cactus-deep)]" />
+            订阅地址、token、IP、目标域名和本地路径会被过滤。
+          </p>
+          <div class="flex gap-2 sm:shrink-0">
+            <Button class="flex-1 sm:flex-none" variant="outline" @click="emit('cancel')">取消</Button>
+            <Button class="flex-1 sm:flex-none" :loading="loading" @click="confirm">收集并创建</Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/webui/src/composables/issueDrafts.ts
+++ b/webui/src/composables/issueDrafts.ts
@@ -1,5 +1,54 @@
 const MAX_ISSUE_BODY_CHARS = 5200;
 
+export type IssueKind =
+  | "app-connectivity"
+  | "command-error"
+  | "subscription-node"
+  | "dns-routing"
+  | "other";
+
+export const ISSUE_KIND_OPTIONS: ReadonlyArray<{
+  value: IssueKind;
+  label: string;
+  description: string;
+  context: string;
+}> = [
+  {
+    value: "app-connectivity",
+    label: "某个 App 无法联网",
+    description: "应用打不开、连接超时，或流量走错出口。",
+    context: "附带近期活动连接的进程、规则和代理链，以及脱敏后的 sing-box 日志尾部。",
+  },
+  {
+    value: "command-error",
+    label: "命令或操作报错",
+    description: "CLI/WebUI 操作失败、超时或没有生效。",
+    context: "附带上一条命令的安全分类、执行阶段、后台任务状态和脱敏错误输出。",
+  },
+  {
+    value: "subscription-node",
+    label: "订阅或节点异常",
+    description: "订阅更新失败、节点不可用，或代理组选择异常。",
+    context: "附带订阅状态、选择器摘要和相关 sing-box 日志。",
+  },
+  {
+    value: "dns-routing",
+    label: "DNS、TUN 或分流异常",
+    description: "DNS 泄露、TUN 未接管、直连/代理分流不符合预期。",
+    context: "附带健康检查、DNS、网络与透明代理状态。",
+  },
+  {
+    value: "other",
+    label: "其他问题",
+    description: "不属于以上类型，或暂时无法判断。",
+    context: "附带通用支持包和最近一次 WebUI 操作摘要。",
+  },
+];
+
+export function issueKindLabel(kind: IssueKind): string {
+  return ISSUE_KIND_OPTIONS.find((option) => option.value === kind)?.label || "其他问题";
+}
+
 function fenced(text: string): string {
   const body = text.trim() || "(empty)";
   return `\`\`\`text\n${body.replace(/```/g, "`\u200b``")}\n\`\`\``;
@@ -43,6 +92,7 @@ export function sanitizeDiagnosticText(text: string): string {
 export type IssueOperationContext = {
   phase: string;
   lastCommand: string;
+  lastOutput: string;
   backgroundLabel: string;
   backgroundArgs: string;
   backgroundStatus: string;
@@ -94,10 +144,127 @@ function operationText(operation: IssueOperationContext): string {
   ].join("\n");
 }
 
+function safeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function connectionProcess(metadata: Record<string, unknown>): string {
+  const packageName = safeString(metadata.processPackageName);
+  if (packageName) return packageName;
+  const processName = safeString(metadata.processName);
+  if (processName) return processName;
+  const processPath = safeString(metadata.processPath);
+  return processPath.split("/").filter(Boolean).at(-1) || "";
+}
+
+const SAFE_ROUTE_TAGS = new Set([
+  "proxy",
+  "select",
+  "final",
+  "proxy-rule",
+  "dns-guard",
+  "network-test",
+  "hotspot",
+  "download-direct",
+  "dev-proxy",
+  "social-proxy",
+  "media-proxy",
+  "game-proxy",
+  "telegram-proxy",
+  "ai-proxy",
+  "ai-chatgpt",
+  "ai-gemini",
+  "ai-grok",
+  "ai-claude",
+  "direct",
+  "block",
+  "warp",
+]);
+
+function safeRouteHop(value: unknown): string {
+  const hop = safeString(value);
+  return SAFE_ROUTE_TAGS.has(hop) ? hop : "[selected-node]";
+}
+
+/**
+ * Keep routing evidence useful without exporting destinations, source
+ * addresses, connection IDs, traffic sizes, or subscription-provided node
+ * names. Selector tags such as proxy-rule/direct remain visible.
+ */
+export function summarizeConnectionsForIssue(text: string): string {
+  try {
+    const root = JSON.parse(text) as Record<string, unknown>;
+    const raw = Array.isArray(root.connections) ? root.connections : null;
+    if (!raw) return "active_connections=unavailable";
+    const rows = raw
+      .slice(-12)
+      .map((value, index) => {
+        if (!value || typeof value !== "object") return "";
+        const item = value as Record<string, unknown>;
+        const metadata = item.metadata && typeof item.metadata === "object"
+          ? item.metadata as Record<string, unknown>
+          : {};
+        const process = connectionProcess(metadata);
+        const network = safeString(metadata.network);
+        const inbound = safeString(item.inbound)
+          || safeString(metadata.inbound)
+          || safeString(metadata.type);
+        const rule = safeString(item.rule);
+        const chain = Array.isArray(item.chains)
+          ? item.chains.map(safeRouteHop).filter(Boolean).slice(0, 8).join(" -> ")
+          : "";
+        return [
+          `connection.${index + 1}`,
+          process ? `process=${process}` : "",
+          inbound ? `inbound=${inbound}` : "",
+          network ? `network=${network}` : "",
+          rule ? `rule=${rule}` : "",
+          chain ? `chain=${chain}` : "",
+        ].filter(Boolean).join(" ");
+      })
+      .filter(Boolean);
+    return [
+      `active_connection_count=${raw.length}`,
+      `included_recent_connections=${rows.length}`,
+      ...rows,
+    ].join("\n");
+  } catch {
+    return "active_connections=unavailable\nparse_error=invalid response";
+  }
+}
+
+export function sanitizeConnectionLog(text: string): string {
+  return sanitizeDiagnosticText(text)
+    .replace(/\b(to|from)\s+[^\s,;]+/gi, "$1 [filtered-endpoint]")
+    .replace(/\b(destination|host|domain|source)(\s*[:=]\s*)[^\s,;]+/gi, "$1$2[filtered-endpoint]")
+    .replace(/\b(outbound|selector)(\s*[:=]\s*)([^\s,;]+)/gi, (_match, key, separator, value) => (
+      `${key}${separator}${SAFE_ROUTE_TAGS.has(value) ? value : "[selected-node]"}`
+    ))
+    .replace(/\b(selected\s+node|node)(\s+(?:to|is)\s+|\s*[:=]\s*)[^\s,;]+/gi, "$1$2[selected-node]");
+}
+
+export function commandFailureContext(operation: IssueOperationContext): string {
+  const output = operation.lastOutput
+    .split(/\r?\n/)
+    .filter((line) => !/^\s*\$\s+/.test(line))
+    .join("\n");
+  return [
+    `captured_phase=${operation.phase || "idle"}`,
+    `captured_command=${classifyOperationCommand(operation.lastCommand || "")}`,
+    `background_status=${operation.backgroundStatus || "idle"}`,
+    `background_command=${classifyOperationCommand(operation.backgroundArgs || "")}`,
+    "",
+    "[captured output]",
+    deterministicSlice(sanitizeDiagnosticText(output), 1800),
+  ].join("\n");
+}
+
 export function buildIssueBody(parts: {
+  kind: IssueKind;
   moduleProp: string;
   device: string;
   support: string;
+  focusedContext: string;
   operation: IssueOperationContext;
 }): string {
   const sections = [
@@ -105,12 +272,15 @@ export function buildIssueBody(parts: {
     "",
     "请在这里描述你遇到的问题、复现步骤和期望结果。",
     "",
+    `问题类型：${issueKindLabel(parts.kind)}`,
+    "",
     "## Generated Context",
     "",
-    issueSection("Module", deterministicSlice(sanitizeDiagnosticText(parts.moduleProp), 500)),
-    issueSection("Device", deterministicSlice(sanitizeDiagnosticText(parts.device), 500)),
-    issueSection("Support Bundle", deterministicSlice(sanitizeDiagnosticText(parts.support), 3000)),
-    issueSection("UI Operation", deterministicSlice(sanitizeDiagnosticText(operationText(parts.operation)), 600)),
+    issueSection("Focused Context", deterministicSlice(sanitizeDiagnosticText(parts.focusedContext), 2350)),
+    issueSection("Support Summary", deterministicSlice(sanitizeDiagnosticText(parts.support), 1150)),
+    issueSection("Module", deterministicSlice(sanitizeDiagnosticText(parts.moduleProp), 350)),
+    issueSection("Device", deterministicSlice(sanitizeDiagnosticText(parts.device), 350)),
+    issueSection("UI Operation", deterministicSlice(sanitizeDiagnosticText(operationText(parts.operation)), 650)),
   ].join("\n");
   return deterministicSlice(sections, MAX_ISSUE_BODY_CHARS);
 }

--- a/webui/src/composables/issueReporter.ts
+++ b/webui/src/composables/issueReporter.ts
@@ -1,5 +1,15 @@
 import { MODULE_DIR, REPO } from "@/constants";
-import { buildIssueBody, buildIssueUrl, propValue } from "@/composables/issueDrafts";
+import {
+  buildIssueBody,
+  buildIssueUrl,
+  commandFailureContext,
+  issueKindLabel,
+  propValue,
+  sanitizeConnectionLog,
+  summarizeConnectionsForIssue,
+  type IssueKind,
+  type IssueOperationContext,
+} from "@/composables/issueDrafts";
 import { copyText, intentDataQuote, shellQuote } from "@/utils";
 import type { RuntimeState } from "@/types";
 import type { BackgroundTaskState } from "@/composables/backgroundTasks";
@@ -22,10 +32,86 @@ type IssueReporterDeps = {
   runCli: (args: string, label?: string, quiet?: boolean) => Promise<string>;
 };
 
-export async function createMagicNetIssue({ state, runShell, runCli }: IssueReporterDeps): Promise<void> {
-  const operation = {
+function relevantLogTail(text: string, pattern: RegExp, fallbackLines = 32): string {
+  const lines = text.split(/\r?\n/).filter(Boolean);
+  const relevant = lines.filter((line) => pattern.test(line));
+  return (relevant.length ? relevant.slice(-60) : lines.slice(-fallbackLines)).join("\n");
+}
+
+async function collectFocusedContext(
+  kind: IssueKind,
+  operation: IssueOperationContext,
+  runCli: IssueReporterDeps["runCli"],
+): Promise<string> {
+  if (kind === "command-error") return commandFailureContext(operation);
+  if (kind === "app-connectivity") {
+    const [connections, logs] = await Promise.all([
+      runCli("api conns", "读取近期活动连接", true),
+      runCli("service logs sing-box 160", "读取近期连接日志", true),
+    ]);
+    return [
+      "[recent connection paths]",
+      summarizeConnectionsForIssue(connections),
+      "",
+      "[recent sing-box log tail]",
+      sanitizeConnectionLog(relevantLogTail(
+        logs,
+        /\b(connect|connection|inbound|outbound|route|rule|reject|block|timeout|error|warn|fail|denied)\b/i,
+        40,
+      )),
+    ].join("\n");
+  }
+  if (kind === "subscription-node") {
+    const [status, logs] = await Promise.all([
+      runCli("sub status", "读取订阅状态", true),
+      runCli("service logs sing-box 160", "读取订阅与节点日志", true),
+    ]);
+    return [
+      "[subscription status]",
+      status,
+      "",
+      "[selector/subscription log tail]",
+      sanitizeConnectionLog(relevantLogTail(
+        logs,
+        /\b(subscription|selector|proxy|outbound|node|update|timeout|error|warn|fail)\b/i,
+      )),
+    ].join("\n");
+  }
+  if (kind === "dns-routing") {
+    const [health, dns, network, transparent] = await Promise.all([
+      runCli("health", "运行健康检查", true),
+      runCli("dns status", "读取 DNS 状态", true),
+      runCli("network status", "读取网络策略", true),
+      runCli("transparent status", "读取 TUN 状态", true),
+    ]);
+    return [
+      "[health]",
+      health,
+      "",
+      "[dns]",
+      dns,
+      "",
+      "[network]",
+      network,
+      "",
+      "[transparent]",
+      transparent,
+    ].join("\n");
+  }
+  return [
+    "No additional category-specific command was run.",
+    "The support summary and captured UI operation are included below.",
+  ].join("\n");
+}
+
+export async function createMagicNetIssue(
+  { state, runShell, runCli }: IssueReporterDeps,
+  kind: IssueKind,
+): Promise<void> {
+  const operation: IssueOperationContext = {
     phase: state.phase,
     lastCommand: state.lastCommand,
+    lastOutput: state.output,
     backgroundLabel: state.backgroundTask.label,
     backgroundArgs: state.backgroundTask.args,
     backgroundStatus: state.backgroundTask.status,
@@ -38,12 +124,20 @@ export async function createMagicNetIssue({ state, runShell, runCli }: IssueRepo
     const moduleProp = await runShell(`cat ${shellQuote(`${MODULE_DIR}/module.prop`)}`, "读取模块版本", true);
     const version = propValue(moduleProp, "version") || "unknown";
     const runtimeLabel = state.runtime.singBoxState === "unknown" ? "runtime" : state.runtime.singBoxState;
-    const title = `[MagicNet] ${version} ${runtimeLabel} diagnostic report`;
-    const [device, support] = await Promise.all([
+    const title = `[MagicNet] ${version} ${issueKindLabel(kind)} · ${runtimeLabel}`;
+    const [device, support, focusedContext] = await Promise.all([
       runShell("getprop ro.product.model; getprop ro.build.version.release; getprop ro.build.version.sdk; uname -a", "读取设备信息", true),
-      runCli("support bundle", "生成支持包", true)
+      runCli("support bundle", "生成支持包", true),
+      collectFocusedContext(kind, operation, runCli),
     ]);
-    const body = buildIssueBody({ moduleProp, device, support, operation });
+    const body = buildIssueBody({
+      kind,
+      moduleProp,
+      device,
+      support,
+      focusedContext,
+      operation,
+    });
     const copied = await copyText(body);
     const issueUrl = buildIssueUrl(REPO, title, body);
     state.output = [

--- a/webui/src/composables/useMagicNet.ts
+++ b/webui/src/composables/useMagicNet.ts
@@ -47,6 +47,7 @@ import {
   wifiPolicyDefaults,
 } from "@/composables/parsers";
 import { createMagicNetIssue } from "@/composables/issueReporter";
+import type { IssueKind } from "@/composables/issueDrafts";
 import { useExternalLinks } from "@/composables/useExternalLinks";
 import {
   compactCommand,
@@ -89,6 +90,9 @@ const state = reactive({
     ? "正在读取 MagicNet 状态..."
     : "本地预览模式：真机 WebUI 才会执行 root 命令。",
   backgroundTask: { ...backgroundTaskDefaults },
+  issueReporter: {
+    open: false,
+  },
   runtime: { ...runtimeDefaults },
   health: [] as HealthItem[],
   pingtest: "",
@@ -562,7 +566,16 @@ async function refreshWifiPolicy(quiet = false): Promise<boolean> {
 }
 
 async function createIssue(): Promise<void> {
-  await createMagicNetIssue({ state, runShell, runCli });
+  state.issueReporter.open = true;
+}
+
+function closeIssueReporter(): void {
+  state.issueReporter.open = false;
+}
+
+async function submitIssue(kind: IssueKind): Promise<void> {
+  closeIssueReporter();
+  await createMagicNetIssue({ state, runShell, runCli }, kind);
 }
 
 async function refreshTopology(): Promise<void> {
@@ -726,6 +739,8 @@ export function useMagicNet() {
     refreshWarp,
     refreshWifiPolicy,
     createIssue,
+    closeIssueReporter,
+    submitIssue,
     refreshTopology,
     refreshSysroute,
     loadConfig,


### PR DESCRIPTION
## Summary

- add a one-question Issue flow with five problem categories
- collect focused, privacy-filtered context for app connectivity, command failures, subscription/node problems, and DNS/TUN routing problems
- summarize recent connections without destination addresses, connection IDs, traffic totals, or private node names
- remove the empty root `.envrc` and add a repository hygiene regression test
- correct hotspot/VPN coexistence documentation and document the new Issue flow
- run WebUI tests and type checking as part of the module build hook, and wire existing architecture/safety tests into `scripts/pre-commit.sh`

## Validation

- `npm run check` (18 tests, TypeScript typecheck, Vite production build)
- `bash scripts/test-repository-hygiene.sh`
- `bash scripts/test-policy-architecture.sh`
- `bash scripts/test-ad-routing.sh`
- `bash scripts/test-app-routing-policy.sh`
- `bash scripts/test-block-conf-safety.sh`
- `bash scripts/test-mcp-phase-config.sh`
- `bash scripts/test-rule-hash-retry.sh`
- `git diff --check`

## Notes

Full local `scripts/pre-commit.sh` was not available in the current environment because `kam`, `cargo`, and `shellcheck` are not installed and git submodules are not initialized. GitHub Actions will exercise the repository-level build and validation paths.

## Summary by Sourcery

在 WebUI 中引入按类别感知的 issue 上报流程，根据问题类型收集更聚焦且经过隐私过滤的诊断信息，并通过测试校验代码仓库卫生状况和文档的正确性。

New Features:
- 在 WebUI 中新增分类的 issue 类型，在创建 GitHub issue 之前弹出对话框选择问题类别。
- 针对每种 issue 类别收集聚焦的诊断上下文，包括应用连接路径、命令失败摘要、订阅/节点状态以及 DNS/TUN 路由健康状况。
- 在 issue 报告中包含隐私保护的近期连接摘要，同时避免泄露端点、ID、流量大小或私有节点名称。

Bug Fixes:
- 在面向用户的文档中澄清并修正文中关于热点转发和 VPN 共存行为的描述，使其与当前实现保持一致。

Enhancements:
- 优化 issue 内容结构，突出聚焦上下文和支持性摘要，同时保持 UI 操作细节以及模块/设备元数据的简洁。
- 更严格地清理命令输出和连接日志，避免在诊断信息中泄露敏感 token、端点和节点标识。
- 新增仓库卫生检查，确保不跟踪构建产物、私有环境变量文件或过时的文档说明。

Build:
- 通过统一的 `check` 脚本在模块预构建钩子中运行 WebUI 测试、类型检查和生产构建，如任一步骤失败则打包失败。

CI:
- 扩展 `scripts/pre-commit.sh` 工作流，运行仓库卫生、路由架构、应用路由、广告拦截、配置安全性、MCP 阶段配置以及规则哈希重试相关的测试。
- 添加测试覆盖新的 issue 上报对话框、类别选择、聚焦上下文收集、日志清理以及命令失败摘要。

Documentation:
- 更新 README，记录热点选择器命令、应用级代理/绕过控制，以及新的按类别感知的 issue 上报流程。
- 明确构建和本地模拟文档，说明在模块构建期间如何执行 WebUI 测试，以及当前的热点选择器和运行时导出模型。

Tests:
- 添加仓库卫生测试脚本，强制执行干净的跟踪状态，并记录热点和 issue 上报相关特性。
- 添加 WebUI 测试，用于验证 issue 内容的确定性、诊断信息中的敏感数据过滤，以及 issue 类型选项。
- 为新的 IssueReporterDialog 线路以及在 reporter composable 中按类别触发的 CLI 调用新增测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a category-aware issue reporting flow in the WebUI that gathers focused, privacy-filtered diagnostics per problem type and validates repository hygiene and documentation through tests.

New Features:
- Add categorized issue types in the WebUI with a dialog to select the problem category before creating a GitHub issue.
- Collect focused diagnostic context per issue category, including app connectivity paths, command failure summaries, subscription/node status, and DNS/TUN routing health.
- Include a privacy-preserving summary of recent connections in issue reports without leaking endpoints, IDs, traffic sizes, or private node names.

Bug Fixes:
- Clarify and correct hotspot forwarding and VPN coexistence behavior in user-facing documentation to match the current implementation.

Enhancements:
- Refine issue body structure to highlight focused context and support summaries while keeping UI operation details and module/device metadata concise.
- Sanitize command outputs and connection logs more aggressively to avoid leaking sensitive tokens, endpoints, and node identifiers in diagnostics.
- Add repository hygiene checks to ensure no build artifacts, private env files, or outdated documentation claims are tracked.

Build:
- Run WebUI tests, type checking, and production build via a unified `check` script from the module pre-build hook, failing packaging if any step fails.

CI:
- Extend the `scripts/pre-commit.sh` workflow to run repository hygiene, routing architecture, application routing, ad-blocking, config safety, MCP phase config, and rule-hash retry tests.
- Add tests covering the new issue-reporting dialog, category selection, focused context collection, log sanitization, and command failure summarization.

Documentation:
- Update README to document hotspot selector commands, app-level proxy/bypass controls, and the new category-aware issue reporting flow.
- Clarify build and local simulation docs to describe WebUI test execution during module builds and the current hotspot selector and runtime export model.

Tests:
- Add repository hygiene test script to enforce clean tracking state and documentation of hotspot and issue-reporting features.
- Add WebUI tests for issue body determinism, sensitive data filtering in diagnostics, and issue kind options.
- Add a test for the new IssueReporterDialog wiring and category-specific CLI invocations in the reporter composable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 WebUI 中引入按类别感知的 issue 上报流程，根据问题类型收集更聚焦且经过隐私过滤的诊断信息，并通过测试校验代码仓库卫生状况和文档的正确性。

New Features:
- 在 WebUI 中新增分类的 issue 类型，在创建 GitHub issue 之前弹出对话框选择问题类别。
- 针对每种 issue 类别收集聚焦的诊断上下文，包括应用连接路径、命令失败摘要、订阅/节点状态以及 DNS/TUN 路由健康状况。
- 在 issue 报告中包含隐私保护的近期连接摘要，同时避免泄露端点、ID、流量大小或私有节点名称。

Bug Fixes:
- 在面向用户的文档中澄清并修正文中关于热点转发和 VPN 共存行为的描述，使其与当前实现保持一致。

Enhancements:
- 优化 issue 内容结构，突出聚焦上下文和支持性摘要，同时保持 UI 操作细节以及模块/设备元数据的简洁。
- 更严格地清理命令输出和连接日志，避免在诊断信息中泄露敏感 token、端点和节点标识。
- 新增仓库卫生检查，确保不跟踪构建产物、私有环境变量文件或过时的文档说明。

Build:
- 通过统一的 `check` 脚本在模块预构建钩子中运行 WebUI 测试、类型检查和生产构建，如任一步骤失败则打包失败。

CI:
- 扩展 `scripts/pre-commit.sh` 工作流，运行仓库卫生、路由架构、应用路由、广告拦截、配置安全性、MCP 阶段配置以及规则哈希重试相关的测试。
- 添加测试覆盖新的 issue 上报对话框、类别选择、聚焦上下文收集、日志清理以及命令失败摘要。

Documentation:
- 更新 README，记录热点选择器命令、应用级代理/绕过控制，以及新的按类别感知的 issue 上报流程。
- 明确构建和本地模拟文档，说明在模块构建期间如何执行 WebUI 测试，以及当前的热点选择器和运行时导出模型。

Tests:
- 添加仓库卫生测试脚本，强制执行干净的跟踪状态，并记录热点和 issue 上报相关特性。
- 添加 WebUI 测试，用于验证 issue 内容的确定性、诊断信息中的敏感数据过滤，以及 issue 类型选项。
- 为新的 IssueReporterDialog 线路以及在 reporter composable 中按类别触发的 CLI 调用新增测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a category-aware issue reporting flow in the WebUI that gathers focused, privacy-filtered diagnostics per problem type and validates repository hygiene and documentation through tests.

New Features:
- Add categorized issue types in the WebUI with a dialog to select the problem category before creating a GitHub issue.
- Collect focused diagnostic context per issue category, including app connectivity paths, command failure summaries, subscription/node status, and DNS/TUN routing health.
- Include a privacy-preserving summary of recent connections in issue reports without leaking endpoints, IDs, traffic sizes, or private node names.

Bug Fixes:
- Clarify and correct hotspot forwarding and VPN coexistence behavior in user-facing documentation to match the current implementation.

Enhancements:
- Refine issue body structure to highlight focused context and support summaries while keeping UI operation details and module/device metadata concise.
- Sanitize command outputs and connection logs more aggressively to avoid leaking sensitive tokens, endpoints, and node identifiers in diagnostics.
- Add repository hygiene checks to ensure no build artifacts, private env files, or outdated documentation claims are tracked.

Build:
- Run WebUI tests, type checking, and production build via a unified `check` script from the module pre-build hook, failing packaging if any step fails.

CI:
- Extend the `scripts/pre-commit.sh` workflow to run repository hygiene, routing architecture, application routing, ad-blocking, config safety, MCP phase config, and rule-hash retry tests.
- Add tests covering the new issue-reporting dialog, category selection, focused context collection, log sanitization, and command failure summarization.

Documentation:
- Update README to document hotspot selector commands, app-level proxy/bypass controls, and the new category-aware issue reporting flow.
- Clarify build and local simulation docs to describe WebUI test execution during module builds and the current hotspot selector and runtime export model.

Tests:
- Add repository hygiene test script to enforce clean tracking state and documentation of hotspot and issue-reporting features.
- Add WebUI tests for issue body determinism, sensitive data filtering in diagnostics, and issue kind options.
- Add a test for the new IssueReporterDialog wiring and category-specific CLI invocations in the reporter composable.

</details>

</details>