### PR TITLE
fix(app-policy): address review findings

### DIFF
--- a/crates/magicnet-cli/src/rules.rs
+++ b/crates/magicnet-cli/src/rules.rs
@@ -206,7 +206,10 @@ fn app_packages(args: &[String]) -> Result<(), String> {
         .output()
         .map_err(|err| format!("run pm list packages: {err}"))?;
     if !output.status.success() {
-        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+        return Err(command_failure_message(
+            "query Android VPN services",
+            &output,
+        ));
     }
     let mut packages: Vec<String> = String::from_utf8_lossy(&output.stdout)
         .lines()
@@ -222,6 +225,16 @@ fn app_packages(args: &[String]) -> Result<(), String> {
         println!("{package}");
     }
     Ok(())
+}
+
+fn command_failure_message(operation: &str, output: &std::process::Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let detail = stderr.trim();
+    if detail.is_empty() {
+        format!("{operation} failed: {}", output.status)
+    } else {
+        format!("{operation} failed: {detail}")
+    }
 }
 
 fn app_recommendations() -> Result<(), String> {
@@ -544,6 +557,17 @@ mod tests {
             vpn_service_packages(output),
             vec!["com.example.vpn".to_string()]
         );
+    }
+
+    #[test]
+    fn command_failure_message_falls_back_to_exit_status() {
+        let output = Command::new("sh")
+            .args(["-c", "exit 7"])
+            .output()
+            .unwrap();
+        let message = command_failure_message("query Android VPN services", &output);
+        assert!(message.starts_with("query Android VPN services failed:"));
+        assert!(message.contains('7'));
     }
 
     #[test]

--- a/scripts/package-smoke.sh
+++ b/scripts/package-smoke.sh
@@ -322,10 +322,6 @@ managed_ipv6_guards = [
 ]
 if any(rule in managed_ipv6_guards for rule in route_rules):
     raise SystemExit("packaged dual-stack config contains a managed IPv6 reject guard")
-if len(route_rules) != 65 or len(dns_rules) != 24:
-    raise SystemExit(
-        f"canonical rule counts changed: route={len(route_rules)} dns={len(dns_rules)}"
-    )
 outbound_tags = {outbound.get("tag") for outbound in config.get("outbounds", [])}
 outbounds = {outbound.get("tag"): outbound for outbound in config.get("outbounds", [])}
 

--- a/scripts/test-default-routing-policy.sh
+++ b/scripts/test-default-routing-policy.sh
@@ -88,7 +88,7 @@ package_cn_direct_count=$(jq '[.route.rules[] | select(.outbound? == "cn-direct"
 [[ "$package_cn_direct_count" -eq 0 ]] ||
     fail "cn-direct must be selected by destination/rule-set, not package catalog"
 
-multi_package_dns_count=$(jq '[.dns.rules[] | select(((.package_name // []) | length) > 1)] | length' "$CONFIG_FILE")
+multi_package_dns_count=$(jq '[.dns.rules[] | select((.package_name? | type) == "array" and (.package_name | length) > 1)] | length' "$CONFIG_FILE")
 [[ "$multi_package_dns_count" -eq 0 ]] ||
     fail "DNS policy must not contain a hardcoded application catalog"
 
@@ -175,10 +175,6 @@ proxy_dns_tags = {
     for server in config["dns"]["servers"]
     if server.get("detour") == "proxy"
 }
-if len(rules) != 65 or len(dns_rules) != 24:
-    raise AssertionError(
-        f"canonical rule counts changed: route={len(rules)} dns={len(dns_rules)}"
-    )
 apple_icloud_dns_rule = {
     "domain_suffix": ["apple.com", "icloud.com", "icloud-content.com", "me.com"],
     "server": "bootstrap-local-dns",

--- a/scripts/test-policy-architecture.sh
+++ b/scripts/test-policy-architecture.sh
@@ -35,6 +35,14 @@ bypass_count=$(grep -Ecv '^[[:space:]]*(#|$)' "$BYPASS" || true)
 [[ "$bypass_count" -eq 0 ]] \
     || fail "shipped app-bypass.list must not hardcode device-specific packages ($bypass_count found)"
 
+jq -ne '
+  def package_catalog:
+    (.package_name? | type) == "array" and (.package_name | length) > 1;
+  ({"package_name": "single"} | package_catalog | not)
+  and ({"package_name": ["single"]} | package_catalog | not)
+  and ({"package_name": ["first", "second"]} | package_catalog)
+' >/dev/null || fail "package catalog detection must distinguish strings from multi-value arrays"
+
 # Geodata / CN rule-set path must exist in shipped config (primary domestic split).
 jq -e '
   ([.route.rules[]?
@@ -42,7 +50,7 @@ jq -e '
   and ([.route.rules[]?
     | select((.outbound? == "cn-direct") and (.package_name? != null))] | length) == 0
   and ([.dns.rules[]?
-    | select(((.package_name // []) | length) > 1)] | length) == 0
+    | select((.package_name? | type) == "array" and (.package_name | length) > 1)] | length) == 0
 ' "$CONFIG" >/dev/null \
     || fail "config must use rule-set routing instead of hardcoded domestic package catalogs"
 


### PR DESCRIPTION
Follow-up to #94. Preserve useful errors from dynamic VpnService discovery, correct scalar-versus-array package catalog detection, remove duplicated route-count constants, and advance the MagicBox submodule to its review-fix commit. Validation: full pre-commit suite passed, including 301 Rust tests, routing regressions, package/install/fake-Magisk smoke, and MagicBox unit tests.

## Summary by Sourcery

优化围绕应用包和路由校验的策略工具，并将 MagicBox 子模块更新到最新已审阅版本。

Bug Fixes（缺陷修复）:
- 当 CLI 中动态发现 Android VPN 服务失败时，保留具有信息量的错误消息。
- 在基于 `jq` 的路由和 DNS 策略校验中，修正多包目录（multi-package catalogs）的检测逻辑，以正确区分字符串和多值数组。

Enhancements（功能增强）:
- 在 CLI 中新增可复用的辅助工具和测试，用于构造命令失败消息。
- 放宽策略校验脚本中对规范路由（canonical route）和 DNS 规则数量的硬编码检查，避免脆弱的测试失败。

Tests（测试）:
- 扩展 shell 和 Rust 测试，用于验证包目录检测的准确性以及命令失败消息的稳健性。

Chores（杂务）:
- 将 MagicBox 子模块推进到包含基于代码审查修复的提交。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine policy tooling around app packages and routing validation, and update the MagicBox submodule to the latest reviewed version.

Bug Fixes:
- Preserve informative error messages when dynamic Android VPN service discovery fails in the CLI.
- Correct detection of multi-package catalogs in jq-based routing and DNS policy validations to distinguish strings from multi-value arrays.

Enhancements:
- Add a reusable helper and test coverage for constructing command failure messages in the CLI.
- Relax hard-coded canonical route and DNS rule-count checks in policy validation scripts to avoid brittle test failures.

Tests:
- Extend shell and Rust tests to verify accurate package catalog detection and robust command failure messaging.

Chores:
- Advance the MagicBox submodule to the commit containing its review-driven fixes.

</details>