### PR TITLE
Refine WebUI with Apple-inspired interaction design

### DIFF
--- a/webui/apple-design-contract.test.mjs
+++ b/webui/apple-design-contract.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (relativePath) =>
+  readFileSync(new URL(relativePath, import.meta.url), "utf8");
+
+const styles = read("./src/styles.css");
+const app = read("./src/App.vue");
+const button = read("./src/components/ui/Button.vue");
+const card = read("./src/components/ui/Card.vue");
+const pageHeader = read("./src/components/ui/PageHeader.vue");
+
+// Materials communicate hierarchy and retain solid fallbacks.
+assert.match(styles, /--mn-material:/, "material surface token must exist");
+assert.match(
+  styles,
+  /backdrop-filter:\s*blur\(/,
+  "functional chrome must use a translucent material",
+);
+assert.match(
+  styles,
+  /@media\s*\(prefers-reduced-transparency:\s*reduce\)/,
+  "translucency must have a solid accessibility fallback",
+);
+assert.match(
+  styles,
+  /@media\s*\(prefers-contrast:\s*more\)/,
+  "materials must adapt to increased contrast",
+);
+assert.match(app, /mn-topbar mn-chrome/, "top actions must share one material layer");
+assert.match(
+  app,
+  /ref="advancedDialog"[^>]*mn-chrome-raised/,
+  "modal navigation must use the heavier raised material",
+);
+
+// Platform typography and optical hierarchy.
+assert.match(
+  styles,
+  /font-family:\s*\n?\s*-apple-system,\s*BlinkMacSystemFont/,
+  "platform system typography must be preferred",
+);
+assert.match(styles, /font-optical-sizing:\s*auto/, "optical sizing must be enabled");
+assert.match(
+  pageHeader,
+  /tracking-\[-0\.04em\]/,
+  "display text must use size-appropriate tighter tracking",
+);
+
+// Press feedback starts immediately and visual motion remains interruptible.
+assert.match(button, /active:scale-\[0\.97\]/, "buttons need direct press feedback");
+assert.match(button, /active:duration-75/, "press feedback must not wait on a long transition");
+assert.match(
+  styles,
+  /--mn-motion-spring:\s*cubic-bezier/,
+  "shared spring-like response curve must exist",
+);
+assert.match(
+  styles,
+  /transform-origin:\s*bottom center/,
+  "mobile sheet motion must remain anchored to its trigger region",
+);
+assert.match(
+  styles,
+  /@media\s*\(prefers-reduced-motion:\s*reduce\)/,
+  "motion must have a reduced-motion equivalent",
+);
+
+// Controls keep touch targets, location context, and familiar grouping.
+assert.match(button, /min-h-11/, "button touch targets must remain at least 44px");
+assert.match(card, /rounded-\[1\.25rem\]/, "cards must use the shared large-radius language");
+assert.match(app, /:aria-current="activeTab === item\.key \? 'page'/, "navigation must expose the current location");
+assert.match(app, /mobile-nav mn-chrome/, "mobile navigation must stay a floating functional layer");
+
+console.log("apple design contract tests passed");

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -281,11 +281,11 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="mn-shell relative mx-auto min-h-dvh w-full max-w-[1500px] px-3 pb-[calc(7rem+env(safe-area-inset-bottom))] pt-3 sm:px-5 md:px-7 md:pb-12 md:pt-6">
-    <header class="mb-5 flex flex-nowrap items-center justify-between gap-1 md:mb-7">
-      <div class="mn-chrome flex min-w-0 items-center gap-1 rounded-md p-0.5 pr-1.5">
+  <div class="mn-shell relative mx-auto min-h-dvh w-full max-w-[1560px] px-3 pb-[calc(7.5rem+env(safe-area-inset-bottom))] pt-3 sm:px-5 md:px-7 md:pb-12 md:pt-5">
+    <header class="mn-topbar mn-chrome mb-5 flex flex-nowrap items-center justify-between gap-2 rounded-[1.25rem] p-1.5 md:mb-6 md:p-2">
+      <div class="flex min-w-0 items-center gap-1 pr-1.5">
         <button
-          class="brand-mark mn-brand-mark grid size-11 shrink-0 place-items-center overflow-hidden rounded-[5px] transition-[transform,opacity] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.94]"
+          class="brand-mark mn-brand-mark grid size-11 shrink-0 place-items-center overflow-hidden rounded-[0.85rem] transition-[transform,opacity] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.94] active:duration-75"
           type="button"
           aria-label="MagicNet 品牌标记"
           title="MagicNet"
@@ -300,13 +300,13 @@ onUnmounted(() => {
             decoding="async"
           />
         </button>
-        <div class="hidden min-w-0 min-[360px]:block pl-1">
+        <div class="hidden min-w-0 min-[360px]:block pl-1.5">
           <h1 class="truncate text-[17px] font-semibold leading-tight tracking-[-0.03em] text-[var(--mn-ink)] sm:text-xl">MagicNet</h1>
-          <p class="hidden truncate text-[11px] text-[var(--mn-ink-faint)] sm:block">Root 网络工作台</p>
+          <p class="hidden truncate text-[11px] font-medium tracking-[0.01em] text-[var(--mn-ink-faint)] sm:block">Root 网络工作台</p>
         </div>
       </div>
 
-      <div class="mn-chrome flex items-center gap-0.5 rounded-md p-0.5">
+      <div class="flex items-center gap-0.5 rounded-[0.95rem] bg-[color-mix(in_srgb,var(--mn-ink)_4%,transparent)] p-0.5 shadow-[inset_0_0_0_1px_var(--mn-border)]">
         <Button
           variant="outline"
           size="sm"
@@ -364,8 +364,8 @@ onUnmounted(() => {
       </div>
     </header>
 
-    <section class="runtime-cockpit mn-chrome relative z-20 mb-5 grid gap-3 rounded-md p-1 md:sticky md:top-4 md:grid-cols-[minmax(220px,1.05fr)_minmax(0,1fr)_auto] md:items-center md:gap-2">
-      <div class="rounded-[5px] bg-[color-mix(in_srgb,var(--mn-cactus)_28%,var(--mn-carrier))] px-4 py-3 shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--mn-cactus)_45%,transparent)]">
+    <section class="runtime-cockpit mn-chrome relative z-20 mb-5 grid gap-3 rounded-[1.25rem] p-1.5 md:sticky md:top-4 md:grid-cols-[minmax(220px,1.05fr)_minmax(0,1fr)_auto] md:items-center md:gap-2">
+      <div class="rounded-[0.95rem] bg-[color-mix(in_srgb,var(--mn-cactus)_30%,var(--mn-material-heavy))] px-4 py-3 shadow-[inset_0_1px_0_color-mix(in_srgb,#fff_45%,transparent),inset_0_0_0_1px_color-mix(in_srgb,var(--mn-cactus)_45%,transparent)]">
         <div class="flex items-center justify-between gap-3">
           <div class="min-w-0 flex-1">
             <span class="text-[9px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-faint)]">运行状态</span>
@@ -406,17 +406,19 @@ onUnmounted(() => {
       </Button>
     </section>
 
-    <main class="grid min-w-0 gap-5 md:grid-cols-[190px_minmax(0,1fr)] md:items-start md:gap-6">
-      <nav class="desktop-rail mn-chrome sticky top-36 hidden gap-1 rounded-md p-1.5 md:grid" aria-label="MagicNet 页面">
+    <main class="grid min-w-0 gap-5 md:grid-cols-[204px_minmax(0,1fr)] md:items-start md:gap-6">
+      <nav class="desktop-rail mn-chrome sticky top-36 hidden gap-1 rounded-[1.25rem] p-2 md:grid" aria-label="MagicNet 页面">
         <div class="px-3 pb-1 pt-2 text-[9px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-faint)]">常用工作区</div>
         <button
           v-for="item in primaryTabs"
           :key="item.key"
           :data-tab="item.key"
           :class="[
-            'flex min-h-11 min-w-0 items-center gap-3 rounded-[5px] px-3 text-sm font-medium transition-[transform,color,background-color,opacity] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.98]',
+            'flex min-h-11 min-w-0 items-center gap-3 rounded-[0.85rem] px-3 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.98]',
             activeTab === item.key ? 'mn-nav-active' : 'mn-nav-idle',
           ]"
+          type="button"
+          :aria-current="activeTab === item.key ? 'page' : undefined"
           @click="setTab(item.key)"
         >
           <component :is="item.icon" :size="18" />
@@ -429,9 +431,11 @@ onUnmounted(() => {
           :key="item.key"
           :data-tab="item.key"
           :class="[
-            'flex min-h-11 min-w-0 items-center gap-3 rounded-[5px] px-3 text-sm font-medium transition-[transform,color,background-color,opacity] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.98]',
+            'flex min-h-11 min-w-0 items-center gap-3 rounded-[0.85rem] px-3 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.98]',
             activeTab === item.key ? 'mn-nav-advanced-active' : 'mn-nav-idle',
           ]"
+          type="button"
+          :aria-current="activeTab === item.key ? 'page' : undefined"
           @click="setTab(item.key)"
         >
           <component :is="item.icon" :size="18" />
@@ -449,21 +453,23 @@ onUnmounted(() => {
             />
           </KeepAlive>
           <template #fallback>
-            <div class="mn-chrome rounded-md p-8 text-sm text-[var(--mn-ink-muted)]" role="status">加载面板…</div>
+            <div class="mn-chrome rounded-[1.25rem] p-8 text-sm text-[var(--mn-ink-muted)]" role="status">加载面板…</div>
           </template>
         </Suspense>
       </section>
     </main>
 
-    <nav class="mobile-nav mn-chrome fixed inset-x-3 bottom-[max(0.75rem,env(safe-area-inset-bottom))] z-30 grid grid-cols-6 gap-1 rounded-md p-1 md:hidden" aria-label="MagicNet 移动导航">
+    <nav class="mobile-nav mn-chrome fixed inset-x-3 bottom-[max(0.75rem,env(safe-area-inset-bottom))] z-30 grid grid-cols-6 gap-0.5 rounded-[1.35rem] p-1.5 md:hidden" aria-label="MagicNet 移动导航">
       <button
         v-for="item in primaryTabs"
         :key="item.key"
         :data-tab="item.key"
         :class="[
-          'flex min-h-11 min-w-0 flex-col items-center justify-center gap-0.5 rounded-[5px] px-1 text-[10px] font-medium transition-[transform,color,background-color,opacity] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.95]',
+          'flex min-h-11 min-w-0 flex-col items-center justify-center gap-0.5 rounded-[0.85rem] px-1 text-[10px] font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.95]',
           activeTab === item.key ? 'mn-nav-active' : 'mn-nav-idle',
         ]"
+        type="button"
+        :aria-current="activeTab === item.key ? 'page' : undefined"
         @click="setTab(item.key)"
       >
         <component :is="item.icon" :size="18" />
@@ -472,9 +478,11 @@ onUnmounted(() => {
       <button
         ref="advancedNavTrigger"
         :class="[
-          'flex min-h-11 min-w-0 flex-col items-center justify-center gap-0.5 rounded-[5px] px-1 text-[10px] font-medium transition-[transform,color,background-color,opacity] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.95]',
+          'flex min-h-11 min-w-0 flex-col items-center justify-center gap-0.5 rounded-[0.85rem] px-1 text-[10px] font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.95]',
           activeAdvancedTab ? 'mn-nav-advanced-active' : 'mn-nav-idle',
         ]"
+        type="button"
+        :aria-current="activeAdvancedTab ? 'page' : undefined"
         aria-haspopup="dialog"
         :aria-expanded="showAdvancedNav"
         @click="openAdvancedNav"
@@ -487,7 +495,7 @@ onUnmounted(() => {
     <Transition name="sheet">
       <div v-if="showAdvancedNav" class="fixed inset-0 z-40 md:hidden">
         <button class="absolute inset-0 size-full bg-[color-mix(in_srgb,var(--mn-ink)_35%,transparent)]" type="button" aria-label="关闭进阶导航" @click="closeAdvancedNav()" />
-        <div ref="advancedDialog" class="mn-chrome absolute inset-x-3 bottom-[max(0.75rem,env(safe-area-inset-bottom))] rounded-md p-1.5 pb-2" role="dialog" aria-modal="true" aria-label="进阶导航" tabindex="-1">
+        <div ref="advancedDialog" class="mn-chrome-raised absolute inset-x-3 bottom-[max(0.75rem,env(safe-area-inset-bottom))] rounded-[1.5rem] p-2 pb-2.5" role="dialog" aria-modal="true" aria-label="进阶导航" tabindex="-1">
           <div class="flex items-center justify-between px-3 pb-2 pt-2">
             <div>
               <span class="text-[9px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-faint)]">更多工作区</span>
@@ -501,9 +509,11 @@ onUnmounted(() => {
               :key="item.key"
               :data-tab="item.key"
               :class="[
-                'flex min-h-11 min-w-0 items-center gap-3 rounded-[5px] px-4 text-sm font-medium transition-[transform,color,background-color,opacity] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-heather)_70%,var(--mn-ink))] active:scale-[0.97]',
+                'flex min-h-11 min-w-0 items-center gap-3 rounded-[0.95rem] px-4 text-sm font-medium transition-[transform,color,background-color,opacity] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-heather)_70%,var(--mn-ink))] active:scale-[0.97] active:duration-75',
                 activeTab === item.key ? 'mn-nav-active' : 'mn-inset-soft text-[var(--mn-ink-soft)]',
               ]"
+              type="button"
+              :aria-current="activeTab === item.key ? 'page' : undefined"
               @click="setTab(item.key)"
             >
               <component :is="item.icon" :size="19" />
@@ -529,9 +539,9 @@ onUnmounted(() => {
     </Transition>
 
     <Transition name="toast">
-      <aside v-if="easterEggVisible" class="mn-chrome fixed bottom-28 right-3 z-50 max-w-[calc(100vw-1.5rem)] rounded-md p-1 md:bottom-8 md:right-8 md:max-w-sm" role="status" aria-live="polite">
-        <div class="flex items-start gap-3 rounded-[5px] bg-[color-mix(in_srgb,var(--mn-cactus)_18%,var(--mn-carrier))] p-4">
-          <div class="grid size-10 shrink-0 place-items-center overflow-hidden rounded-sm bg-[var(--mn-cactus)]">
+      <aside v-if="easterEggVisible" class="mn-chrome-raised fixed bottom-28 right-3 z-50 max-w-[calc(100vw-1.5rem)] rounded-[1.25rem] p-1.5 md:bottom-8 md:right-8 md:max-w-sm" role="status" aria-live="polite">
+        <div class="flex items-start gap-3 rounded-[0.95rem] bg-[color-mix(in_srgb,var(--mn-cactus)_18%,var(--mn-material-heavy))] p-4">
+          <div class="grid size-10 shrink-0 place-items-center overflow-hidden rounded-[0.75rem] bg-[var(--mn-cactus)]">
             <img :src="MAGICNET_LOGO_URL" alt="" class="size-10 object-cover" width="40" height="40" decoding="async" />
           </div>
           <div class="min-w-0 flex-1">
@@ -549,7 +559,7 @@ onUnmounted(() => {
               </template>
             </p>
           </div>
-          <button class="grid size-11 shrink-0 place-items-center rounded-[5px] text-[var(--mn-ink-faint)] transition-[transform,color,background-color,opacity] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] hover:bg-[color-mix(in_srgb,var(--mn-ink)_6%,transparent)] hover:text-[var(--mn-ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.94]" type="button" aria-label="关闭彩蛋" @click="closeEasterEgg">
+          <button class="grid size-11 shrink-0 place-items-center rounded-[0.85rem] text-[var(--mn-ink-faint)] transition-[transform,color,background-color,opacity] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] hover:bg-[color-mix(in_srgb,var(--mn-ink)_6%,transparent)] hover:text-[var(--mn-ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.94] active:duration-75" type="button" aria-label="关闭彩蛋" @click="closeEasterEgg">
             <X :size="16" />
           </button>
         </div>

--- a/webui/src/components/pages/ControlPage.vue
+++ b/webui/src/components/pages/ControlPage.vue
@@ -20,6 +20,7 @@ import Badge from "@/components/ui/Badge.vue";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
 import Input from "@/components/ui/Input.vue";
+import PageHeader from "@/components/ui/PageHeader.vue";
 import {
   applyConfigAction,
   applyTransparentModeAction,
@@ -267,20 +268,12 @@ onMounted(() => {
 
 <template>
   <div class="grid gap-4 md:gap-5">
-    <div
-      class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-4"
+    <PageHeader
+      overline="Control Center"
+      title="模块控制"
+      description="管理模块生命周期和常用入口；节点、测速与代理组继续由 sing-box WebUI 负责。"
     >
-      <div class="max-w-3xl">
-        <span
-          class="inline-flex rounded-full bg-[color-mix(in_srgb,var(--mn-ink)_5%,transparent)] px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-[var(--mn-ink-muted)] shadow-[inset_0_0_0_1px_var(--mn-border)]"
-          >控制中心</span
-        >
-        <h2 class="mt-2 text-2xl font-semibold tracking-[-0.04em] text-[var(--mn-ink)] md:mt-3 md:text-3xl">模块控制</h2>
-        <p class="mt-2 text-sm leading-6 text-[var(--mn-ink-muted)] md:text-[15px]">
-          只放模块生命周期和入口。节点、测速、代理模式交给 sing-box WebUI。
-        </p>
-      </div>
-      <div class="flex flex-wrap items-center gap-2">
+      <template #actions>
         <Button variant="outline" @click="copyControlSnapshot"
           ><Copy :size="17" />{{
             snapshotCopied ? "已复制快照" : "复制快照"
@@ -292,8 +285,8 @@ onMounted(() => {
           "
           >{{ state.runtime.singBoxState }}</Badge
         >
-      </div>
-    </div>
+      </template>
+    </PageHeader>
 
     <div class="grid grid-cols-1 gap-3 md:grid-cols-12 md:gap-4">
       <Card

--- a/webui/src/components/ui/Badge.vue
+++ b/webui/src/components/ui/Badge.vue
@@ -16,7 +16,7 @@ const toneClass = computed(() => ({
   danger: "mn-fill-danger",
 }[props.tone]));
 
-const classes = computed(() => cn("inline-flex min-h-7 items-center rounded-full px-3 text-[11px] font-semibold tracking-wide", toneClass.value, props.class));
+const classes = computed(() => cn("inline-flex min-h-7 items-center rounded-full px-3 text-[11px] font-semibold tracking-[0.015em] shadow-[inset_0_1px_0_color-mix(in_srgb,#fff_18%,transparent)]", toneClass.value, props.class));
 </script>
 
 <template>

--- a/webui/src/components/ui/Button.vue
+++ b/webui/src/components/ui/Button.vue
@@ -25,20 +25,20 @@ const props = withDefaults(
 );
 
 const buttonVariants = cva(
-  "group inline-flex max-w-full items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-semibold transition-[transform,color,background-color,opacity,box-shadow] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mn-focus)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--mn-ivory)] active:scale-[0.975] disabled:pointer-events-none disabled:cursor-progress disabled:opacity-50 disabled:active:scale-100",
+  "group inline-flex max-w-full items-center justify-center gap-2 whitespace-nowrap rounded-[0.85rem] text-sm font-semibold tracking-[-0.01em] transition-[transform,color,background-color,opacity,box-shadow,filter] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mn-focus)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--mn-ivory)] active:scale-[0.97] active:duration-75 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 disabled:active:scale-100",
   {
     variants: {
       variant: {
         default:
-          "bg-[var(--mn-cactus)] text-[var(--mn-on-accent)] shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--mn-ink)_12%,transparent)] hover:bg-[var(--mn-cactus-deep)]",
+          "bg-[var(--mn-cactus)] text-[var(--mn-on-accent)] shadow-[inset_0_1px_0_color-mix(in_srgb,#fff_45%,transparent),inset_0_0_0_1px_color-mix(in_srgb,var(--mn-ink)_12%,transparent),0_4px_12px_color-mix(in_srgb,var(--mn-cactus-deep)_18%,transparent)] hover:bg-[color-mix(in_srgb,var(--mn-cactus)_72%,var(--mn-cactus-deep))] active:shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--mn-ink)_14%,transparent)]",
         secondary:
-          "bg-[color-mix(in_srgb,var(--mn-ink)_8%,transparent)] text-[var(--mn-ink)] shadow-[inset_0_0_0_1px_var(--mn-border)] hover:bg-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)]",
+          "bg-[color-mix(in_srgb,var(--mn-ink)_7%,transparent)] text-[var(--mn-ink)] shadow-[inset_0_1px_0_var(--mn-material-edge),inset_0_0_0_1px_var(--mn-border)] hover:bg-[color-mix(in_srgb,var(--mn-ink)_11%,transparent)]",
         outline:
-          "bg-[var(--mn-carrier)] text-[var(--mn-ink)] shadow-[inset_0_0_0_1px_var(--mn-border-strong)] hover:bg-[var(--mn-carrier-deep)]",
+          "bg-[var(--mn-material-heavy)] text-[var(--mn-ink)] shadow-[inset_0_1px_0_var(--mn-material-edge),inset_0_0_0_1px_var(--mn-border),0_2px_7px_color-mix(in_srgb,var(--mn-ink)_5%,transparent)] hover:bg-[color-mix(in_srgb,var(--mn-carrier-deep)_72%,var(--mn-material-heavy))]",
         ghost:
           "bg-transparent text-[var(--mn-ink-soft)] hover:bg-[color-mix(in_srgb,var(--mn-ink)_8%,transparent)] hover:text-[var(--mn-ink)]",
         destructive:
-          "bg-[var(--mn-clay)] text-[var(--mn-ivory)] shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--mn-ink)_12%,transparent)] hover:brightness-110",
+          "bg-[var(--mn-clay)] text-white shadow-[inset_0_1px_0_color-mix(in_srgb,#fff_28%,transparent),inset_0_0_0_1px_color-mix(in_srgb,var(--mn-ink)_12%,transparent),0_4px_12px_color-mix(in_srgb,var(--mn-clay)_20%,transparent)] hover:brightness-105",
       },
       size: {
         sm: "min-h-11 px-4",

--- a/webui/src/components/ui/Card.vue
+++ b/webui/src/components/ui/Card.vue
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 const props = defineProps<{ class?: string }>();
 const classes = computed(() =>
   cn(
-    "magic-card min-w-0 rounded-md p-4 text-[var(--mn-ink)] md:p-5",
+    "magic-card min-w-0 rounded-[1.25rem] p-4 text-[var(--mn-ink)] md:p-5",
     props.class,
   ),
 );

--- a/webui/src/components/ui/Input.vue
+++ b/webui/src/components/ui/Input.vue
@@ -6,7 +6,7 @@ const props = defineProps<{ class?: string }>();
 const model = defineModel<string>();
 const classes = computed(() =>
   cn(
-    "mn-field min-h-11 w-full rounded-md px-3.5 py-2.5 outline-none transition-[color,background-color,box-shadow] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]",
+    "mn-field min-h-11 w-full rounded-[0.85rem] px-3.5 py-2.5 outline-none transition-[color,background-color,box-shadow] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]",
     props.class,
   ),
 );

--- a/webui/src/components/ui/PageHeader.vue
+++ b/webui/src/components/ui/PageHeader.vue
@@ -9,9 +9,9 @@ defineProps<{
 <template>
   <div class="flex min-w-0 flex-col gap-4">
     <div class="max-w-3xl">
-      <span class="mn-pill inline-flex rounded-sm px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em]">{{ overline }}</span>
-      <h2 class="mt-2.5 text-2xl font-semibold tracking-[-0.03em] text-[var(--mn-ink)] md:text-3xl">{{ title }}</h2>
-      <p class="mt-2 text-sm leading-6 text-[var(--mn-ink-muted)] md:text-[15px]">{{ description }}</p>
+      <span class="mn-pill inline-flex rounded-full px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em]">{{ overline }}</span>
+      <h2 class="mt-2.5 text-[clamp(1.75rem,4vw,2.25rem)] font-semibold leading-[1.08] tracking-[-0.04em] text-[var(--mn-ink)]">{{ title }}</h2>
+      <p class="mt-2 max-w-[68ch] text-sm leading-6 text-[var(--mn-ink-muted)] md:text-[15px] md:leading-7">{{ description }}</p>
     </div>
     <div v-if="$slots.default || $slots.actions" class="mn-page-actions md:justify-end">
       <slot name="actions">

--- a/webui/src/components/ui/Textarea.vue
+++ b/webui/src/components/ui/Textarea.vue
@@ -8,7 +8,7 @@ const props = defineProps<{ class?: string }>();
 const model = defineModel<string>();
 const classes = computed(() =>
   cn(
-    "mn-field min-h-28 w-full resize-y rounded-md px-3.5 py-3 outline-none transition-[color,background-color,box-shadow] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]",
+    "mn-field min-h-28 w-full resize-y rounded-[0.85rem] px-3.5 py-3 outline-none transition-[color,background-color,box-shadow] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]",
     props.class,
   ),
 );

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -2,10 +2,9 @@
 
 /*
   MagicNet WebUI design tokens.
-  Light: anthropic-art ivory editorial field (#BCD1CA / #CBCADB / #E3DACC / #FAF9F5 / #141413).
-  Dark: near-black ink canvas with muted cactus/heather accents.
-  Toggle via document.documentElement[data-theme="light"|"dark"].
-  Contrast rule: body text uses ink scale; never pale accent-on-accent for readable copy.
+  The brand palette stays warm and quiet while functional layers use a restrained,
+  Apple-inspired material system: platform typography, translucent chrome, clear
+  depth, immediate press feedback, and accessibility fallbacks.
 */
 
 @theme {
@@ -71,8 +70,25 @@ html[data-theme="light"] {
   --mn-tone-info-border: color-mix(in srgb, var(--mn-info) 40%, transparent);
   --mn-code-bg: #ebe8de;
   --mn-overlay: color-mix(in srgb, var(--mn-ink) 42%, transparent);
+  --mn-material: color-mix(in srgb, #ffffff 76%, transparent);
+  --mn-material-heavy: color-mix(in srgb, #f7f5ef 90%, transparent);
+  --mn-material-edge: color-mix(in srgb, #ffffff 72%, transparent);
+  --mn-shadow-card:
+    0 1px 1px color-mix(in srgb, var(--mn-ink) 5%, transparent),
+    0 10px 30px color-mix(in srgb, var(--mn-ink) 7%, transparent);
+  --mn-shadow-float:
+    0 1px 1px color-mix(in srgb, var(--mn-ink) 6%, transparent),
+    0 18px 48px color-mix(in srgb, var(--mn-ink) 14%, transparent);
+  --mn-radius-sm: 0.75rem;
+  --mn-radius-md: 1rem;
+  --mn-radius-lg: 1.375rem;
+  --mn-motion-spring: cubic-bezier(0.22, 1, 0.36, 1);
+  --mn-motion-press: 90ms;
 
-  font-family: "Plus Jakarta Sans", "MiSans", "HarmonyOS Sans SC", system-ui, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display",
+    "HarmonyOS Sans SC", "MiSans", system-ui, sans-serif;
+  font-optical-sizing: auto;
   background: var(--mn-ivory);
   color: var(--mn-ink);
   font-synthesis: none;
@@ -119,6 +135,15 @@ html[data-theme="dark"] {
   --mn-tone-info-border: color-mix(in srgb, var(--mn-info) 45%, transparent);
   --mn-code-bg: #0e0e0d;
   --mn-overlay: color-mix(in srgb, #000 58%, transparent);
+  --mn-material: color-mix(in srgb, #2b2b28 72%, transparent);
+  --mn-material-heavy: color-mix(in srgb, #242421 91%, transparent);
+  --mn-material-edge: color-mix(in srgb, #ffffff 15%, transparent);
+  --mn-shadow-card:
+    0 1px 0 color-mix(in srgb, #ffffff 5%, transparent),
+    0 14px 34px color-mix(in srgb, #000 30%, transparent);
+  --mn-shadow-float:
+    0 1px 0 color-mix(in srgb, #ffffff 7%, transparent),
+    0 22px 54px color-mix(in srgb, #000 46%, transparent);
 
   background: var(--mn-ivory);
   color: var(--mn-ink);
@@ -143,6 +168,7 @@ body {
   color: var(--mn-ink);
   overflow-x: hidden;
   touch-action: pan-x pan-y pinch-zoom;
+  -webkit-font-smoothing: antialiased;
 }
 
 #app {
@@ -153,6 +179,18 @@ body {
 
 button {
   -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+.rounded-md {
+  border-radius: var(--mn-radius-md);
 }
 
 .truncate {
@@ -167,9 +205,15 @@ button {
 }
 
 .magic-card {
-  background: var(--mn-carrier);
+  background: color-mix(in srgb, var(--mn-carrier) 94%, var(--mn-surface-input));
   color: var(--mn-ink);
-  box-shadow: inset 0 0 0 1px var(--mn-border);
+  box-shadow:
+    inset 0 0 0 1px var(--mn-border),
+    var(--mn-shadow-card);
+  transition:
+    box-shadow 300ms var(--mn-motion-spring),
+    transform 300ms var(--mn-motion-spring),
+    background-color 220ms ease-out;
 }
 
 .mn-shell {
@@ -177,24 +221,39 @@ button {
 }
 
 .mn-chrome {
-  background: var(--mn-carrier);
-  box-shadow: inset 0 0 0 1px var(--mn-border);
+  background: var(--mn-material);
+  box-shadow:
+    inset 0 1px 0 var(--mn-material-edge),
+    inset 0 0 0 1px var(--mn-border),
+    var(--mn-shadow-card);
+  -webkit-backdrop-filter: blur(22px) saturate(150%);
+  backdrop-filter: blur(22px) saturate(150%);
 }
 
 .mn-chrome-raised {
-  background: var(--mn-carrier);
-  box-shadow: inset 0 0 0 1px var(--mn-border-strong);
+  background: var(--mn-material-heavy);
+  box-shadow:
+    inset 0 1px 0 var(--mn-material-edge),
+    inset 0 0 0 1px var(--mn-border-strong),
+    var(--mn-shadow-float);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  backdrop-filter: blur(28px) saturate(160%);
 }
 
 .mn-brand-mark {
   background: var(--mn-cactus);
   color: var(--mn-on-accent);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--mn-ink) 12%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--mn-ink) 12%, transparent),
+    0 5px 14px color-mix(in srgb, var(--mn-cactus-deep) 26%, transparent);
 }
 
 .mn-nav-active {
-  background: var(--mn-cactus);
+  background: color-mix(in srgb, var(--mn-cactus) 88%, var(--mn-surface-input));
   color: var(--mn-on-accent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, #fff 52%, transparent),
+    0 3px 12px color-mix(in srgb, var(--mn-cactus-deep) 18%, transparent);
   font-weight: 600;
 }
 
@@ -203,15 +262,71 @@ button {
 }
 
 .mn-nav-idle:hover {
-  background: color-mix(in srgb, var(--mn-ink) 8%, transparent);
+  background: color-mix(in srgb, var(--mn-ink) 7%, transparent);
   color: var(--mn-ink);
 }
 
 .mn-nav-advanced-active {
-  background: color-mix(in srgb, var(--mn-heather) 42%, var(--mn-carrier));
+  background: color-mix(in srgb, var(--mn-heather) 46%, var(--mn-material-heavy));
   color: var(--mn-ink);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--mn-heather) 55%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, #fff 36%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, var(--mn-heather) 55%, transparent);
   font-weight: 600;
+}
+
+.mn-topbar {
+  position: relative;
+  isolation: isolate;
+}
+
+.mn-topbar::after,
+.runtime-cockpit::after,
+.mobile-nav::before,
+.mn-page-actions::after {
+  position: absolute;
+  pointer-events: none;
+  content: "";
+  opacity: 0.7;
+}
+
+.mn-topbar::after,
+.runtime-cockpit::after,
+.mn-page-actions::after {
+  right: 1rem;
+  bottom: -1px;
+  left: 1rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--mn-border-strong), transparent);
+}
+
+.mobile-nav::before {
+  inset: 0.18rem 1rem auto;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--mn-material-edge), transparent);
+}
+
+.runtime-cockpit {
+  transform: translateZ(0);
+}
+
+.desktop-rail,
+.mobile-nav {
+  transform: translateZ(0);
+}
+
+.desktop-rail button,
+.mobile-nav button {
+  transition:
+    transform var(--mn-motion-press) ease-out,
+    color 180ms ease-out,
+    background-color 240ms var(--mn-motion-spring),
+    box-shadow 240ms var(--mn-motion-spring);
+}
+
+.desktop-rail button:active,
+.mobile-nav button:active {
+  transition-duration: var(--mn-motion-press);
 }
 
 .mn-status-dot-ok {
@@ -248,7 +363,7 @@ pre {
 .sheet-leave-active,
 .toast-enter-active,
 .toast-leave-active {
-  transition: opacity 220ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition: opacity 220ms ease-out;
 }
 
 .sheet-enter-active > div:last-child,
@@ -256,8 +371,10 @@ pre {
 .toast-enter-active,
 .toast-leave-active {
   transition:
-    opacity 220ms cubic-bezier(0.22, 1, 0.36, 1),
-    transform 280ms cubic-bezier(0.22, 1, 0.36, 1);
+    opacity 220ms ease-out,
+    transform 360ms var(--mn-motion-spring),
+    filter 280ms ease-out;
+  transform-origin: bottom center;
 }
 
 .sheet-enter-from,
@@ -269,12 +386,14 @@ pre {
 
 .sheet-enter-from > div:last-child,
 .sheet-leave-to > div:last-child {
-  transform: translateY(16px);
+  filter: blur(6px);
+  transform: translateY(18px) scale(0.975);
 }
 
 .toast-enter-from,
 .toast-leave-to {
-  transform: translateY(8px);
+  filter: blur(4px);
+  transform: translateY(10px) scale(0.98);
 }
 
 code,
@@ -290,7 +409,9 @@ textarea {
 
 .mn-inset {
   background: var(--mn-surface-sunken);
-  box-shadow: inset 0 0 0 1px var(--mn-border);
+  box-shadow:
+    inset 0 0 0 1px var(--mn-border),
+    inset 0 1px 4px color-mix(in srgb, var(--mn-ink) 6%, transparent);
 }
 
 .mn-inset-soft {
@@ -298,7 +419,7 @@ textarea {
 }
 
 .mn-pill {
-  background: color-mix(in srgb, var(--mn-ink) 8%, transparent);
+  background: color-mix(in srgb, var(--mn-ink) 6%, transparent);
   color: var(--mn-ink-muted);
   box-shadow: inset 0 0 0 1px var(--mn-border);
 }
@@ -405,17 +526,23 @@ textarea {
   align-items: center;
   padding: 0.5rem;
   margin: 0 0 0.75rem;
-  border-radius: 0.375rem;
-  background: color-mix(in srgb, var(--mn-carrier) 94%, transparent);
-  box-shadow: inset 0 0 0 1px var(--mn-border);
-  backdrop-filter: blur(8px);
+  border-radius: var(--mn-radius-md);
+  background: var(--mn-material);
+  box-shadow:
+    inset 0 1px 0 var(--mn-material-edge),
+    inset 0 0 0 1px var(--mn-border),
+    0 8px 24px color-mix(in srgb, var(--mn-ink) 8%, transparent);
+  -webkit-backdrop-filter: blur(18px) saturate(145%);
+  backdrop-filter: blur(18px) saturate(145%);
 }
 
 /* Form fields share theme surfaces (used by Input/Textarea and native controls) */
 .mn-field {
   background: var(--mn-surface-input);
   color: var(--mn-ink);
-  box-shadow: inset 0 0 0 1px var(--mn-border-strong);
+  box-shadow:
+    inset 0 0 0 1px var(--mn-border),
+    0 1px 2px color-mix(in srgb, var(--mn-ink) 5%, transparent);
 }
 
 .mn-field:focus,
@@ -439,6 +566,52 @@ textarea {
   color: var(--mn-ink);
 }
 
+@media (hover: hover) and (pointer: fine) {
+  .magic-card:hover {
+    box-shadow:
+      inset 0 0 0 1px var(--mn-border-strong),
+      0 1px 1px color-mix(in srgb, var(--mn-ink) 5%, transparent),
+      0 16px 38px color-mix(in srgb, var(--mn-ink) 9%, transparent);
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  :root,
+  html[data-theme="light"] {
+    --mn-material: #f4f2eb;
+    --mn-material-heavy: #f0eee6;
+  }
+
+  html[data-theme="dark"] {
+    --mn-material: #20201e;
+    --mn-material-heavy: #252522;
+  }
+
+  .mn-chrome,
+  .mn-chrome-raised,
+  .mn-page-actions {
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+}
+
+@media (prefers-contrast: more) {
+  :root,
+  html[data-theme="light"] {
+    --mn-material: #faf9f5;
+    --mn-material-heavy: #ffffff;
+    --mn-border: color-mix(in srgb, var(--mn-ink) 34%, transparent);
+    --mn-border-strong: color-mix(in srgb, var(--mn-ink) 52%, transparent);
+  }
+
+  html[data-theme="dark"] {
+    --mn-material: #121211;
+    --mn-material-heavy: #1c1c1a;
+    --mn-border: color-mix(in srgb, var(--mn-ink) 42%, transparent);
+    --mn-border-strong: color-mix(in srgb, var(--mn-ink) 62%, transparent);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -447,5 +620,13 @@ textarea {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+  }
+
+  .sheet-enter-from > div:last-child,
+  .sheet-leave-to > div:last-child,
+  .toast-enter-from,
+  .toast-leave-to {
+    filter: none;
+    transform: none;
   }
 }


### PR DESCRIPTION
## Summary

- introduce restrained translucent materials for functional chrome, navigation, sheets, and status surfaces
- refine typography, spacing, radii, shadows, controls, and immediate press feedback across the shared WebUI design system
- improve mobile navigation hierarchy and anchored sheet transitions
- expose current navigation state with `aria-current`
- add reduced-motion, reduced-transparency, and increased-contrast fallbacks
- standardize the control page header on the shared `PageHeader` component
- add an Apple design contract test to protect the interaction and accessibility decisions

## Why

The existing WebUI had inconsistent surface depth, control geometry, and motion timing. This made navigation and transient layers feel visually flat and less predictable, especially on mobile. The update keeps MagicNet's existing palette and information architecture while giving functional layers clearer hierarchy and faster, more physical feedback.

## User impact

Users get clearer navigation state, more consistent controls, better touch feedback, improved mobile sheets, and accessibility-aware fallbacks without changing MagicNet's operational behavior.

## Validation

- `npm test` — 18/18 tests passed
- `npm run typecheck`
- `npm run build`

## 由 Sourcery 提供的摘要

在提升导航清晰度和无障碍防护的同时，以 Apple 风格的材质、动效和字体系统精炼 WebUI 的整体视觉体系。

新功能：
- 为卡片、导航、弹窗（sheet）和状态界面引入半透明材质令牌（tokens）以及分层的浏览器框架（chrome）处理。
- 在主导航和高级导航控件上通过 `aria-current` 暴露当前导航状态。
- 新增自动化的 Apple 设计契约测试，用于断言关键交互、动效和无障碍相关决策。

增强优化：
- 在共享 UI 组件和布局中采用更加贴合平台的字体系统，并更新圆角、阴影和触控反馈。
- 统一桌面端与移动端的导航结构，加入锚定式 sheet 过渡效果并优化移动端导航层级。
- 通过在控制页中应用共享的 `PageHeader` 组件并改进其布局，来标准化页面头部。
- 收紧按钮、徽章、卡片、输入框、文本域和胶囊（pill）的样式，以突出层级结构并提供更有触感的反馈。
- 调整 sheet 和 toast 的动效曲线、起点和过渡，使其更具物理质感，同时保持可中断性。
- 提供降低透明度、提高对比度以及更精致的“减弱动效”样式，以更好地支持用户偏好。

测试：
- 新增一个基于 Node 的契约测试，用于验证关键 WebUI 文件中是否存在材质令牌、动效偏好、字体系统以及导航语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在改进 WebUI 的共享设计系统时，引入 Apple 风格的材质、动效和排版，同时提升桌面端与移动端的导航清晰度、无障碍回退方案以及整体视觉层级。

新功能：
- 为浏览器框架（chrome）、卡片以及功能性表面引入半透明材质和阴影 tokens。
- 通过在桌面端和移动端的主标签及高级标签上使用 `aria-current` 暴露导航状态。
- 添加基于 Node 的 Apple 设计契约测试，用于强制执行关键交互、动效和无障碍规范。

优化：
- 更新全局排版，优先使用平台系统字体，并启用光学尺寸与更平滑的渲染效果。
- 统一卡片、按钮、表单字段、徽章、胶囊以及布局的圆角、间距和阴影，实现更一致的层级结构。
- 打磨移动端和桌面端的导航框架、运行时驾驶舱、浮层（sheets）以及 toast 过渡动画，使动效更具锚定感和弹簧般的反馈。
- 在共享的 `PageHeader` 组件上标准化页面标题区域，包括 Control 页面在内。
- 在 WebUI 样式中添加考虑无障碍需求的回退方案，以支持“减少动态效果”“降低透明度”“增强对比度”等系统偏好。

测试：
- 添加自动化契约测试，用于验证关键 WebUI 文件中材质 tokens、动效偏好、排版选择以及导航语义的存在与正确性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the WebUI’s shared design system with Apple-inspired materials, motion, and typography while improving navigation clarity, accessibility fallbacks, and visual hierarchy across desktop and mobile.

New Features:
- Introduce translucent material and shadow tokens for chrome, cards, and functional surfaces.
- Expose navigation state via aria-current on primary and advanced tabs across desktop and mobile.
- Add a Node-based Apple design contract test to enforce key interaction, motion, and accessibility rules.

Enhancements:
- Update global typography to prefer platform system fonts with optical sizing and smoother rendering.
- Unify card, button, field, badge, pill, and layout radii, spacing, and shadows for a more cohesive hierarchy.
- Refine mobile and desktop navigation shells, runtime cockpit, sheets, and toast transitions for anchored, spring-like motion.
- Standardize page headers on the shared PageHeader component, including in the Control page.
- Add accessibility-aware fallbacks for reduced motion, reduced transparency, and increased contrast in the WebUI styling.

Tests:
- Add an automated contract test that validates presence of material tokens, motion preferences, typography choices, and navigation semantics in key WebUI files.

</details>

</details>