### PR TITLE
fix(magicnet): disable DNS interception after deferred config failure

### DIFF
--- a/scripts/fake-magisk-smoke.sh
+++ b/scripts/fake-magisk-smoke.sh
@@ -963,6 +963,24 @@ assert_dns_interception_not_enabled "$MOCK_LOG" "toggle stop"
 sleep 3600 &
 echo "$!" >"$MODDIR/.state/fake-sing-box.pid"
 : >"$MOCK_LOG"
+# A deferred config rewrite can fail after sing-box is already running. DNS
+# interception must stay disabled until every managed rewrite succeeds.
+# shellcheck disable=SC2016
+if run env MAGIC_DNS_GUARD_IFACES=lo sh -c '
+    . "$MODDIR/lib/kamfw/.kamfwrc"
+    import __runtime__
+    . "$MODDIR/lib/magicnet.sh"
+    magicnet_dns_apply_unlocked() {
+        return 1
+    }
+    magicnet_after_kernel_start_deferred_unlocked
+'; then
+    echo "deferred config failure was reported as success" >&2
+    exit 1
+fi
+assert_dns_interception_not_enabled "$MOCK_LOG" "deferred config failure"
+
+: >"$MOCK_LOG"
 run env MAGIC_DNS_GUARD_IFACES=lo "$MODDIR/cli" service stop
 assert_dns_cleanup_log "$MOCK_LOG"
 : >"$MOCK_LOG"

--- a/scripts/test-app-routing-policy.sh
+++ b/scripts/test-app-routing-policy.sh
@@ -386,12 +386,13 @@ assert_deferred_failure_disables_dns_controls() (
   magicnet_dns_apply_unlocked() { printf '%s\n' dns-apply >>"$events"; return 1; }
   magicnet_transparent_apply_unlocked() { printf '%s\n' transparent >>"$events"; }
   magicnet_app_policy_apply_unlocked() { printf '%s\n' app-policy >>"$events"; }
-  magicnet_warp_apply_unlocked() { printf '%s\n' warp >>"$events"; }
+  magicnet_warp_apply_unlocked() { printf '%s\n' warp >>"$events"; return 1; }
   magicnet_singbox_apply_hotspot_policy() { printf '%s\n' hotspot >>"$events"; }
   magicnet_enable_dns_capture() { printf '%s\n' capture-enable >>"$events"; }
   magicnet_enable_dns_leak_guard() { printf '%s\n' guard-enable >>"$events"; }
   magicnet_disable_dns_capture() { printf '%s\n' capture-disable >>"$events"; }
   magicnet_disable_dns_leak_guard() { printf '%s\n' guard-disable >>"$events"; }
+  magicnet_warn() { printf 'warning:%s\n' "$*" >>"$events"; }
 
   if magicnet_after_kernel_start_deferred_unlocked; then
     printf '%s\n' 'deferred config failure must return non-zero' >&2
@@ -399,6 +400,7 @@ assert_deferred_failure_disables_dns_controls() (
   fi
   grep -qx capture-disable "$events"
   grep -qx guard-disable "$events"
+  grep -qx 'warning:Deferred network configuration failed: dns,warp; DNS interception disabled' "$events"
   if grep -Eq '^(capture|guard)-enable$' "$events"; then
     printf '%s\n' 'deferred config failure enabled DNS controls' >&2
     cat "$events" >&2

--- a/src/MagicNet/lib/magicnet/network.sh
+++ b/src/MagicNet/lib/magicnet/network.sh
@@ -194,34 +194,37 @@ magicnet_after_kernel_start() {
     unset _after_kernel_runner
 }
 
-magicnet_after_kernel_start_deferred_unlocked() {
-    _deferred_rc=0
-    magicnet_dns_apply_unlocked || _deferred_rc=1
-    magicnet_transparent_apply_unlocked || _deferred_rc=1
-    magicnet_app_policy_apply_unlocked || _deferred_rc=1
-    magicnet_warp_apply_unlocked || _deferred_rc=1
+magicnet_after_kernel_start_deferred_unlocked() (
+    _deferred_failures=
+    _deferred_mark_failed() {
+        _deferred_failures="${_deferred_failures}${_deferred_failures:+,}$1"
+    }
+
+    magicnet_dns_apply_unlocked || _deferred_mark_failed dns
+    magicnet_transparent_apply_unlocked || _deferred_mark_failed transparent
+    magicnet_app_policy_apply_unlocked || _deferred_mark_failed app-policy
+    magicnet_warp_apply_unlocked || _deferred_mark_failed warp
     # Keep the hotspot route authoritative after every deferred config rewrite.
     # These rewrites run asynchronously after the core starts and may otherwise
     # publish a snapshot that predates the startup-time hotspot normalization.
-    magicnet_singbox_apply_hotspot_policy || _deferred_rc=1
-    if [ "$_deferred_rc" -ne 0 ]; then
+    magicnet_singbox_apply_hotspot_policy || _deferred_mark_failed hotspot
+
+    if [ -z "$_deferred_failures" ]; then
+        magicnet_enable_dns_capture || _deferred_mark_failed dns-capture
+        magicnet_enable_dns_leak_guard || _deferred_mark_failed dns-leak-guard
+    fi
+
+    if [ -n "$_deferred_failures" ]; then
         # A partially applied configuration must not leave stale interception
         # or leak-guard rules pointing at a failed DNS/core setup.
         magicnet_disable_dns_capture || true
         magicnet_disable_dns_leak_guard || true
-        unset _deferred_rc
+        magicnet_warn "Deferred network configuration failed: ${_deferred_failures}; DNS interception disabled"
         return 1
     fi
-    magicnet_enable_dns_capture || _deferred_rc=1
-    magicnet_enable_dns_leak_guard || _deferred_rc=1
-    _deferred_result="$_deferred_rc"
-    if [ "$_deferred_rc" -ne 0 ]; then
-        magicnet_disable_dns_capture || true
-        magicnet_disable_dns_leak_guard || true
-    fi
-    unset _deferred_rc
-    return "$_deferred_result"
-}
+
+    return 0
+)
 
 magicnet_after_kernel_start_deferred() {
     magicnet_with_config_lock magicnet_after_kernel_start_deferred_unlocked


### PR DESCRIPTION
## Summary

Closes #97.

Deferred network setup now records every failed component and keeps DNS interception disabled unless all managed rewrites and DNS-control installs succeed.

## Changes

- Rebased the contribution onto the current `main`, which already contains the initial fail-closed behavior from #104.
- Report all failed stages by name (`dns`, `transparent`, `app-policy`, `warp`, `hotspot`, `dns-capture`, or `dns-leak-guard`).
- Use one cleanup/return path and a subshell-scoped function body so helper state cannot leak into the caller.
- Keep the fake-Magisk deferred-failure scenario and strengthen the focused routing-policy regression to verify multi-component diagnostics.

## Validation

- `TMPDIR=/home/lightjunction/.tmp/magicnet-pr98-tests scripts/pre-commit.sh`
  - route/DNS policy suites passed
  - WebUI tests: 26 passed
  - TypeScript typecheck and Vite build passed
  - Rust CLI and MCP checks passed
  - sing-box 1.13.16 config validation passed
  - fake-Magisk TUN smoke passed

The only compiler diagnostic was the pre-existing unused `SubscriptionAuthority::port` warning.