### PR TITLE
fix: make backup restore atomic

### DIFF
--- a/crates/magicnet-cli/src/utils.rs
+++ b/crates/magicnet-cli/src/utils.rs
@@ -350,9 +350,9 @@ const MODULE_TRANSACTION_STAGING_PARENT: &str = ".tmp";
 const MODULE_TRANSACTION_STAGING_DIRECTORY: &str = "magicnet-app-transaction";
 
 /// Replaces ordinary module files as one recoverable transaction. All targets
-/// must be distinct strict relative paths below the same module directory.
-/// New contents and backups stay in a private module-root staging directory,
-/// so no stage name is ever resolved through the target directory.
+/// must be distinct strict relative paths below the module root. New contents
+/// and backups stay in a private module-root staging directory, so no stage
+/// name is ever resolved through a target directory.
 pub(crate) fn replace_module_text_files_transactionally(
     app: &App,
     replacements: &[(&Path, &str)],
@@ -449,37 +449,37 @@ where
     W: FnMut(&mut File, &[u8]) -> Result<(), String>,
     F: FnMut(ModuleTransactionRename, &File, &OsStr, &File, &OsStr) -> Result<(), String>,
 {
-    if replacements.len() < 2 {
-        return Err("module transaction requires at least two targets".to_string());
+    if replacements.is_empty() {
+        return Err("module transaction requires at least one target".to_string());
     }
     let targets = replacements
         .iter()
         .map(|(relative, _)| split_module_relative_file(relative))
         .collect::<Result<Vec<_>, _>>()?;
-    let target_directory = &targets[0].directory;
     if targets
         .iter()
-        .any(|target| target.directory.as_path() != target_directory.as_path())
-        || targets
-            .iter()
-            .enumerate()
-            .any(|(index, target)| {
-                targets[..index]
-                    .iter()
-                    .any(|seen| seen.name.as_os_str() == target.name.as_os_str())
+        .enumerate()
+        .any(|(index, target)| {
+            targets[..index].iter().any(|seen| {
+                seen.directory == target.directory
+                    && seen.name.as_os_str() == target.name.as_os_str()
             })
+        })
     {
-        return Err(
-            "module transaction targets must be distinct files in one directory".to_string(),
-        );
+        return Err("module transaction targets must be distinct files".to_string());
     }
     let module_root = open_module_root(app)?;
-    let directory = open_module_directory_from_root(
-        module_root
-            .try_clone()
-            .map_err(|err| format!("clone module root directory: {err}"))?,
-        target_directory,
-    )?;
+    let directories = targets
+        .iter()
+        .map(|target| {
+            open_module_directory_from_root(
+                module_root
+                    .try_clone()
+                    .map_err(|err| format!("clone module root directory: {err}"))?,
+                &target.directory,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
     let names = targets
         .into_iter()
         .map(|target| target.name)
@@ -490,9 +490,11 @@ where
         .collect::<Vec<_>>();
     let snapshots = names
         .iter()
-        .map(|name| snapshot_module_transaction_target(&directory, name))
+        .zip(&directories)
+        .map(|(name, directory)| snapshot_module_transaction_target(directory, name))
         .collect::<Result<Vec<_>, _>>()?;
-    let staging_directory = open_module_transaction_staging_directory(&module_root, &directory)?;
+    let staging_directory =
+        open_module_transaction_staging_directory(&module_root, &directories)?;
     let mut stages = std::iter::repeat_with(|| None)
         .take(names.len())
         .collect::<Vec<Option<ModuleTransactionStage>>>();
@@ -521,7 +523,7 @@ where
             .expect("each module transaction stage exists before commit");
         let commit = match commit_module_transaction_stage(
             &staging_directory,
-            &directory,
+            &directories[index],
             &names[index],
             &snapshots[index],
             stage,
@@ -541,7 +543,7 @@ where
                     if let Some(commit) = committed[rollback_index].take() {
                         if let Err(restore_err) = rollback_module_transaction_commit(
                             &staging_directory,
-                            &directory,
+                            &directories[rollback_index],
                             &names[rollback_index],
                             commit,
                             rollback_index + 1,
@@ -636,7 +638,7 @@ fn open_existing_private_module_file(
 
 fn open_module_transaction_staging_directory(
     module_root: &File,
-    target_directory: &File,
+    target_directories: &[File],
 ) -> Result<File, String> {
     let temporary = ensure_private_module_directory_at(
         module_root,
@@ -646,18 +648,20 @@ fn open_module_transaction_staging_directory(
         &temporary,
         OsStr::new(MODULE_TRANSACTION_STAGING_DIRECTORY),
     )?;
-    let target_device = target_directory
-        .metadata()
-        .map_err(|err| format!("inspect module transaction target directory: {err}"))?
-        .dev();
     let staging_device = staging
         .metadata()
         .map_err(|err| format!("inspect module transaction staging directory: {err}"))?
         .dev();
-    if target_device != staging_device {
-        return Err(
-            "module transaction staging directory is not on the target filesystem".to_string(),
-        );
+    for target_directory in target_directories {
+        let target_device = target_directory
+            .metadata()
+            .map_err(|err| format!("inspect module transaction target directory: {err}"))?
+            .dev();
+        if target_device != staging_device {
+            return Err(
+                "module transaction staging directory is not on the target filesystem".to_string(),
+            );
+        }
     }
     Ok(staging)
 }
@@ -1385,6 +1389,94 @@ mod tests {
 
         assert_eq!(fs::read_to_string(&bypass).unwrap(), "new-bypass\n");
         assert_eq!(fs::read_to_string(&proxy).unwrap(), "new-proxy\n");
+        assert_no_transaction_stages(&app);
+        fs::remove_dir_all(&directory).expect("remove test directory");
+    }
+
+    #[test]
+    fn module_transaction_replaces_files_across_module_directories() {
+        let (app, directory) = test_app("transaction-cross-directory");
+        let (bypass, _) = prepare_transaction_app_lists(&app);
+        let subscription = app
+            .moddir
+            .join(".config/sing-box/subscription.user-agent");
+        fs::create_dir_all(subscription.parent().expect("subscription parent"))
+            .expect("create subscription directory");
+        fs::write(&subscription, "old-agent\n").expect("write subscription fixture");
+
+        replace_module_text_files_transactionally(
+            &app,
+            &[
+                (
+                    Path::new(".config/sing-box/subscription.user-agent"),
+                    "new-agent\n",
+                ),
+                (
+                    Path::new(".config/magicnet/app-bypass.list"),
+                    "new-bypass\n",
+                ),
+            ],
+        )
+        .expect("replace files across module directories");
+
+        assert_eq!(fs::read_to_string(&subscription).unwrap(), "new-agent\n");
+        assert_eq!(fs::read_to_string(&bypass).unwrap(), "new-bypass\n");
+        assert_no_transaction_stages(&app);
+        fs::remove_dir_all(&directory).expect("remove test directory");
+    }
+
+    #[test]
+    fn module_transaction_rolls_back_across_directories_after_replace_failure() {
+        let (app, directory) = test_app("transaction-cross-directory-rollback");
+        let (bypass, proxy) = prepare_transaction_app_lists(&app);
+        let subscription = app
+            .moddir
+            .join(".config/sing-box/subscription.user-agent");
+        fs::create_dir_all(subscription.parent().expect("subscription parent"))
+            .expect("create subscription directory");
+        fs::write(&subscription, "old-agent\n").expect("write subscription fixture");
+        let mut replace_count = 0usize;
+
+        let error = replace_module_text_files_transactionally_with_rename(
+            &app,
+            &[
+                (
+                    Path::new(".config/sing-box/subscription.user-agent"),
+                    "new-agent\n",
+                ),
+                (
+                    Path::new(".config/magicnet/app-bypass.list"),
+                    "new-bypass\n",
+                ),
+                (
+                    Path::new(".config/magicnet/app-proxy.list"),
+                    "new-proxy\n",
+                ),
+            ],
+            |operation, source_directory, source, destination_directory, destination| {
+                replace_count += 1;
+                if replace_count == 3 {
+                    Err("injected cross-directory replace failure".to_string())
+                } else {
+                    rename_module_transaction_entry(
+                        operation,
+                        source_directory,
+                        source,
+                        destination_directory,
+                        destination,
+                    )
+                }
+            },
+        )
+        .expect_err("third replacement must fail");
+
+        assert!(
+            error.contains("injected cross-directory replace failure"),
+            "{error}"
+        );
+        assert_eq!(fs::read_to_string(&subscription).unwrap(), "old-agent\n");
+        assert_eq!(fs::read_to_string(&bypass).unwrap(), "old-bypass\n");
+        assert_eq!(fs::read_to_string(&proxy).unwrap(), "old-proxy\n");
         assert_no_transaction_stages(&app);
         fs::remove_dir_all(&directory).expect("remove test directory");
     }

--- a/crates/magicnet-cli/src/webui_backup.rs
+++ b/crates/magicnet-cli/src/webui_backup.rs
@@ -1,5 +1,6 @@
+use std::collections::HashSet;
 use std::fs;
-use std::path::Path;
+use std::path::PathBuf;
 
 use argon2::{Algorithm, Argon2, Params, Version};
 use chacha20poly1305::{
@@ -10,10 +11,8 @@ use chacha20poly1305::{
 use crate::subscriptions::{
     normalize_subscription_filter_text, validate_subscription_url, validate_subscription_user_agent,
 };
-use crate::{
-    decode_base64, run_magicnet_function, shell_inert_conf_value, write_secret_file,
-    write_text_file, App,
-};
+use crate::utils::replace_module_text_files_transactionally;
+use crate::{decode_base64, run_magicnet_function, shell_inert_conf_value, App};
 
 pub(crate) fn backup_cmd(app: &App, args: &[String]) -> Result<(), String> {
     match args.first().map(String::as_str).unwrap_or("export") {
@@ -200,9 +199,10 @@ fn verify_legacy_backup_password(text: &str, password: &str) -> Result<(), Strin
 fn restore_backup(app: &App, text: &str) -> Result<(), String> {
     let mut current: Option<String> = None;
     let mut buf = String::new();
+    let mut sections = Vec::new();
     for line in text.lines() {
         if let Some(path) = line.strip_prefix("--- ") {
-            flush_restore(app, current.take(), &buf)?;
+            collect_restore_section(&mut sections, current.take(), &buf);
             current = Some(path.to_string());
             buf.clear();
         } else if current.is_some() {
@@ -210,21 +210,51 @@ fn restore_backup(app: &App, text: &str) -> Result<(), String> {
             buf.push('\n');
         }
     }
-    flush_restore(app, current, &buf)
-}
+    collect_restore_section(&mut sections, current, &buf);
 
-fn flush_restore(app: &App, rel: Option<String>, text: &str) -> Result<(), String> {
-    let Some(rel) = rel else {
-        return Ok(());
-    };
-    if !backup_files().contains(&rel.as_str()) {
+    // Parse and validate the complete backup before touching any persisted
+    // configuration. The previous streaming restore could replace early files
+    // and then fail on a later malformed section, leaving disk and runtime
+    // configuration out of sync.
+    let mut seen = HashSet::new();
+    let mut replacements = Vec::new();
+    for (rel, text) in sections {
+        if !backup_files().contains(&rel.as_str()) {
+            continue;
+        }
+        if !seen.insert(rel.clone()) {
+            return Err(format!("refusing to restore duplicate config section: {rel}"));
+        }
+        validate_restore_section(&rel, &text)?;
+        replacements.push((PathBuf::from(rel), text));
+    }
+    if replacements.is_empty() {
         return Ok(());
     }
+    let replacement_refs = replacements
+        .iter()
+        .map(|(path, text)| (path.as_path(), text.as_str()))
+        .collect::<Vec<_>>();
+    replace_module_text_files_transactionally(app, &replacement_refs)
+}
+
+fn collect_restore_section(
+    sections: &mut Vec<(String, String)>,
+    rel: Option<String>,
+    text: &str,
+) {
+    let Some(rel) = rel else {
+        return;
+    };
+    sections.push((rel, text.to_string()));
+}
+
+fn validate_restore_section(rel: &str, text: &str) -> Result<(), String> {
     // `.conf` files are `.`-sourced by the shell library. A shell-inert value
     // alone is not enough: unknown keys such as PATH can still change the
     // runtime environment. Each restored file therefore has its own fixed
     // schema and value domain.
-    if rel.ends_with(".conf") && !sourced_conf_content_matches_schema(&rel, text) {
+    if rel.ends_with(".conf") && !sourced_conf_content_matches_schema(rel, text) {
         return Err(format!(
             "refusing to restore {rel}: file is shell-sourced and violates its allowlisted schema"
         ));
@@ -249,18 +279,7 @@ fn flush_restore(app: &App, rel: Option<String>, text: &str) -> Result<(), Strin
             ));
         }
     }
-    if secret_backup_file(&rel) {
-        write_secret_file(app, Path::new(&rel), text)
-    } else {
-        write_text_file(app, Path::new(&rel), text)
-    }
-}
-
-fn secret_backup_file(rel: &str) -> bool {
-    matches!(
-        rel,
-        ".config/sing-box/subscription.url" | ".config/magicnet/warp-endpoint.json"
-    )
+    Ok(())
 }
 
 /// Whether every line of a shell-sourced configuration file belongs to its
@@ -441,6 +460,61 @@ mod tests {
         let err = restore_backup(&app, text).unwrap_err();
         assert!(err.contains("block.conf"), "unexpected error: {err}");
         assert!(!app.moddir.join(".config/magicnet/block.conf").exists());
+    }
+
+    #[test]
+    fn restore_validation_failure_leaves_every_existing_config_unchanged() {
+        let app = temp_app();
+        let subscription = app
+            .moddir
+            .join(".config/sing-box/subscription.user-agent");
+        let app_mode = app.moddir.join(".config/magicnet/app-mode.conf");
+        fs::create_dir_all(subscription.parent().expect("subscription parent")).unwrap();
+        fs::create_dir_all(app_mode.parent().expect("app mode parent")).unwrap();
+        fs::write(&subscription, "old-agent\n").unwrap();
+        fs::write(&app_mode, "MAGICNET_APP_MODE=blacklist\n").unwrap();
+
+        let text = concat!(
+            "MagicNet backup v2\n",
+            "--- .config/sing-box/subscription.user-agent\n",
+            "new-agent\n",
+            "--- .config/magicnet/app-mode.conf\n",
+            "MAGICNET_APP_MODE=whitelist\n",
+            "--- .config/magicnet/dns.conf\n",
+            "PATH=/tmp/invalid\n",
+        );
+        let err = restore_backup(&app, text).expect_err("invalid final section must abort");
+
+        assert!(err.contains("dns.conf"), "{err}");
+        assert_eq!(fs::read_to_string(&subscription).unwrap(), "old-agent\n");
+        assert_eq!(
+            fs::read_to_string(&app_mode).unwrap(),
+            "MAGICNET_APP_MODE=blacklist\n"
+        );
+        assert!(!app.moddir.join(".config/magicnet/dns.conf").exists());
+    }
+
+    #[test]
+    fn restore_rejects_duplicate_known_sections_without_writing() {
+        let app = temp_app();
+        let app_mode = app.moddir.join(".config/magicnet/app-mode.conf");
+        fs::create_dir_all(app_mode.parent().expect("app mode parent")).unwrap();
+        fs::write(&app_mode, "MAGICNET_APP_MODE=blacklist\n").unwrap();
+        let text = concat!(
+            "MagicNet backup v2\n",
+            "--- .config/magicnet/app-mode.conf\n",
+            "MAGICNET_APP_MODE=whitelist\n",
+            "--- .config/magicnet/app-mode.conf\n",
+            "MAGICNET_APP_MODE=blacklist\n",
+        );
+
+        let err = restore_backup(&app, text).expect_err("duplicate section must abort");
+
+        assert!(err.contains("duplicate config section"), "{err}");
+        assert_eq!(
+            fs::read_to_string(&app_mode).unwrap(),
+            "MAGICNET_APP_MODE=blacklist\n"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- parse and validate the complete backup before writing any configuration
- reject duplicate known configuration sections before commit
- extend the existing module transaction helper across `.config/sing-box` and `.config/magicnet`
- roll back already-replaced files when a later cross-directory commit fails
- add regression coverage for validation failure, duplicate sections, cross-directory commit, and rollback

## Root cause

`restore_backup` streamed sections directly into their destination files. If an early section was valid and a later shell-sourced `.conf` section failed schema validation, the earlier files stayed replaced while the command returned before `magicnet_apply_runtime_config` ran. Persisted policy and the effective sing-box runtime could therefore disagree.

## Reproduction

1. Start with existing subscription and app-policy files.
2. Restore a backup containing valid replacements for those files.
3. Put an invalid key such as `PATH=...` in a later `dns.conf` section.
4. The old implementation returns an error after the earlier files have already changed.

## Validation

- `git diff --check`
- new Rust unit tests cover preflight aborts and cross-directory rollback
- full Rust formatting/check/test execution is delegated to GitHub Actions because the local runner does not include the Rust toolchain

Fixes #83

## Summary by Sourcery

通过在跨目录的模块事务中验证完整备份并应用配置更改，使备份恢复过程具有原子性。

Bug Fixes:
- 确保在备份恢复过程中，如果后续部分验证失败，不会导致配置被部分更新。
- 在提交任何更改之前，拒绝备份中重复的已知配置段。
- 通过在模块目录间以单一事务操作应用所有恢复的文件，防止持久化策略与运行时配置之间出现不一致。

Enhancements:
- 扩展模块文件事务助手，以支持在模块根目录下跨多个目录的不同目标，同时共享同一个暂存区域。

Tests:
- 添加单元测试，覆盖跨目录的事务性替换以及失败时的回滚行为。
- 添加单元测试，验证在验证失败或存在重复配置段时，恢复操作会中止且不会修改现有配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make backup restore atomic by validating the full backup and applying configuration changes via a cross-directory module transaction.

Bug Fixes:
- Ensure backup restore does not leave partially updated configuration when a later section fails validation.
- Reject duplicate known configuration sections in a backup before committing any changes.
- Prevent inconsistencies between persisted policy and runtime configuration by applying all restored files in a single transactional operation across module directories.

Enhancements:
- Extend the module file transaction helper to support distinct targets across multiple directories under the module root while sharing a single staging area.

Tests:
- Add unit tests covering cross-directory transactional replacement and rollback on failure.
- Add unit tests verifying that restore aborts on validation failure or duplicate sections without modifying existing configuration.

</details>