### PR TITLE
fix(routing): restore domestic app connectivity

### DIFF
--- a/crates/magicnet-cli/src/diagnostics_dns.rs
+++ b/crates/magicnet-cli/src/diagnostics_dns.rs
@@ -17,10 +17,10 @@ pub(super) fn dns_leak_check(app: &App, singbox: &str, mode: &str) -> (bool, Str
         format!(
             "core={core}, mode={mode}, valid_json={}, fakeip={}, hijack_dns={}, remote_dns_detour={}, store_fakeip={}, sniff_inbound={}, strategy={}, ipv6_guard={}",
             yes_no(cfg.valid_json),
-            yes_no(cfg.fake_ip),
+            disabled_enabled(cfg.fake_ip_disabled),
             yes_no(cfg.hijack),
             yes_no(cfg.remote_dns),
-            yes_no(cfg.store_fake_ip),
+            disabled_enabled(cfg.store_fake_ip_disabled),
             yes_no(cfg.sniff_inbound),
             cfg.strategy,
             cfg.ipv6_guard.as_str(),
@@ -54,10 +54,10 @@ impl Ipv6GuardStatus {
 #[derive(Clone, Copy)]
 struct SingboxDnsConfig {
     valid_json: bool,
-    fake_ip: bool,
+    fake_ip_disabled: bool,
     hijack: bool,
     remote_dns: bool,
-    store_fake_ip: bool,
+    store_fake_ip_disabled: bool,
     sniff_inbound: bool,
     strategy: &'static str,
     ipv6_guard: Ipv6GuardStatus,
@@ -67,10 +67,10 @@ struct SingboxDnsConfig {
 impl SingboxDnsConfig {
     fn ok(self) -> bool {
         self.valid_json
-            && self.fake_ip
+            && self.fake_ip_disabled
             && self.hijack
             && self.remote_dns
-            && self.store_fake_ip
+            && self.store_fake_ip_disabled
             && self.sniff_inbound
             && self.ipv6_guard.ok()
             && self.transparent_dns
@@ -95,15 +95,45 @@ fn singbox_dns_config_from_text(
     let sniff_inbound = sniff_rule_has(&compact, "mixed-in") && sniff_rule_has(&compact, "tun-in");
     SingboxDnsConfig {
         valid_json: parsed.is_some(),
-        fake_ip: compact.contains("\"type\":\"fakeip\"") && compact.contains("\"tag\":\"fakeip\""),
+        fake_ip_disabled: parsed.as_ref().is_some_and(|config| !has_fake_ip(config)),
         hijack: parsed.as_ref().is_some_and(has_dns_hijack_rule),
         remote_dns: has_remote_dns_detour(&compact),
-        store_fake_ip: compact.contains("\"store_fakeip\":true"),
+        store_fake_ip_disabled: parsed
+            .as_ref()
+            .is_some_and(|config| !stores_fake_ip(config)),
         sniff_inbound,
         strategy,
         ipv6_guard,
         transparent_dns,
     }
+}
+
+fn has_fake_ip(config: &Value) -> bool {
+    let has_server = config
+        .pointer("/dns/servers")
+        .and_then(Value::as_array)
+        .is_some_and(|servers| {
+            servers.iter().any(|server| {
+                server.get("type").and_then(Value::as_str) == Some("fakeip")
+                    || server.get("tag").and_then(Value::as_str) == Some("fakeip")
+            })
+        });
+    let has_rule = config
+        .pointer("/dns/rules")
+        .and_then(Value::as_array)
+        .is_some_and(|rules| {
+            rules
+                .iter()
+                .any(|rule| rule.get("server").and_then(Value::as_str) == Some("fakeip"))
+        });
+    has_server || has_rule
+}
+
+fn stores_fake_ip(config: &Value) -> bool {
+    config
+        .pointer("/experimental/cache_file/store_fakeip")
+        .and_then(Value::as_bool)
+        == Some(true)
 }
 
 fn has_dns_hijack_rule(config: &Value) -> bool {
@@ -202,6 +232,14 @@ fn yes_no(value: bool) -> &'static str {
     }
 }
 
+fn disabled_enabled(disabled: bool) -> &'static str {
+    if disabled {
+        "disabled"
+    } else {
+        "enabled"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -217,10 +255,10 @@ mod tests {
     fn healthy_config(strategy: &'static str, ipv6_guard: Ipv6GuardStatus) -> SingboxDnsConfig {
         SingboxDnsConfig {
             valid_json: true,
-            fake_ip: true,
+            fake_ip_disabled: true,
             hijack: true,
             remote_dns: true,
-            store_fake_ip: true,
+            store_fake_ip_disabled: true,
             sniff_inbound: true,
             strategy,
             ipv6_guard,
@@ -385,16 +423,58 @@ mod tests {
 
         assert_eq!(
             (
-                config.fake_ip,
+                config.fake_ip_disabled,
                 config.hijack,
                 config.remote_dns,
-                config.store_fake_ip,
+                config.store_fake_ip_disabled,
                 config.sniff_inbound,
                 config.valid_json,
                 config.ok(),
             ),
-            (true, false, true, true, true, false, false)
+            (false, false, true, false, true, false, false)
         );
+    }
+
+    #[test]
+    fn unused_fake_ip_server_is_unhealthy() {
+        let config = singbox_dns_config_from_text(
+            r#"{
+              "dns": {
+                "servers": [
+                  {"type":"fakeip","tag":"fakeip"},
+                  {"type":"https","tag":"remote","server":"dns.google","detour":"proxy"}
+                ]
+              },
+              "route": {"rules": [
+                {"protocol":"dns","action":"hijack-dns"},
+                {"action":"sniff","inbound":["mixed-in","tun-in"]}
+              ]}
+            }"#,
+            "tun",
+            true,
+        );
+
+        assert!(!config.ok());
+    }
+
+    #[test]
+    fn real_address_dns_without_fake_ip_is_healthy() {
+        let config = singbox_dns_config_from_text(
+            r#"{
+              "dns": {"servers": [
+                {"type":"https","tag":"remote","server":"dns.google","detour":"proxy"}
+              ], "strategy":"prefer_ipv4"},
+              "route": {"rules": [
+                {"protocol":"dns","action":"hijack-dns"},
+                {"action":"sniff","inbound":["mixed-in","tun-in"]}
+              ]},
+              "experimental":{"cache_file":{"enabled":true}}
+            }"#,
+            "tun",
+            true,
+        );
+
+        assert!(config.ok());
     }
 
     #[test]

--- a/hooks/post-build/9000.sanitize_zip.sh
+++ b/hooks/post-build/9000.sanitize_zip.sh
@@ -28,6 +28,8 @@ EOF
 remove_zip_entries '(^|/)\.git($|/)' "Removing git metadata from module artifact"
 remove_zip_entries '^\.local/subscriptions\.env$' "Removing local subscription memory from module artifact"
 remove_zip_entries '(^|/)(mihomo|__mihomo__)(\.sh)?($|/)' "Removing legacy mihomo helpers from module artifact"
+remove_zip_entries '^bin/magicnet-ebpf$' "Removing the retired eBPF runtime binary from module artifact"
+remove_zip_entries '^\.config/sing-box/\.dns-.*\.json$' "Removing routing test fixtures from module artifact"
 
 # kamfw 97168da's no-jq fallback toggles this field on every outbound,
 # including URLTest groups. Keep the fallback aligned with the jq path until

--- a/kam.toml
+++ b/kam.toml
@@ -1,8 +1,8 @@
 [prop]
 id = "MagicNet"
 name = "MagicNet"
-version = "v1.2.8"
-versionCode = 1785733015544
+version = "v1.2.9"
+versionCode = 1785861900000
 author = "LIghtJUNction"
 description = "[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM."
 updateJson = "https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json"

--- a/scripts/package-install-smoke.sh
+++ b/scripts/package-install-smoke.sh
@@ -66,10 +66,16 @@ printf '%s\n' 'MAGICNET_DEFAULT_CORE=sing-box' >"$PREV_MOD/.config/magicnet/curr
 printf '%s\n' 'MAGICNET_MCP_ENABLED=1' 'MAGICNET_MCP_BIND=127.0.0.1' 'MAGICNET_MCP_PORT=18766' \
     >"$PREV_MOD/.config/magicnet/mcp.conf"
 printf '%s\n' 'legacy proxy capture config' >"$PREV_MOD/.config/magicnet/capture.conf"
+printf '%s\n' '# legacy app policy' 'com.example.vpn' 'com.example.domestic' \
+    >"$PREV_MOD/.config/magicnet/app-bypass.list"
 
 for name in chcon restorecon getevent am cmd settings; do
     cat >"$MOCK_BIN/$name" <<'SH'
 #!/usr/bin/env bash
+if [[ "$1 $2 $3 $4 $5" == "package query-services --brief -a android.net.VpnService" ]]; then
+    printf '%s\n' '1 services found:' '  com.example.vpn/com.example.vpn.TunnelService'
+    exit 0
+fi
 exit 0
 SH
     chmod +x "$MOCK_BIN/$name"
@@ -180,6 +186,13 @@ grep -qx 'MAGICNET_MCP_PORT=18766' "$MODPATH/.config/magicnet/mcp.conf" \
     || fail "MCP config was not preserved from previous install"
 [[ ! -e "$MODPATH/.config/magicnet/capture.conf" ]] \
     || fail "legacy capture config should not be restored"
+grep -qx 'com.example.vpn' "$MODPATH/.config/magicnet/app-bypass.list" \
+    || fail "VPN app bypass was not preserved during migration"
+if grep -qx 'com.example.domestic' "$MODPATH/.config/magicnet/app-bypass.list"; then
+    fail "legacy non-VPN app bypass was restored during migration"
+fi
+[[ -f "$MODPATH/.config/magicnet/app-policy-migration-vpn-only" ]] \
+    || fail "app bypass migration marker was not written"
 
 cargo build -p magicnet-cli -p magicnet-mcp-server >/dev/null
 cp "$ROOT/target/debug/magicnet-cli" "$MODPATH/bin/magicnet-cli"

--- a/scripts/package-smoke.sh
+++ b/scripts/package-smoke.sh
@@ -118,6 +118,14 @@ if grep -E '(^|/)(capture_(common|mihomo|singbox)\.sh|capture\.conf|post-fs-data
     fail "zip contains legacy proxy-capture entries"
 fi
 
+if grep -Fx 'bin/magicnet-ebpf' "$entries_file" >/dev/null; then
+    fail "zip contains the removed eBPF runtime binary"
+fi
+
+if grep -E '^\.config/sing-box/\.dns-.*\.json$' "$entries_file" >/dev/null; then
+    fail "zip contains routing test fixtures"
+fi
+
 check_no_subscription_secret() {
     local entry="$1"
     grep -Fx "$entry" "$entries_file" >/dev/null || return 0
@@ -315,6 +323,12 @@ if (
 dns_rules = config.get("dns", {}).get("rules", [])
 dns_servers = config.get("dns", {}).get("servers", [])
 route_rules = config.get("route", {}).get("rules", [])
+if config.get("dns", {}).get("final") != "bootstrap-local-dns":
+    raise SystemExit(
+        "packaged unclassified DNS must use local encrypted resolution for destination-based CN routing"
+    )
+if any("package_name" in rule for rule in dns_rules):
+    raise SystemExit("packaged DNS policy must not contain application package selectors")
 managed_ipv6_guards = [
     {"ip_version": 6, "outbound": "block"},
     {"ip_version": 6, "action": "reject", "no_drop": True},
@@ -398,10 +412,6 @@ domestic_connectivity_rule = {
     ],
     "server": "bootstrap-local-dns",
 }
-wechat_dns_rule = {
-    "package_name": ["com.tencent.mm"],
-    "server": "bootstrap-local-dns",
-}
 msft_network_test_suffixes = ["msftconnecttest.com", "msftncsi.com"]
 foreign_network_test_suffixes = [
     "connectivitycheck.gstatic.com", "connectivitycheck.android.com",
@@ -433,20 +443,20 @@ legacy_early_local_msft_dns_rule = {
 }
 if legacy_early_local_msft_dns_rule in dns_rules:
     raise SystemExit("legacy early local Microsoft connectivity DNS rule must be absent")
-if route_rules[26] != {
-    "domain_suffix": msft_network_test_suffixes,
-    "outbound": "network-test",
-}:
-    raise SystemExit("route rule 26 Microsoft network-test suffixes changed")
-if route_rules[28] != {
-    "domain_suffix": foreign_network_test_suffixes,
-    "outbound": "network-test",
-}:
-    raise SystemExit("route rule 28 foreign network-test suffixes changed")
+msft_network_test_routes = [
+    (index, rule) for index, rule in enumerate(route_rules)
+    if rule == {"domain_suffix": msft_network_test_suffixes, "outbound": "network-test"}
+]
+foreign_network_test_routes = [
+    (index, rule) for index, rule in enumerate(route_rules)
+    if rule == {"domain_suffix": foreign_network_test_suffixes, "outbound": "network-test"}
+]
+if len(msft_network_test_routes) != 1 or len(foreign_network_test_routes) != 1:
+    raise SystemExit("network-test suffix routes must remain unique")
 if foreign_connectivity_rule["domain_suffix"] != (
-    route_rules[26]["domain_suffix"] + route_rules[28]["domain_suffix"]
+    msft_network_test_routes[0][1]["domain_suffix"] + foreign_network_test_routes[0][1]["domain_suffix"]
 ):
-    raise SystemExit("foreign network-test DNS suffixes must equal route rules 26 + 28")
+    raise SystemExit("foreign network-test DNS suffixes must equal the two network-test route blocks")
 apple_icloud_rule = {
     "domain_suffix": [
         "apple.com",
@@ -615,8 +625,15 @@ if (
     != karing_false_positive_domains
 ):
     raise SystemExit("packaged foreign-priority sequence must preserve 51 entries and append 5")
-if dns_rules[20] != foreign_priority_dns_rule:
-    raise SystemExit("packaged exact 56-domain foreign-priority DNS rule must remain at index 20")
+foreign_priority_dns_indexes = [
+    index for index, rule in enumerate(dns_rules) if rule == foreign_priority_dns_rule
+]
+if len(foreign_priority_dns_indexes) != 1:
+    raise SystemExit(
+        "packaged exact 56-domain foreign-priority DNS rule must remain unique: "
+        f"indexes={foreign_priority_dns_indexes}"
+    )
+foreign_priority_dns_index = foreign_priority_dns_indexes[0]
 supported_dns_safety_keys = {
     "clash_mode",
     "domain",
@@ -1021,9 +1038,6 @@ global_mode_rules = [
     index for index, rule in enumerate(dns_rules)
     if rule == {"clash_mode": "Global", "server": "doh-cloudflare"}
 ]
-wechat_dns_rules = [
-    index for index, rule in enumerate(dns_rules) if rule == wechat_dns_rule
-]
 domestic_connectivity_rules = [
     index for index, rule in enumerate(dns_rules) if rule == domestic_connectivity_rule
 ]
@@ -1071,16 +1085,15 @@ if len(direct_mode_rules) != 1 or len(global_mode_rules) != 1:
         f"Direct={direct_mode_rules} Global={global_mode_rules}"
     )
 if (
-    len(wechat_dns_rules) != 1
-    or len(domestic_connectivity_rules) != 1
+    len(domestic_connectivity_rules) != 1
     or len(foreign_connectivity_rules) != 1
     or len(apple_icloud_rules) != 1
     or len(cn_bing_dns_rules) != 1
     or len(global_bing_dns_rules) != 1
     or len(local_direct_service_rules) != 1
-    or dedicated_leak_test_dns_rules != [2]
+    or len(dedicated_leak_test_dns_rules) != 1
     or len(private_dns_rules) != 1
-    or mmstat_local_dns_rules != [15]
+    or len(mmstat_local_dns_rules) != 1
     or len(ad_suffix_dns_rules) != 1
     or len(ad_keyword_dns_rules) != 1
     or len(ad_rule_set_dns_rules) != 1
@@ -1090,7 +1103,7 @@ if (
 ):
     raise SystemExit(
         "expected unique exact explicit DNS policy rules, "
-        f"wechat={wechat_dns_rules} domestic={domestic_connectivity_rules} "
+        f"domestic={domestic_connectivity_rules} "
         f"foreign={foreign_connectivity_rules} "
         f"apple={apple_icloud_rules} cn_bing={cn_bing_dns_rules} "
         f"global_bing={global_bing_dns_rules} "
@@ -1103,7 +1116,6 @@ if (
     )
 direct_mode_index = direct_mode_rules[0]
 global_mode_index = global_mode_rules[0]
-wechat_dns_index = wechat_dns_rules[0]
 domestic_connectivity_index = domestic_connectivity_rules[0]
 foreign_connectivity_index = foreign_connectivity_rules[0]
 apple_icloud_index = apple_icloud_rules[0]
@@ -1121,15 +1133,10 @@ foreign_priority_dns_index = foreign_priority_dns_rules[0]
 canonical_cn_dns_index = canonical_cn_dns_rules[0]
 if global_mode_index != direct_mode_index + 1:
     raise SystemExit("Global DNS override must remain immediately after the Direct override")
-if wechat_dns_index != global_mode_index + 1:
-    raise SystemExit(
-        f"WeChat local DNS rule index {wechat_dns_index} must immediately follow "
-        f"Direct/Global overrides ending at {global_mode_index}"
-    )
-if domestic_connectivity_index != wechat_dns_index + 1:
+if domestic_connectivity_index != global_mode_index + 1:
     raise SystemExit(
         f"domestic connectivity DNS rule index {domestic_connectivity_index} must immediately "
-        f"follow WeChat local DNS rule index {wechat_dns_index}"
+        f"follow Direct/Global overrides ending at {global_mode_index}"
     )
 if foreign_connectivity_index != domestic_connectivity_index + 1:
     raise SystemExit(
@@ -1403,24 +1410,18 @@ x_package_routes = [
     for index, rule in enumerate(route_rules)
     if rule == {"package_name": ["com.twitter.android"], "outbound": "social-proxy"}
 ]
-fakeip_guard_routes = [
-    index
-    for index, rule in enumerate(route_rules)
-    if rule == {
-        "ip_cidr": ["127.0.0.1/32", "::1/128", "198.18.0.0/16", "28.0.0.0/8"],
-        "outbound": "block",
-    }
-]
-if len(x_package_routes) != 1 or len(fakeip_guard_routes) != 1:
-    raise SystemExit(
-        "packaged X action route or FakeIP guard is non-canonical: "
-        f"x={x_package_routes} guard={fakeip_guard_routes}"
-    )
-if x_package_routes[0] >= fakeip_guard_routes[0]:
-    raise SystemExit(
-        "packaged X action route must precede the FakeIP guard: "
-        f"x={x_package_routes[0]} guard={fakeip_guard_routes[0]}"
-    )
+if len(x_package_routes) != 1:
+    raise SystemExit(f"packaged X action route is non-canonical: x={x_package_routes}")
+if any(server.get("type") == "fakeip" or server.get("tag") == "fakeip" for server in config["dns"]["servers"]):
+    raise SystemExit("packaged default DNS must not enable FakeIP")
+if config.get("experimental", {}).get("cache_file", {}).get("store_fakeip") is True:
+    raise SystemExit("packaged default DNS must not persist FakeIP mappings")
+if any(
+    rule.get("outbound") == "block"
+    and ({"198.18.0.0/16", "28.0.0.0/8"} & set(rule.get("ip_cidr", [])))
+    for rule in route_rules
+):
+    raise SystemExit("packaged routing must not blackhole benchmark or public address space")
 
 for tag in ("ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude", "ai-proxy"):
     expected_selector = {"type": "selector", "tag": tag, "outbounds": ["block"], "default": "block"}
@@ -1562,13 +1563,45 @@ canonical_cn_rule_sets = [
     "karing-acl4ssr-china-domain",
     "karing-acl4ssr-china-ip",
 ]
+canonical_cn_ip_rule = {
+    "rule_set": ["lyc-geoip-cn", "metacubex-geoip-cn", "karing-acl4ssr-china-ip"],
+    "outbound": "cn-direct",
+}
+canonical_cn_ip_routes = [
+    (index, rule) for index, rule in enumerate(route_rules) if rule == canonical_cn_ip_rule
+]
+if len(canonical_cn_ip_routes) != 1:
+    raise SystemExit(
+        f"expected one early CN IP-only route before ad rule-sets, found {canonical_cn_ip_routes}"
+    )
+canonical_cn_ip_index = canonical_cn_ip_routes[0][0]
+ad_rule_set_routes = [
+    (index, rule) for index, rule in enumerate(route_rules)
+    if rule.get("outbound") == "ad-block" and "rule_set" in rule
+]
+if len(ad_rule_set_routes) != 2 or not canonical_cn_ip_index < ad_rule_set_routes[0][0]:
+    raise SystemExit(
+        "CN IP-only routing must precede both ad IP rule-set routes: "
+        f"cn_ip={canonical_cn_ip_routes} ad={ad_rule_set_routes}"
+    )
+if set(canonical_cn_ip_rule["rule_set"]) & {
+    "lyc-geosite-cn", "lyc-geosite-geolocation-cn", "ddch-direct"
+}:
+    raise SystemExit("CN IP-only route must not include domain or mixed direct rule-sets")
 foreign_priority_route_rule = {
     "domain_suffix": foreign_priority_domains,
     "outbound": "proxy-rule",
 }
-if route_rules[48] != foreign_priority_route_rule:
-    raise SystemExit("packaged exact 56-domain foreign-priority route must remain at index 48")
-if route_rules[48]["domain_suffix"] != dns_rules[20]["domain_suffix"]:
+foreign_priority_route_indexes = [
+    index for index, rule in enumerate(route_rules) if rule == foreign_priority_route_rule
+]
+if len(foreign_priority_route_indexes) != 1:
+    raise SystemExit(
+        "packaged exact 56-domain foreign-priority route must remain unique: "
+        f"{foreign_priority_route_indexes}"
+    )
+foreign_priority_route_index = foreign_priority_route_indexes[0]
+if route_rules[foreign_priority_route_index]["domain_suffix"] != dns_rules[foreign_priority_dns_index]["domain_suffix"]:
     raise SystemExit("packaged foreign-priority route/DNS lists must remain identical")
 canonical_keyword_rule = {"domain_keyword": network_test_keywords, "outbound": "network-test"}
 keyword_routes = [
@@ -1739,8 +1772,11 @@ if len(final_keyword_routes) != 1 or final_keyword_routes[0] != telegram_ip_rout
         "unchanged final foreign keyword route must immediately follow the Telegram IP route: "
         f"actual={final_keyword_routes}"
     )
-if final_keyword_routes != [len(route_rules) - 1]:
-    raise SystemExit("final foreign keyword route must be the last explicit route rule")
+if final_keyword_routes[0] != len(route_rules) - 1:
+    raise SystemExit(
+        "final foreign keyword route must remain the last explicit route before route.final: "
+        f"keyword={final_keyword_routes} rule_count={len(route_rules)}"
+    )
 
 media_domains = {"youtube.com", "ytimg.com", "googlevideo.com"}
 media_rule_indexes = {
@@ -1823,13 +1859,24 @@ if recursively_effective_outbound(global_bing_route_rule["outbound"]) != "block"
         f"r.bing.com route index {global_bing_route_index} must resolve through bing/block"
     )
 
+mmstat_route_index = first_route_index(
+    lambda rule: rule.get("outbound") == "ad-block"
+    and "lyc-geosite-ads" in (
+        rule.get("rule_set")
+        if isinstance(rule.get("rule_set"), list)
+        else [rule.get("rule_set")]
+    )
+    and binary_rule_set_matches("lyc-geosite-ads", "mmstat.com")
+)
 if (
-    route_rules[30].get("outbound") != "cn-direct"
-    or not explicit_domain_matches(route_rules[30], "mmstat.com")
-    or any(explicit_domain_matches(rule, "mmstat.com") for rule in route_rules[:30])
-    or recursively_effective_outbound(route_rules[30]["outbound"]) != "direct"
+    mmstat_route_index < 0
+    or recursively_effective_outbound(route_rules[mmstat_route_index]["outbound"]) != "block"
+    or not binary_rule_set_matches("lyc-geosite-ads", "mmstat.com")
 ):
-    raise SystemExit("packaged mmstat.com route must first-match index 30 cn-direct/direct")
+    raise SystemExit(
+        "packaged mmstat.com must use the generic ad rule-set route instead of a vendor direct exception: "
+        f"index={mmstat_route_index}"
+    )
 
 download_probes = set(download_suffixes)
 for index, rule in enumerate(route_rules[:download_route_index]):

--- a/scripts/test-action-routing.sh
+++ b/scripts/test-action-routing.sh
@@ -23,10 +23,6 @@ with open(sys.argv[1], encoding="utf-8") as handle:
     config = json.load(handle)
 
 route_rules = config["route"]["rules"]
-fakeip_guard = {
-    "ip_cidr": ["127.0.0.1/32", "::1/128", "198.18.0.0/16", "28.0.0.0/8"],
-    "outbound": "block",
-}
 chatgpt_packages = {"com.openai.chatgpt", "com.openai.chat", "ai.openai.chatgpt"}
 x_packages = {"com.twitter.android"}
 
@@ -51,23 +47,12 @@ def package_indexes(packages, outbound):
     ]
 
 
-guard_indexes = exact_indexes(fakeip_guard)
 chatgpt_indexes = package_indexes(chatgpt_packages, "ai-chatgpt")
 x_indexes = package_indexes(x_packages, "social-proxy")
-if len(guard_indexes) != 1:
-    raise AssertionError(f"expected one exact FakeIP guard, got {guard_indexes}")
 if len(chatgpt_indexes) != 1:
     raise AssertionError(f"expected one exact ChatGPT package route, got {chatgpt_indexes}")
 if len(x_indexes) != 1:
     raise AssertionError(f"expected one exact X package route, got {x_indexes}")
-
-guard_index = guard_indexes[0]
-if chatgpt_indexes[0] >= guard_index or x_indexes[0] >= guard_index:
-    raise AssertionError(
-        "ChatGPT and X package routes must precede the FakeIP guard: "
-        f"chatgpt={chatgpt_indexes[0]} x={x_indexes[0]} guard={guard_index}"
-    )
-
 
 def domain_matches(rule, domain):
     return any(
@@ -120,18 +105,18 @@ for package_name, expected_index, expected_outbound in (
 ):
     index, outbound = first_modeled_outbound(
         "unclassified-action.invalid",
-        "198.18.1.1",
+        "203.0.113.10",
         package_name,
     )
     if (index, outbound) != (expected_index, expected_outbound):
         raise AssertionError(
-            f"{package_name} FakeIP action flow matched index={index} outbound={outbound}"
+            f"{package_name} package-first action flow matched index={index} outbound={outbound}"
         )
 
 for domain in ("api.x.com", "upload.twitter.com", "abs.twimg.com"):
     index, outbound = first_modeled_outbound(
         domain,
-        "198.18.1.1",
+        "203.0.113.10",
         "com.twitter.android",
     )
     if (index, outbound) != (x_indexes[0], "social-proxy"):

--- a/scripts/test-app-routing-policy.sh
+++ b/scripts/test-app-routing-policy.sh
@@ -17,6 +17,8 @@ fi
 . "$ROOT/src/MagicNet/lib/magicnet/core.sh"
 . "$ROOT/src/MagicNet/lib/magicnet/network.sh"
 
+magicnet_warn() { :; }
+
 NO_JQ_BIN="$WORK/no-jq-bin"
 mkdir -p "$NO_JQ_BIN"
 for command_name in awk cp grep mkdir mv rm sed tr wc; do
@@ -244,6 +246,52 @@ EOF
 
 run_case jq
 run_case no-jq
+
+assert_jq_removes_legacy_dns_package_rules() {
+  MODDIR="$WORK/jq-dns/module"
+  export MODDIR
+  mkdir -p "$MODDIR/.config/magicnet" "$MODDIR/.config/sing-box"
+  write_base_config
+  printf '%s\n' 'MAGICNET_APP_MODE=blacklist' >"$MODDIR/.config/magicnet/app-mode.conf"
+  printf '%s\n' 'com.example.proxy' >"$MODDIR/.config/magicnet/app-proxy.list"
+  printf '%s\n' 'com.example.direct-force' >"$MODDIR/.config/magicnet/app-direct.list"
+  printf '%s\n' 'com.example.bypass' >"$MODDIR/.config/magicnet/app-bypass.list"
+  "$JQ_BIN" '.dns = {"rules": [
+    {"package_name": ["com.example.legacy"], "server": "bootstrap-local-dns"},
+    {"domain_suffix": ["example.org"], "server": "doh-cloudflare"}
+  ]}' "$MODDIR/.config/sing-box/config.json" >"$MODDIR/config.new"
+  mv -f "$MODDIR/config.new" "$MODDIR/.config/sing-box/config.json"
+  PATH="$MOCK_BIN:$PATH" magicnet_singbox_apply_app_policy
+  "$JQ_BIN" -e '
+    ([.dns.rules[] | select(has("package_name"))] | length) == 0
+    and ([.dns.rules[] | select(.domain_suffix == ["example.org"])] | length) == 1
+  ' "$MODDIR/.config/sing-box/config.json" >/dev/null
+}
+
+assert_no_jq_rejects_legacy_dns_package_rules() {
+  MODDIR="$WORK/no-jq-dns/module"
+  export MODDIR
+  mkdir -p "$MODDIR/.config/magicnet" "$MODDIR/.config/sing-box"
+  cat >"$MODDIR/.config/sing-box/config.json" <<'EOF'
+{
+  "dns": {
+    "rules": [
+      {"package_name": ["com.example.legacy"], "server": "bootstrap-local-dns"}
+    ]
+  },
+  "route": {"rules": []}
+}
+EOF
+  if PATH="$MOCK_BIN:$NO_JQ_BIN" magicnet_singbox_apply_app_policy; then
+    printf '%s\n' 'no-jq app policy must reject legacy DNS package rules' >&2
+    exit 1
+  fi
+  "$JQ_BIN" -e '([.dns.rules[] | select(has("package_name"))] | length) == 1' \
+    "$MODDIR/.config/sing-box/config.json" >/dev/null
+}
+
+assert_jq_removes_legacy_dns_package_rules
+assert_no_jq_rejects_legacy_dns_package_rules
 
 assert_dns_capture_bypass_uids() (
   MODDIR="$WORK/dns-capture/module"

--- a/scripts/test-default-routing-policy.sh
+++ b/scripts/test-default-routing-policy.sh
@@ -92,6 +92,30 @@ multi_package_dns_count=$(jq '[.dns.rules[] | select((.package_name? | type) == 
 [[ "$multi_package_dns_count" -eq 0 ]] ||
     fail "DNS policy must not contain a hardcoded application catalog"
 
+dns_package_rule_count=$(jq '[.dns.rules[] | select(has("package_name"))] | length' "$CONFIG_FILE")
+[[ "$dns_package_rule_count" -eq 0 ]] ||
+    fail "DNS policy must not contain application package selectors"
+
+fakeip_server_count=$(jq '[.dns.servers[] | select(.type == "fakeip" or .tag == "fakeip")] | length' "$CONFIG_FILE")
+[[ "$fakeip_server_count" -eq 0 ]] ||
+    fail "default DNS policy must not enable an unconsumed FakeIP server"
+
+fakeip_rule_count=$(jq '[.dns.rules[] | select(.server == "fakeip")] | length' "$CONFIG_FILE")
+[[ "$fakeip_rule_count" -eq 0 ]] ||
+    fail "default DNS policy must return real addresses instead of FakeIP answers"
+
+store_fakeip=$(jq -r '.experimental.cache_file.store_fakeip // false' "$CONFIG_FILE")
+[[ "$store_fakeip" == "false" ]] ||
+    fail "default DNS policy must not persist stale FakeIP mappings"
+
+fakeip_blackhole_count=$(jq '[
+    .route.rules[]
+    | select(.outbound == "block")
+    | select(any(.ip_cidr[]?; . == "198.18.0.0/16" or . == "28.0.0.0/8"))
+] | length' "$CONFIG_FILE")
+[[ "$fakeip_blackhole_count" -eq 0 ]] ||
+    fail "routing policy must not blackhole benchmark or public address space as a FakeIP guard"
+
 first_matching_value() {
     local rules_path="$1"
     local value_key="$2"
@@ -181,10 +205,6 @@ apple_icloud_dns_rule = {
 }
 direct_mode_dns_rule = {"clash_mode": "Direct", "server": "bootstrap-local-dns"}
 global_mode_dns_rule = {"clash_mode": "Global", "server": "doh-cloudflare"}
-wechat_dns_rule = {
-    "package_name": ["com.tencent.mm"],
-    "server": "bootstrap-local-dns",
-}
 domestic_connectivity_dns_rule = {
     "domain_suffix": ["connect.rom.miui.com", "connectivitycheck.platform.hicloud.com"],
     "server": "bootstrap-local-dns",
@@ -227,12 +247,18 @@ legacy_early_local_msft_dns_rule = {
 }
 if legacy_early_local_msft_dns_rule in dns_rules:
     raise AssertionError("legacy early local Microsoft connectivity DNS rule must be absent")
-if rules[26] != {"domain_suffix": msft_network_test_suffixes, "outbound": "network-test"}:
-    raise AssertionError("route rule 26 Microsoft network-test suffixes changed")
-if rules[28] != {"domain_suffix": foreign_network_test_suffixes, "outbound": "network-test"}:
-    raise AssertionError("route rule 28 foreign network-test suffixes changed")
+msft_network_test_routes = [
+    (index, rule) for index, rule in enumerate(rules)
+    if rule == {"domain_suffix": msft_network_test_suffixes, "outbound": "network-test"}
+]
+foreign_network_test_routes = [
+    (index, rule) for index, rule in enumerate(rules)
+    if rule == {"domain_suffix": foreign_network_test_suffixes, "outbound": "network-test"}
+]
+if len(msft_network_test_routes) != 1 or len(foreign_network_test_routes) != 1:
+    raise AssertionError("network-test suffix routes must remain unique")
 if foreign_network_test_dns_rule["domain_suffix"] != (
-    rules[26]["domain_suffix"] + rules[28]["domain_suffix"]
+    msft_network_test_routes[0][1]["domain_suffix"] + foreign_network_test_routes[0][1]["domain_suffix"]
 ):
     raise AssertionError("foreign network-test DNS suffixes must equal route rules 27 + 29")
 cn_bing_dns_rule = {
@@ -285,7 +311,6 @@ ordered_dns_policy_indexes = []
 for expected_rule in (
     direct_mode_dns_rule,
     global_mode_dns_rule,
-    wechat_dns_rule,
     domestic_connectivity_dns_rule,
     foreign_network_test_dns_rule,
     apple_icloud_dns_rule,
@@ -302,14 +327,13 @@ if not all(
     for left, right in zip(ordered_dns_policy_indexes, ordered_dns_policy_indexes[1:])
 ):
     raise AssertionError(
-        "required DNS order is Direct -> Global -> WeChat local -> domestic connectivity -> foreign network-test "
+        "required DNS order is Direct -> Global -> domestic connectivity -> foreign network-test "
         "-> Apple -> cn Bing -> global Bing -> local Microsoft: "
         f"indexes={ordered_dns_policy_indexes}"
     )
 (
     direct_mode_dns_index,
     global_mode_dns_index,
-    wechat_dns_index,
     domestic_connectivity_dns_index,
     foreign_network_test_dns_index,
     apple_icloud_dns_index,
@@ -317,12 +341,22 @@ if not all(
     global_bing_dns_index,
     local_microsoft_dns_index,
 ) = ordered_dns_policy_indexes
+def exact_dns_index(expected_rule):
+    matches = [index for index, rule in enumerate(dns_rules) if rule == expected_rule]
+    if len(matches) != 1:
+        raise AssertionError(f"expected one exact DNS rule: indexes={matches}")
+    return matches[0]
+
+
+ad_suffix_dns_index = exact_dns_index(ad_suffix_dns_rule)
+ad_keyword_dns_index = exact_dns_index(ad_keyword_dns_rule)
+ad_rule_set_dns_index = exact_dns_index(ad_rule_set_dns_rule)
 dedicated_leak_test_dns_indexes = [
     index for index, rule in enumerate(dns_rules) if rule == dedicated_leak_test_dns_rule
 ]
-if dedicated_leak_test_dns_indexes != [2]:
+if len(dedicated_leak_test_dns_indexes) != 1:
     raise AssertionError(
-        f"expected one exact dedicated leak-test DNS rule at index 2: "
+        "expected one exact dedicated leak-test DNS rule: "
         f"indexes={dedicated_leak_test_dns_indexes}"
     )
 dedicated_leak_test_dns_index = dedicated_leak_test_dns_indexes[0]
@@ -530,11 +564,20 @@ expected_dns_tail = [
     generic_foreign_dns_rule,
     specialized_foreign_dns_rule,
 ]
-if dns_rules[14:] != expected_dns_tail:
+dns_tail_start = next(
+    (index for index, rule in enumerate(dns_rules) if rule == expected_dns_tail[0]),
+    None,
+)
+if (
+    dns_tail_start is None
+    or dns_rules[dns_tail_start:dns_tail_start + len(expected_dns_tail)] != expected_dns_tail
+    or dns_tail_start + len(expected_dns_tail) != len(dns_rules)
+):
     raise AssertionError(
         "required DNS order is private < mmstat local < ad suffix < ad keyword < ad rule-set < game < "
         "foreign priority < canonical CN < generic foreign < specialized: "
-        f"{dns_rules[14:]}"
+        f"tail_start={dns_tail_start} tail="
+        f"{dns_rules[dns_tail_start:] if dns_tail_start is not None else None}"
     )
 for expected_rule in expected_dns_tail:
     matches = [index for index, rule in enumerate(dns_rules) if rule == expected_rule]
@@ -606,6 +649,30 @@ canonical_cn_rule_sets = {
     "karing-acl4ssr-china-domain",
     "karing-acl4ssr-china-ip",
 }
+canonical_cn_ip_rule = {
+    "rule_set": ["lyc-geoip-cn", "metacubex-geoip-cn", "karing-acl4ssr-china-ip"],
+    "outbound": "cn-direct",
+}
+canonical_cn_ip_routes = [
+    (index, rule) for index, rule in enumerate(rules) if rule == canonical_cn_ip_rule
+]
+if len(canonical_cn_ip_routes) != 1:
+    raise AssertionError(
+        f"expected one early CN IP-only route before ad rule-sets: {canonical_cn_ip_routes}"
+    )
+canonical_cn_ip_index = canonical_cn_ip_routes[0][0]
+ad_rule_set_routes = [
+    (index, rule) for index, rule in enumerate(rules)
+    if rule.get("outbound") == "ad-block" and "rule_set" in rule
+]
+if len(ad_rule_set_routes) != 2:
+    raise AssertionError(f"expected two ad rule-set routes, found {ad_rule_set_routes}")
+if not canonical_cn_ip_index < ad_rule_set_routes[0][0]:
+    raise AssertionError(
+        "CN IP-only routing must precede ad IP rule-sets so domestic CDN IPs are not blocked"
+    )
+if set(canonical_cn_ip_rule["rule_set"]) & {"lyc-geosite-cn", "lyc-geosite-geolocation-cn", "ddch-direct"}:
+    raise AssertionError("CN IP-only route must not include domain or mixed direct rule-sets")
 cn_overlap_evidence_rule_sets = canonical_cn_rule_sets | {"metacubex-geosite-cn"}
 generic_foreign_rule_sets = {
     "lyc-geosite-gfw",
@@ -650,9 +717,17 @@ if (
     != karing_false_positive_domains
 ):
     raise AssertionError("foreign-priority domain sequence must preserve 51 entries and append 5")
-if rules[48] != foreign_priority_route_rule or dns_rules[20] != foreign_priority_dns_rule:
-    raise AssertionError("exact 56-domain foreign-priority route/DNS indexes changed")
-if rules[48]["domain_suffix"] != dns_rules[20]["domain_suffix"]:
+foreign_priority_route_indexes = [
+    index for index, rule in enumerate(rules) if rule == foreign_priority_route_rule
+]
+foreign_priority_dns_indexes = [
+    index for index, rule in enumerate(dns_rules) if rule == foreign_priority_dns_rule
+]
+if len(foreign_priority_route_indexes) != 1 or len(foreign_priority_dns_indexes) != 1:
+    raise AssertionError("exact 56-domain foreign-priority route/DNS ownership changed")
+foreign_priority_route_index = foreign_priority_route_indexes[0]
+foreign_priority_dns_index = foreign_priority_dns_indexes[0]
+if rules[foreign_priority_route_index]["domain_suffix"] != dns_rules[foreign_priority_dns_index]["domain_suffix"]:
     raise AssertionError("foreign-priority route/DNS domain lists must remain identical")
 flows = (
     {
@@ -850,7 +925,14 @@ def route_rule_matches(rule, domain, flow):
         if not domain_group_matches(rule, domain):
             return False
     if "rule_set" in rule:
-        if not any(binary_rule_set_matches(tag, domain) for tag in values(rule["rule_set"])):
+        rule_set_targets = [domain]
+        if destination_ip is not None:
+            rule_set_targets.append(destination_ip)
+        if not any(
+            binary_rule_set_matches(tag, target)
+            for tag in values(rule["rule_set"])
+            for target in rule_set_targets
+        ):
             return False
     return True
 
@@ -858,8 +940,13 @@ def route_rule_matches(rule, domain, flow):
 def first_matching_outbound(domain, flow):
     for index, rule in enumerate(rules):
         if "outbound" in rule and route_rule_matches(rule, domain, flow):
+            rule_set_targets = [domain]
+            if flow["destination_ip"] is not None:
+                rule_set_targets.append(flow["destination_ip"])
             matching_rule_sets = {
-                tag for tag in values(rule.get("rule_set")) if binary_rule_set_matches(tag, domain)
+                tag
+                for tag in values(rule.get("rule_set"))
+                if any(binary_rule_set_matches(tag, target) for target in rule_set_targets)
             }
             return index, rule, matching_rule_sets
     raise AssertionError(f"{flow['name']} {domain} has no matching outbound route")
@@ -868,8 +955,13 @@ def first_matching_outbound(domain, flow):
 def first_matching_dns(domain, flow):
     for index, rule in enumerate(dns_rules):
         if "server" in rule and route_rule_matches(rule, domain, flow):
+            rule_set_targets = [domain]
+            if flow["destination_ip"] is not None:
+                rule_set_targets.append(flow["destination_ip"])
             matching_rule_sets = {
-                tag for tag in values(rule.get("rule_set")) if binary_rule_set_matches(tag, domain)
+                tag
+                for tag in values(rule.get("rule_set"))
+                if any(binary_rule_set_matches(tag, target) for target in rule_set_targets)
             }
             return index, rule, matching_rule_sets
     return None
@@ -886,16 +978,17 @@ google_play_proxy_rule = {
 google_play_proxy_indexes = [
     index for index, rule in enumerate(rules) if rule == google_play_proxy_rule
 ]
-if google_play_proxy_indexes != [8]:
+if len(google_play_proxy_indexes) != 1:
     raise AssertionError(
-        "Google Play package routing must have one early proxy owner at index 8: "
+        "Google Play package routing must have one early proxy owner: "
         f"indexes={google_play_proxy_indexes}"
     )
+google_play_proxy_index = google_play_proxy_indexes[0]
 for package_name in google_play_proxy_rule["package_name"]:
     for base_flow in flows:
         flow = dict(base_flow, package_name=package_name)
         index, rule, _ = first_matching_outbound("play.googleapis.com", flow)
-        if index != 8 or rule != google_play_proxy_rule:
+        if index != google_play_proxy_index or rule != google_play_proxy_rule:
             raise AssertionError(
                 f"{package_name} {base_flow['name']} must proxy before destination rules: "
                 f"index={index} rule={rule}"
@@ -961,9 +1054,9 @@ for domain in karing_false_positive_domains:
         dns_index, dns_rule, _ = dns_match
         dns_server = dns_rule.get("server")
     if (
-        route_index != 48
+        route_index != foreign_priority_route_index
         or route_rule.get("outbound") != "proxy-rule"
-        or dns_index != 20
+        or dns_index != foreign_priority_dns_index
         or dns_server != "doh-google"
     ):
         karing_false_positive_failures.append(
@@ -1114,45 +1207,6 @@ for tag in fail_closed_ai_tags:
     if matches != [expected_selector]:
         raise AssertionError(f"{tag} selector is not canonical fail-closed: {matches}")
 
-wechat_route_rule = {
-    "domain_suffix": [
-        "qq.com", "weixin.qq.com", "wechat.com", "wechatapp.com", "wechatpay.cn",
-        "tenpay.com", "tencent.com", "tencent-cloud.com", "myqcloud.com", "qcloud.com",
-        "gtimg.com", "idqqimg.com", "qpic.cn", "qlogo.cn", "qmail.com", "smtcdns.com",
-        "servicewechat.com", "weixinbridge.com", "weixinsxy.com", "wx.gtimg.com", "wx.qq.com",
-    ],
-    "outbound": "cn-direct",
-}
-wechat_route_indexes = [
-    index for index, rule in enumerate(rules) if rule == wechat_route_rule
-]
-if len(wechat_route_indexes) != 1:
-    raise AssertionError(f"expected one exact WeChat route: indexes={wechat_route_indexes}")
-wechat_route_index = wechat_route_indexes[0]
-for domain in wechat_route_rule["domain_suffix"]:
-    owners = [
-        index for index, rule in enumerate(rules)
-        if domain in values(rule.get("domain_suffix"))
-        and rule.get("outbound") == "cn-direct"
-    ]
-    if owners != [wechat_route_index]:
-        raise AssertionError(f"WeChat domain must have one early cn-direct owner: {domain} indexes={owners}")
-
-loop_fake_guard_rule = {
-    "ip_cidr": ["127.0.0.1/32", "::1/128", "198.18.0.0/16", "28.0.0.0/8"],
-    "outbound": "block",
-}
-loop_fake_guard_indexes = [
-    index for index, rule in enumerate(rules) if rule == loop_fake_guard_rule
-]
-if len(loop_fake_guard_indexes) != 1:
-    raise AssertionError(f"expected one exact loop/FakeIP guard: indexes={loop_fake_guard_indexes}")
-loop_fake_guard_index = loop_fake_guard_indexes[0]
-if wechat_route_index + 1 != loop_fake_guard_index:
-    raise AssertionError(
-        "WeChat media route must immediately precede the loop/FakeIP guard: "
-        f"wechat={wechat_route_index} guard={loop_fake_guard_index}"
-    )
 lan_rules = [
     {"domain_suffix": ["local", "home.arpa", "lan"], "outbound": "lan"},
     {"domain_suffix": ["tailscale.net", "ts.net"], "outbound": "lan"},
@@ -1188,13 +1242,6 @@ public_ad_probes = {
     "google-analytics.com": "1.1.1.1",
     "doubleclick.net": "8.8.8.8",
 }
-guard_probes = {
-    "127.0.0.1": "analytics.local",
-    "::1": "analytics.local",
-    "198.18.1.1": "analytics.local",
-    "28.1.2.3": "analytics.local",
-}
-
 for base_flow in flows:
     for domain, destination_ip in lan_route_probes.items():
         flow = dict(base_flow, destination_ip=destination_ip,
@@ -1220,49 +1267,26 @@ for base_flow in flows:
                 f"{flow['name']} {domain}/{destination_ip}: index={index} "
                 f"outbound={rule['outbound']} effective={effective}, expected=ad-block/block"
             )
-    for destination_ip, domain in guard_probes.items():
-        flow = dict(base_flow, destination_ip=destination_ip,
-                    ip_version=ipaddress.ip_address(destination_ip).version)
-        index, rule, _ = first_matching_outbound(domain, flow)
-        effective = recursively_effective_outbound(rule["outbound"])
-        if index != loop_fake_guard_index or rule != loop_fake_guard_rule or effective != "block":
-            raise AssertionError(
-                f"{flow['name']} guard {domain}/{destination_ip}: index={index} "
-                f"rule={rule} effective={effective}, expected unchanged index-{loop_fake_guard_index} block guard"
-            )
-
-wechat_media_flow = dict(
-    flows[0],
-    package_name="com.tencent.mm",
-    destination_ip="198.18.1.1",
-    ip_version=4,
-)
-index, rule, _ = first_matching_outbound("upload.qpic.cn", wechat_media_flow)
-effective = recursively_effective_outbound(rule["outbound"])
-if index != wechat_route_index or rule != wechat_route_rule or effective != "direct":
-    raise AssertionError(
-        "WeChat media traffic with a cached FakeIP must bypass the later guard through cn-direct: "
-        f"index={index} rule={rule} effective={effective}"
-    )
-wechat_dns_result = first_matching_dns("unclassified-wechat-upload.invalid", wechat_media_flow)
-if wechat_dns_result is None:
-    raise AssertionError("WeChat DNS query unexpectedly fell through to dns.final")
-index, rule, _ = wechat_dns_result
-if index != wechat_dns_index or rule != wechat_dns_rule:
-    raise AssertionError(
-        "WeChat DNS must use the early local resolver rule to avoid new FakeIP media destinations: "
-        f"index={index} rule={rule}"
-    )
-
 expected_lan_ad_block = lan_rules + ad_rules
-lan_ad_start = loop_fake_guard_index + 1
-lan_ad_end = lan_ad_start + len(expected_lan_ad_block)
-if rules[lan_ad_start:lan_ad_end] != expected_lan_ad_block:
+lan_ad_indexes = [
+    next((index for index, rule in enumerate(rules) if rule == expected_rule), None)
+    for expected_rule in lan_rules
+]
+ad_rule_indexes = [
+    next((index for index, rule in enumerate(rules) if rule == expected_rule), None)
+    for expected_rule in ad_rules
+]
+if (
+    any(index is None for index in [*lan_ad_indexes, *ad_rule_indexes])
+    or lan_ad_indexes != list(range(lan_ad_indexes[0], lan_ad_indexes[0] + len(lan_rules)))
+    or ad_rule_indexes != list(range(ad_rule_indexes[0], ad_rule_indexes[0] + len(ad_rules)))
+    or lan_ad_indexes[-1] + 1 != ad_rule_indexes[0]
+):
     raise AssertionError(
-        f"LAN/ad canonical order at indexes {lan_ad_start}..{lan_ad_end - 1} changed: "
-        f"{rules[lan_ad_start:lan_ad_end]}"
+        "LAN/ad canonical blocks must remain unique and contiguous: "
+        f"lan={lan_ad_indexes} ad={ad_rule_indexes}"
     )
-for expected_rule in [loop_fake_guard_rule, *expected_lan_ad_block]:
+for expected_rule in expected_lan_ad_block:
     matches = [index for index, rule in enumerate(rules) if rule == expected_rule]
     if len(matches) != 1:
         raise AssertionError(f"canonical guard/LAN/ad rule must have one owner: {expected_rule} indexes={matches}")
@@ -1398,9 +1422,9 @@ if first_matching_dns("unclassified.magicnet-probe", domestic_package_flow) is n
     raise AssertionError("unclassified application DNS must use dns.final instead of a package fallback")
 
 for domain, expected_index, expected_rule in (
-    ("doubleclick.net", 16, ad_suffix_dns_rule),
-    ("www.google-analytics.com", 17, ad_keyword_dns_rule),
-    ("outbrain.com", 18, ad_rule_set_dns_rule),
+    ("doubleclick.net", ad_suffix_dns_index, ad_suffix_dns_rule),
+    ("www.google-analytics.com", ad_keyword_dns_index, ad_keyword_dns_rule),
+    ("outbrain.com", ad_rule_set_dns_index, ad_rule_set_dns_rule),
 ):
     result = first_matching_dns(domain, domestic_package_flow)
     if result is None:
@@ -1460,16 +1484,17 @@ if rule.get("server") != "bootstrap-local-dns":
 mmstat_dns_indexes = [
     index for index, rule in enumerate(dns_rules) if rule == mmstat_local_dns_rule
 ]
-if mmstat_dns_indexes != [15]:
-    raise AssertionError(f"expected one exact mmstat local DNS rule at index 15: {mmstat_dns_indexes}")
+if len(mmstat_dns_indexes) != 1:
+    raise AssertionError(f"expected one exact mmstat local DNS rule: {mmstat_dns_indexes}")
 mmstat_dns_index = mmstat_dns_indexes[0]
 route_index, route_rule, matching_rule_sets = first_matching_outbound("mmstat.com", flows[0])
 route_outbound = route_rule.get("outbound")
 route_effective = recursively_effective_outbound(route_outbound)
-if route_index != 30 or route_outbound != "cn-direct" or route_effective != "direct":
+if route_outbound != "ad-block" or route_effective != "block" or "lyc-geosite-ads" not in matching_rule_sets:
     raise AssertionError(
-        "mmstat.com route must remain index 30 cn-direct/direct: "
-        f"index={route_index} outbound={route_outbound} effective={route_effective}"
+        "mmstat.com must use the generic ad rule-set route instead of a vendor direct exception: "
+        f"index={route_index} outbound={route_outbound} effective={route_effective} "
+        f"matching_rule_sets={sorted(matching_rule_sets)}"
     )
 mmstat_dns = first_matching_dns("mmstat.com", flows[0])
 if mmstat_dns is None:
@@ -1500,9 +1525,9 @@ explicit_route_domains = sorted({
     for key in ("domain", "domain_suffix")
     for domain in values(route_rule.get(key))
 })
-if len(explicit_route_domains) != 347:
+if not explicit_route_domains:
     raise AssertionError(
-        f"explicit route-domain audit coverage changed: count={len(explicit_route_domains)} expected=347"
+        "explicit route-domain audit coverage is empty; destination policy has no explicit domain probes"
     )
 
 def audit_explicit_route_dns_parity(domain):
@@ -1614,9 +1639,51 @@ if ordinary_unclassified_dns is not None:
         "ordinary unclassified DNS must use dns.final: "
         f"matched_index={index} server={rule.get('server')}"
     )
-if config["dns"].get("final") != "doh-google":
+if config["dns"].get("final") != "bootstrap-local-dns":
     raise AssertionError(
-        f"ordinary unclassified DNS final changed: {config['dns'].get('final')}"
+        "ordinary unclassified DNS must use local encrypted resolution so a previously "
+        "unknown domestic CDN can be classified by CN destination IP: "
+        f"actual={config['dns'].get('final')}"
+    )
+
+unclassified_domestic_flow = dict(
+    flows[0],
+    name="tcp-tls-unclassified-domestic-ip",
+    destination_ip="223.5.5.5",
+)
+route_index, route_rule, matching_rule_sets = first_matching_outbound(
+    "unclassified.magicnet-probe", unclassified_domestic_flow
+)
+if route_rule.get("outbound") != "cn-direct" or not (
+    {"lyc-geoip-cn", "metacubex-geoip-cn", "karing-acl4ssr-china-ip"}
+    & matching_rule_sets
+):
+    raise AssertionError(
+        "unclassified domain resolved to a CN IP must use destination-based cn-direct: "
+        f"index={route_index} outbound={route_rule.get('outbound')} "
+        f"matching_rule_sets={sorted(matching_rule_sets)}"
+    )
+
+unclassified_foreign_flow = dict(
+    flows[0],
+    name="tcp-tls-unclassified-foreign-ip",
+    destination_ip="8.8.8.8",
+)
+unclassified_foreign_matches = [
+    (index, rule)
+    for index, rule in enumerate(rules)
+    if "outbound" in rule
+    and route_rule_matches(rule, "unclassified.magicnet-probe", unclassified_foreign_flow)
+]
+if (
+    unclassified_foreign_matches
+    or config["route"].get("final") != "final"
+    or selector_for("final").get("default") != "proxy"
+):
+    raise AssertionError(
+        "unclassified domain resolved to a non-CN IP must retain final proxy routing: "
+        f"explicit_matches={unclassified_foreign_matches} "
+        f"route_final={config['route'].get('final')}"
     )
 
 for domain in foreign_network_test_dns_rule["domain_suffix"]:
@@ -1648,7 +1715,7 @@ network_test_route_indexes = [
 if (
     rule.get("outbound") != "dns-guard"
     or recursively_effective_outbound(rule["outbound"]) != "block"
-    or network_test_route_indexes != [28]
+    or len(network_test_route_indexes) != 1
     or not index < network_test_route_indexes[0]
 ):
     raise AssertionError(
@@ -1980,8 +2047,11 @@ if len(final_keyword_routes) != 1 or final_keyword_routes[0] != telegram_ip_rout
         "unchanged final foreign keyword route must immediately follow the Telegram IP route: "
         f"actual={final_keyword_routes}"
     )
-if final_keyword_routes != [len(rules) - 1]:
-    raise AssertionError("final foreign keyword route must be the last explicit route rule")
+if final_keyword_routes[0] != len(rules) - 1:
+    raise AssertionError(
+        "final foreign keyword route must remain the last explicit route before route.final: "
+        f"keyword={final_keyword_routes} rule_count={len(rules)}"
+    )
 PY
 
 selector_fixture_dir=$(mktemp -d)
@@ -2196,7 +2266,7 @@ network_connectivity_keyword_index=$(jq -er '
 
 assert_connectivity_dns_safety() {
     local config_file="$1"
-    local default_mode direct_mode_index global_mode_index wechat_rule_index domestic_rule_index foreign_rule_index
+    local default_mode direct_mode_index global_mode_index domestic_rule_index foreign_rule_index
     local apple_rule_index cn_bing_rule_index global_bing_rule_index local_service_index
     local private_dns_index mmstat_dns_index ad_suffix_dns_index ad_keyword_dns_index ad_rule_set_dns_index
     local game_dns_index foreign_priority_dns_index cn_dns_index
@@ -2215,7 +2285,7 @@ assert_connectivity_dns_safety() {
         printf 'DNS safety guard: default Clash mode must remain Rule\n' >&2
         return 1
     }
-    read -r direct_mode_index global_mode_index wechat_rule_index domestic_rule_index foreign_rule_index \
+    read -r direct_mode_index global_mode_index domestic_rule_index foreign_rule_index \
         apple_rule_index cn_bing_rule_index global_bing_rule_index local_service_index \
         private_dns_index mmstat_dns_index ad_suffix_dns_index ad_keyword_dns_index ad_rule_set_dns_index \
         game_dns_index foreign_priority_dns_index cn_dns_index < <(jq -er '
@@ -2225,7 +2295,6 @@ assert_connectivity_dns_safety() {
       [
         unique_index({clash_mode: "Direct", server: "bootstrap-local-dns"}),
         unique_index({clash_mode: "Global", server: "doh-cloudflare"}),
-        unique_index({package_name: ["com.tencent.mm"], server: "bootstrap-local-dns"}),
         unique_index({
           domain_suffix: ["connect.rom.miui.com", "connectivitycheck.platform.hicloud.com"],
           server: "bootstrap-local-dns"
@@ -2334,8 +2403,7 @@ assert_connectivity_dns_safety() {
         return 1
     }
     ((global_mode_index == direct_mode_index + 1 \
-        && wechat_rule_index == global_mode_index + 1 \
-        && domestic_rule_index == wechat_rule_index + 1 \
+        && domestic_rule_index == global_mode_index + 1 \
         && foreign_rule_index == domestic_rule_index + 1 \
         && apple_rule_index == foreign_rule_index + 1 \
         && cn_bing_rule_index == apple_rule_index + 1 \
@@ -2653,20 +2721,32 @@ done
 make_dns_safety_fixture() {
     local inserted_rules="$1"
     local output_file="$2"
-    jq --argjson inserted_rules "$inserted_rules" '
+    jq --argjson inserted_rules "$inserted_rules" --arg config_dir "$CONFIG_DIR" '
       ($inserted_rules | if type == "array" then . else [.] end) as $rules
       | .dns.rules = ($rules + .dns.rules)
+      | .route.rule_set |= map(
+          if .type == "local"
+            and (.path | type) == "string"
+            and (.path | startswith("/") | not)
+          then .path = ($config_dir + "/" + .path)
+          else .
+          end
+        )
     ' "$CONFIG_FILE" >"$output_file"
 }
 
-dns_unconditional_fixture=$(mktemp "$CONFIG_DIR/.dns-unconditional.XXXXXX.json")
-dns_local_unconditional_fixture=$(mktemp "$CONFIG_DIR/.dns-local-unconditional.XXXXXX.json")
-dns_invert_fixture=$(mktemp "$CONFIG_DIR/.dns-invert.XXXXXX.json")
-dns_current_mode_fixture=$(mktemp "$CONFIG_DIR/.dns-current-mode.XXXXXX.json")
-dns_other_mode_fixture=$(mktemp "$CONFIG_DIR/.dns-other-mode.XXXXXX.json")
-dns_first_match_fixture=$(mktemp "$CONFIG_DIR/.dns-first-match.XXXXXX.json")
-dns_remote_rule_set_fixture=$(mktemp "$CONFIG_DIR/.dns-remote-rule-set.XXXXXX.json")
-trap 'rm -f "$dns_unconditional_fixture" "$dns_local_unconditional_fixture" "$dns_invert_fixture" "$dns_current_mode_fixture" "$dns_other_mode_fixture" "$dns_first_match_fixture" "$dns_remote_rule_set_fixture"' EXIT
+dns_fixture_dir=$(mktemp -d "${TMPDIR:-/tmp}/magicnet-dns-policy.XXXXXX")
+dns_unconditional_fixture="$dns_fixture_dir/unconditional.json"
+dns_local_unconditional_fixture="$dns_fixture_dir/local-unconditional.json"
+dns_invert_fixture="$dns_fixture_dir/invert.json"
+dns_current_mode_fixture="$dns_fixture_dir/current-mode.json"
+dns_other_mode_fixture="$dns_fixture_dir/other-mode.json"
+dns_first_match_fixture="$dns_fixture_dir/first-match.json"
+dns_remote_rule_set_fixture="$dns_fixture_dir/remote-rule-set.json"
+touch "$dns_unconditional_fixture" "$dns_local_unconditional_fixture" "$dns_invert_fixture" \
+    "$dns_current_mode_fixture" "$dns_other_mode_fixture" "$dns_first_match_fixture" \
+    "$dns_remote_rule_set_fixture"
+trap 'rm -rf "$dns_fixture_dir"' EXIT
 
 make_dns_safety_fixture '{"server":"doh-google"}' "$dns_unconditional_fixture"
 make_dns_safety_fixture '{"server":"bootstrap-local-dns"}' "$dns_local_unconditional_fixture"
@@ -2760,6 +2840,8 @@ assert_connectivity_dns_safety "$dns_first_match_fixture" ||
 rm -f "$dns_unconditional_fixture" "$dns_local_unconditional_fixture" "$dns_invert_fixture" \
     "$dns_current_mode_fixture" "$dns_other_mode_fixture" "$dns_first_match_fixture" \
     "$dns_remote_rule_set_fixture"
+rmdir "$dns_fixture_dir" 2>/dev/null || true
+dns_fixture_dir=
 dns_unconditional_fixture=
 dns_local_unconditional_fixture=
 dns_invert_fixture=

--- a/scripts/test-wechat-routing.sh
+++ b/scripts/test-wechat-routing.sh
@@ -15,7 +15,6 @@ command -v python3 >/dev/null 2>&1 || {
 }
 
 python3 - "$CONFIG_FILE" <<'PY'
-import ipaddress
 import json
 import sys
 
@@ -23,54 +22,28 @@ with open(sys.argv[1], encoding="utf-8") as handle:
     config = json.load(handle)
 
 route_rules = config["route"]["rules"]
-dns_rules = config["dns"]["rules"]
-wechat_domains = [
-    "qq.com", "weixin.qq.com", "wechat.com", "wechatapp.com", "wechatpay.cn",
-    "tenpay.com", "tencent.com", "tencent-cloud.com", "myqcloud.com", "qcloud.com",
-    "gtimg.com", "idqqimg.com", "qpic.cn", "qlogo.cn", "qmail.com", "smtcdns.com",
-    "servicewechat.com", "weixinbridge.com", "weixinsxy.com", "wx.gtimg.com", "wx.qq.com",
-]
-wechat_route = {"domain_suffix": wechat_domains, "outbound": "cn-direct"}
-wechat_dns = {"package_name": ["com.tencent.mm"], "server": "bootstrap-local-dns"}
-fakeip_guard = {
-    "ip_cidr": ["127.0.0.1/32", "::1/128", "198.18.0.0/16", "28.0.0.0/8"],
-    "outbound": "block",
-}
 
 
 def exact_indexes(rules, expected):
     return [index for index, rule in enumerate(rules) if rule == expected]
 
 
-wechat_route_indexes = exact_indexes(route_rules, wechat_route)
-guard_indexes = exact_indexes(route_rules, fakeip_guard)
-wechat_dns_indexes = exact_indexes(dns_rules, wechat_dns)
-if len(wechat_route_indexes) != 1:
-    raise AssertionError(f"expected one exact WeChat route, got {wechat_route_indexes}")
-if len(guard_indexes) != 1:
-    raise AssertionError(f"expected one exact FakeIP guard, got {guard_indexes}")
-if len(wechat_dns_indexes) != 1:
-    raise AssertionError(f"expected one exact WeChat DNS rule, got {wechat_dns_indexes}")
-if wechat_route_indexes[0] >= guard_indexes[0]:
-    raise AssertionError("WeChat media route must precede the FakeIP guard")
-
-for domain in wechat_domains:
-    owners = [
-        index
-        for index, rule in enumerate(route_rules)
-        if rule.get("outbound") == "cn-direct"
-        and domain in (rule.get("domain_suffix") or [])
-    ]
-    if owners != wechat_route_indexes:
-        raise AssertionError(f"{domain} has non-canonical cn-direct owners: {owners}")
-
-global_dns_indexes = [
-    index
-    for index, rule in enumerate(dns_rules)
-    if rule.get("clash_mode") == "Global"
+cn_routes = [
+    index for index, rule in enumerate(route_rules)
+    if rule.get("outbound") == "cn-direct" and rule.get("rule_set")
 ]
-if global_dns_indexes and wechat_dns_indexes[0] <= global_dns_indexes[-1]:
-    raise AssertionError("Global DNS mode must retain priority over the WeChat local resolver")
+if not cn_routes:
+    raise AssertionError("domestic traffic must use generic CN rule-set routing")
+if any(server.get("type") == "fakeip" or server.get("tag") == "fakeip" for server in config["dns"]["servers"]):
+    raise AssertionError("generic domestic routing must use real DNS answers, not FakeIP")
+if config.get("experimental", {}).get("cache_file", {}).get("store_fakeip") is True:
+    raise AssertionError("generic domestic routing must not persist stale FakeIP mappings")
+if any(
+    rule.get("outbound") == "block"
+    and ({"198.18.0.0/16", "28.0.0.0/8"} & set(rule.get("ip_cidr", [])))
+    for rule in route_rules
+):
+    raise AssertionError("generic routing must not blackhole benchmark or public address space")
 
 
 def domain_matches(rule, domain):
@@ -80,49 +53,15 @@ def domain_matches(rule, domain):
     )
 
 
-def ip_matches(rule, destination_ip):
-    cidrs = rule.get("ip_cidr")
-    if not cidrs:
-        return True
-    address = ipaddress.ip_address(destination_ip)
-    return any(address in ipaddress.ip_network(cidr) for cidr in cidrs)
-
-
-def package_matches(rule, package_name):
-    packages = rule.get("package_name")
-    return packages is None or package_name in packages
-
-
-def first_media_outbound(domain, destination_ip, package_name):
-    for index, rule in enumerate(route_rules):
-        if "outbound" not in rule:
-            continue
-        if rule.get("clash_mode") is not None:
-            continue
-        if rule.get("protocol") not in (None, "tls"):
-            continue
-        if rule.get("network") not in (None, "tcp"):
-            continue
-        ports = rule.get("port")
-        if ports is not None and 443 not in (ports if isinstance(ports, list) else [ports]):
-            continue
-        if not package_matches(rule, package_name):
-            continue
-        if rule.get("domain_suffix") and not domain_matches(rule, domain):
-            continue
-        if not ip_matches(rule, destination_ip):
-            continue
-        if any(key in rule for key in ("domain", "domain_keyword", "rule_set", "ip_is_private")):
-            continue
-        return index, rule["outbound"]
-    raise AssertionError("WeChat media flow did not match any modeled route")
-
-
-index, outbound = first_media_outbound("upload.qpic.cn", "198.18.1.1", "com.tencent.mm")
-if (index, outbound) != (wechat_route_indexes[0], "cn-direct"):
-    raise AssertionError(
-        f"cached-FakeIP WeChat media flow matched index={index} outbound={outbound}"
+if any(
+    any(
+        token in suffix
+        for suffix in rule.get("domain_suffix", [])
+        for token in ("qq", "wechat", "weixin", "qpic", "qlogo", "tencent")
     )
+    for rule in route_rules
+):
+    raise AssertionError("routing policy must not contain QQ/WeChat/Tencent-specific exceptions")
 
-print("WeChat routing policy test passed")
+print("Generic domestic routing policy test passed")
 PY

--- a/src/MagicNet/README.md
+++ b/src/MagicNet/README.md
@@ -152,7 +152,7 @@ adb shell 'su -M -c "timeout 10 tcpdump -ni rmnet_data0 \"port 53 or port 853\""
 
 目标状态是访问测试期间没有明文 DNS/DoT 流量从物理出口泄露。MagicNet 会在物理出口接口上拦截直连 53/853，避免绕过 TUN 的 DNS 直接出网；如需临时关闭，可设置 `MAGIC_DNS_LEAK_GUARD=0` 后重新应用配置。
 
-DNS 模板保留 `bootstrap-local-dns` 作为启动和直连例外：它解析代理节点域名、局域网、国内直连域名和连通性检测，避免代理尚未建立时让 DNS detour 到代理造成自引用循环，也避免国内网站拿到错误 CDN。代理域名、AI、GFW 和海外媒体仍按规则走海外 DoH 和代理 detour；如果把 `default_domain_resolver` 指向走代理的 DNS，可能出现 `DNS query loopback in transport[...]` 并导致大量站点超时。
+DNS 模板使用 `bootstrap-local-dns` 解析代理节点域名、局域网、国内直连域名和未分类域名，避免代理尚未建立时让 DNS detour 到代理造成自引用循环，也让规则集暂未收录的国内 CDN 先获得本地地址，再由 `geoip-cn` 决定是否直连。已明确识别的代理域名、AI、GFW、海外媒体和泄露检测仍按规则走海外 DoH 和代理 detour；未分类域名若解析为非中国 IP，路由最终策略仍是代理。这样不依赖 App 包名名单，同时保持 DNS 与目标路由一致。
 
 DNS 泄露检测站点会生成一次性探测域名，并根据收到查询的递归解析器判断是否泄露。为了避免这类探测域名被 `bootstrap-local-dns` 或运营商 DNS 解析，模板在所有国内/本地 DNS 规则之前放置高优先级规则，将 BrowserScan、BrowserLeaks、IPLeak、DNSLeakTest、Perfect Privacy、Surfshark、Whoer、DoILeak、Bash.ws、DNS.SB、NextDNS test 等泄露检测域名强制交给 `doh-cloudflare`。`doh-cloudflare` 本身配置了 `detour: proxy`，所以这些探测查询会从代理出口的远端 DoH 发出，而不是从手机本地运营商 DNS 发出。
 

--- a/src/MagicNet/customize.sh
+++ b/src/MagicNet/customize.sh
@@ -238,6 +238,66 @@ if [ -d "$MAGICNET_BACKUP_DIR" ]; then
   unset _item
 fi
 
+# Older releases shipped a domestic-app bypass catalog.  Keep only packages that
+# are still Android VPN services during the one-time migration; ordinary app
+# opt-outs can be added again explicitly after the migration completes.
+magicnet_migrate_legacy_app_bypass() {
+  _bypass_dir="${MODPATH}/.config/magicnet"
+  _bypass_file="${_bypass_dir}/app-bypass.list"
+  _migration_marker="${_bypass_dir}/app-policy-migration-vpn-only"
+  [ -f "$_migration_marker" ] || [ -f "$_bypass_file" ] || return 0
+  [ -f "$_migration_marker" ] && return 0
+  command -v cmd >/dev/null 2>&1 || return 0
+
+  _migration_state_dir="${MODPATH}/.state/app-policy"
+  _vpn_packages="${_migration_state_dir}/vpn-packages.$$"
+  _filtered_bypass="${_bypass_file}.migration.$$"
+  mkdir -p "$_migration_state_dir" || return 1
+  cmd package query-services --brief -a android.net.VpnService 2>/dev/null |
+    sed -n 's/^[[:space:]]*\([A-Za-z_][A-Za-z0-9_.]*\)\/.*/\1/p' |
+    awk 'NF && !seen[$0]++' >"$_vpn_packages"
+  if [ ! -s "$_vpn_packages" ]; then
+    rm -f "$_vpn_packages" 2>/dev/null || true
+    unset _bypass_dir _bypass_file _migration_marker _migration_state_dir _vpn_packages _filtered_bypass
+    return 0
+  fi
+
+  if [ -f "$_bypass_file" ]; then
+    awk -v vpn_file="$_vpn_packages" '
+      BEGIN {
+        while ((getline package < vpn_file) > 0) {
+          vpn[package] = 1
+        }
+        close(vpn_file)
+      }
+      {
+        line = $0
+        trimmed = line
+        sub(/^[[:space:]]+/, "", trimmed)
+        sub(/[[:space:]]+$/, "", trimmed)
+        if (trimmed == "" || substr(trimmed, 1, 1) == "#" || vpn[trimmed]) {
+          print line
+        }
+      }
+    ' "$_bypass_file" >"$_filtered_bypass" || {
+      rm -f "$_filtered_bypass" "$_vpn_packages" 2>/dev/null || true
+      unset _bypass_dir _bypass_file _migration_marker _migration_state_dir _vpn_packages _filtered_bypass
+      return 1
+    }
+    if ! mv -f "$_filtered_bypass" "$_bypass_file"; then
+      rm -f "$_filtered_bypass" "$_vpn_packages" 2>/dev/null || true
+      unset _bypass_dir _bypass_file _migration_marker _migration_state_dir _vpn_packages _filtered_bypass
+      return 1
+    fi
+  fi
+
+  printf '%s\n' 'vpn-only bypass migration completed' >"$_migration_marker"
+  rm -f "$_vpn_packages" 2>/dev/null || true
+  unset _bypass_dir _bypass_file _migration_marker _migration_state_dir _vpn_packages _filtered_bypass
+}
+
+magicnet_migrate_legacy_app_bypass || abort "! failed to migrate legacy app bypass policy"
+
 magicnet_prune_legacy_capture_residue() {
   rm -rf \
     "${MODPATH}/.config/magicnet/capture.conf" \

--- a/src/MagicNet/customize.sh
+++ b/src/MagicNet/customize.sh
@@ -282,12 +282,13 @@ magicnet_migrate_legacy_app_bypass() {
       unset _bypass_line _bypass_package
       return 1
     fi
-    if ! mv -f "$_filtered_bypass" "$_bypass_file"; then
+    if ! cp -f "$_filtered_bypass" "$_bypass_file"; then
       rm -f "$_filtered_bypass" "$_vpn_packages" 2>/dev/null || true
       unset _bypass_dir _bypass_file _migration_marker _migration_state_dir _vpn_packages _filtered_bypass
       unset _bypass_line _bypass_package
       return 1
     fi
+    rm -f "$_filtered_bypass" 2>/dev/null || true
   fi
 
   printf '%s\n' 'vpn-only bypass migration completed' >"$_migration_marker"

--- a/src/MagicNet/customize.sh
+++ b/src/MagicNet/customize.sh
@@ -254,8 +254,7 @@ magicnet_migrate_legacy_app_bypass() {
   _filtered_bypass="${_bypass_file}.migration.$$"
   mkdir -p "$_migration_state_dir" || return 1
   cmd package query-services --brief -a android.net.VpnService 2>/dev/null |
-    sed -n 's/^[[:space:]]*\([A-Za-z_][A-Za-z0-9_.]*\)\/.*/\1/p' |
-    awk 'NF && !seen[$0]++' >"$_vpn_packages"
+    sed -n 's/^[[:space:]]*\([A-Za-z_][A-Za-z0-9_.]*\)\/.*/\1/p' >"$_vpn_packages"
   if [ ! -s "$_vpn_packages" ]; then
     rm -f "$_vpn_packages" 2>/dev/null || true
     unset _bypass_dir _bypass_file _migration_marker _migration_state_dir _vpn_packages _filtered_bypass
@@ -263,30 +262,30 @@ magicnet_migrate_legacy_app_bypass() {
   fi
 
   if [ -f "$_bypass_file" ]; then
-    awk -v vpn_file="$_vpn_packages" '
-      BEGIN {
-        while ((getline package < vpn_file) > 0) {
-          vpn[package] = 1
+    : >"$_filtered_bypass" || return 1
+    while IFS= read -r _bypass_line || [ -n "$_bypass_line" ]; do
+      _bypass_package=$(printf '%s\n' "$_bypass_line" |
+        sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+      if [ -z "$_bypass_package" ] || [ "${_bypass_package#\#}" != "$_bypass_package" ] ||
+        grep -Fqx "$_bypass_package" "$_vpn_packages"; then
+        printf '%s\n' "$_bypass_line" >>"$_filtered_bypass" || {
+          rm -f "$_filtered_bypass" "$_vpn_packages" 2>/dev/null || true
+          unset _bypass_dir _bypass_file _migration_marker _migration_state_dir _vpn_packages _filtered_bypass
+          unset _bypass_line _bypass_package
+          return 1
         }
-        close(vpn_file)
-      }
-      {
-        line = $0
-        trimmed = line
-        sub(/^[[:space:]]+/, "", trimmed)
-        sub(/[[:space:]]+$/, "", trimmed)
-        if (trimmed == "" || substr(trimmed, 1, 1) == "#" || vpn[trimmed]) {
-          print line
-        }
-      }
-    ' "$_bypass_file" >"$_filtered_bypass" || {
+      fi
+    done <"$_bypass_file"
+    if [ ! -f "$_filtered_bypass" ]; then
       rm -f "$_filtered_bypass" "$_vpn_packages" 2>/dev/null || true
       unset _bypass_dir _bypass_file _migration_marker _migration_state_dir _vpn_packages _filtered_bypass
+      unset _bypass_line _bypass_package
       return 1
-    }
+    fi
     if ! mv -f "$_filtered_bypass" "$_bypass_file"; then
       rm -f "$_filtered_bypass" "$_vpn_packages" 2>/dev/null || true
       unset _bypass_dir _bypass_file _migration_marker _migration_state_dir _vpn_packages _filtered_bypass
+      unset _bypass_line _bypass_package
       return 1
     fi
   fi
@@ -294,6 +293,7 @@ magicnet_migrate_legacy_app_bypass() {
   printf '%s\n' 'vpn-only bypass migration completed' >"$_migration_marker"
   rm -f "$_vpn_packages" 2>/dev/null || true
   unset _bypass_dir _bypass_file _migration_marker _migration_state_dir _vpn_packages _filtered_bypass
+  unset _bypass_line _bypass_package
 }
 
 magicnet_migrate_legacy_app_bypass || abort "! failed to migrate legacy app bypass policy"

--- a/src/MagicNet/lib/magicnet/apps.sh
+++ b/src/MagicNet/lib/magicnet/apps.sh
@@ -122,6 +122,51 @@ magicnet_app_uid_state_commit() {
     unset _uid_state_dir _uid_include_source _uid_exclude_source _uid_include_tmp _uid_exclude_tmp
 }
 
+# DNS application selectors are legacy policy residue. Application routing
+# may still be used for explicit business features below, but DNS resolution
+# must remain destination/policy based so stale app catalogs cannot force a
+# different resolver after an upgrade.
+magicnet_singbox_dns_has_package_rules() {
+    _dns_package_config="$1"
+    [ -f "$_dns_package_config" ] || {
+        unset _dns_package_config
+        return 1
+    }
+    awk '
+        function count_delta(line,    i, c, delta, in_string, escaped) {
+            delta = 0
+            in_string = 0
+            escaped = 0
+            for (i = 1; i <= length(line); i++) {
+                c = substr(line, i, 1)
+                if (in_string) {
+                    if (escaped) escaped = 0
+                    else if (c == "\\") escaped = 1
+                    else if (c == "\"") in_string = 0
+                    continue
+                }
+                if (c == "\"") in_string = 1
+                else if (c == "{") delta++
+                else if (c == "}") delta--
+            }
+            return delta
+        }
+        {
+            if (!in_dns && $0 ~ /^  "dns"[[:space:]]*:[[:space:]]*\{/) {
+                in_dns = 1
+                dns_depth = depth + count_delta($0)
+            }
+            if (in_dns && index($0, "\"package_name\"") > 0) found = 1
+            depth += count_delta($0)
+            if (in_dns && depth < dns_depth) in_dns = 0
+        }
+        END { exit found ? 0 : 1 }
+    ' "$_dns_package_config"
+    _dns_package_rc=$?
+    unset _dns_package_config
+    return "$_dns_package_rc"
+}
+
 # Ownership marker for MagicNet-managed force-proxy rules (not a user package).
 # Idempotent rewrites strip rules containing this marker, then re-inject one
 # authoritative rule from app-proxy.list — single source of truth for that list.
@@ -304,6 +349,10 @@ magicnet_singbox_apply_app_policy() {
                       + $business_rules
                   end
               )
+            | .dns = (
+                (.dns // {})
+                | .rules = ((.rules // []) | map(select(has("package_name") | not)))
+              )
         ' "$_config" >"$_tmp" && mv -f "$_tmp" "$_config" &&
             magicnet_app_uid_state_commit "$_uid_state_dir" "$_include_uids_tmp" "$_exclude_uids_tmp"; then
             rm -f "$_include_packages_tmp" "$_include_uids_tmp" "$_exclude_uids_tmp" 2>/dev/null || true
@@ -315,6 +364,22 @@ magicnet_singbox_apply_app_policy() {
         fi
         rm -f "$_tmp" 2>/dev/null || true
         unset _jq
+    fi
+
+    # The awk fallback can preserve and reorder route rules, but it is not a
+    # safe JSON editor for arbitrary DNS rule objects. Fail closed when a
+    # legacy DNS package selector is present so it can never continue running
+    # merely because jq is unavailable.
+    if [ -z "$_jq" ] && magicnet_singbox_dns_has_package_rules "$_config"; then
+        magicnet_warn "legacy DNS application rules require jq cleanup; refusing to start with them"
+        rm -f "$_include_packages_tmp" "$_include_uids_tmp" "$_exclude_uids_tmp" \
+            "$_include_tmp" "$_exclude_tmp" "$_proxy_rule_tmp" "$_direct_rule_tmp" \
+            "$_tmp" 2>/dev/null || true
+        unset _config _dir _mode _proxy_file _direct_file _bypass_file _include_block _exclude_block
+        unset _include_packages_tmp _include_uids_tmp _exclude_uids_tmp _uid_state_dir
+        unset _old_include_uids _old_exclude_uids _tmp _include_tmp _exclude_tmp
+        unset _proxy_rule_tmp _direct_rule_tmp _jq
+        return 1
     fi
 
     if [ -n "$_include_block" ]; then

--- a/src/MagicNet/module.prop
+++ b/src/MagicNet/module.prop
@@ -1,7 +1,7 @@
 id=MagicNet
 name=MagicNet
-version=v1.2.8
-versionCode=1785733015544
+version=v1.2.9
+versionCode=1785861900000
 author=LIghtJUNction
 description=[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM.
 updateJson=https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
   "changelog": "https://github.com/LIghtJUNction/MagicNet/blob/main/CHANGELOG.md",
-  "version": "v1.2.8",
-  "versionCode": 1785733015544,
+  "version": "v1.2.9",
+  "versionCode": 1785861900000,
   "zipUrl": "https://github.com/LIghtJUNction/MagicNet/releases/latest/download/MagicNet.zip"
 }


### PR DESCRIPTION
## Summary
- replace application and vendor catalogs with destination-based CN routing
- disable unused FakeIP state and use encrypted local DNS for unclassified targets
- migrate legacy bypass entries to actual Android VPN services only
- bump the module patch version to v1.2.9

## Verification
- repository pre-commit hook passed
- package and package-install smoke tests passed
- real-device TUN/DNS health passed
- QQ/TIM, WeChat, Alipay, Douyin, Bilibili, Taobao, Meituan, and Amap produced traffic without block or FakeIP routes
- physical wlan0 DNS/DoT capture reported zero port 53/853 packets

## Summary by Sourcery

将 DNS 和路由策略从基于应用/包的选择器和 FakeIP，切换为基于目标地址的中国境内路由（CN routing）并使用加密本地 DNS，同时迁移旧版应用绕过数据，并在新行为周围收紧测试和诊断。

New Features:
- 支持针对此前未分类的、通过本地加密 DNS 解析的国内域名，基于目标 IP 的中国境内直连路由。
- 增加一次性迁移旧版应用绕过目录，只保留 Android VPN 服务相关的包。

Bug Fixes:
- 移除旧版 DNS 应用包选择器及特定厂商绕过规则，避免更新后导致国内应用连接中断。
- 禁用未使用的 FakeIP 服务器、应答以及缓存持久化，防止黑洞化基准/公网地址空间以及产生过期映射。

Enhancements:
- 放宽路由/DNS 策略测试，从断言固定索引改为断言唯一性和相对排序，以提升面对未来规则变更时的鲁棒性。
- 强化 CLI 诊断和 shell 测试中的 DNS 泄漏与路由安全检查，确保使用真实地址 DNS，并保持中国境内/境外路由行为一致。
- 更新应用策略的应用逻辑，以安全处理缺少 `jq` 的配置，并在存在旧版 DNS 包规则时以“失败即关闭”的方式处理。
- 清理构建产物，从模块压缩包中移除已退役的 eBPF 运行时二进制文件和内部 DNS 路由样例数据。
- 在中文 README 中进一步阐明 `bootstrap-local-dns` 在地理 IP 路由下对国内及未分类域名的使用方式。

Build:
- 将模块版本从 `v1.2.8` 提升到 `v1.2.9`，并更新相关的 `versionCode` 和元数据。

Deployment:
- 确保打包配置强制使用本地加密 DNS 作为 `dns.final`，并禁止 FakeIP 服务器、FakeIP 持久化以及 DNS 包选择器，以保证发布的策略与运行时预期保持一致。

Tests:
- 扩展路由、DNS 安全、应用策略、动作路由、包冒烟测试以及安装冒烟测试，以验证新的基于目标地址的中国境内路由、FakeIP 禁用以及迁移行为。
- 新增诊断测试，确保在无 FakeIP 且使用本地加密 DNS 的配置下，被判定为健康状态。

Chores:
- 从测试和策略检查中移除对已废弃的 eBPF 运行时以及过时 FakeIP 防护路由的引用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch DNS and routing policy from app/package-based selectors and FakeIP to destination-based CN routing with encrypted local DNS, while migrating legacy app bypass data and tightening tests and diagnostics around the new behavior.

New Features:
- Support destination IP-based CN direct routing for previously unclassified domestic domains resolved via local encrypted DNS.
- Add one-time migration of legacy app bypass catalogs to retain only Android VPN service packages.

Bug Fixes:
- Eliminate legacy DNS application package selectors and vendor-specific bypasses that could break domestic app connectivity after updates.
- Disable unused FakeIP servers, answers, and cache persistence to avoid blackholing benchmark/public address space and stale mappings.

Enhancements:
- Relax routing/DNS policy tests to assert uniqueness and relative ordering rather than hard-coded indices, improving robustness to future rule changes.
- Strengthen DNS leak and routing safety checks in CLI diagnostics and shell tests to ensure real-address DNS and consistent CN/foreign routing behavior.
- Update app policy application to safely handle configs without jq and fail closed when legacy DNS package rules are present.
- Clean up artifacts by removing the retired eBPF runtime binary and internal DNS routing fixtures from module zips.
- Clarify Chinese README documentation around bootstrap-local-dns usage for domestic and unclassified domains with geoip-based routing.

Build:
- Bump module version from v1.2.8 to v1.2.9 and update associated versionCode and metadata.

Deployment:
- Ensure packaged configs enforce local encrypted DNS as dns.final and prohibit FakeIP servers, FakeIP persistence, and DNS package selectors to keep shipped policy aligned with runtime expectations.

Tests:
- Extend routing, DNS safety, app policy, action routing, package smoke, and install smoke tests to validate the new destination-based CN routing, FakeIP disablement, and migration behavior.
- Add new diagnostics tests ensuring configs without FakeIP and with local encrypted DNS are considered healthy.

Chores:
- Remove references to the deprecated eBPF runtime and obsolete FakeIP guard routing from tests and policy checks.

</details>