### PR TITLE
fix: enforce Android per-app TUN filtering by UID

### DIFF
--- a/scripts/test-app-routing-policy.sh
+++ b/scripts/test-app-routing-policy.sh
@@ -48,13 +48,14 @@ case "${1:-} ${2:-}" in
     case "$user:$package" in
       0:com.example.bypass) printf '%s\n' 'package:com.example.bypass uid:11001' ;;
       10:com.example.bypass) printf '%s\n' 'package:com.example.bypass uid:1011001' ;;
-      0:com.example.direct-force) printf '%s\n' 'package:com.example.direct-force uid:11002' ;;
+      0:com.example.directforce) printf '%s\n' 'package:com.example.directforce uid:11002' ;;
       0:com.example.proxy) printf '%s\n' 'package:com.example.proxy uid:11003' ;;
     esac
     ;;
 esac
 EOF
 chmod +x "$MOCK_BIN/cmd"
+ln -s "$MOCK_BIN/cmd" "$NO_JQ_BIN/cmd"
 
 write_base_config() {
   cat >"$MODDIR/.config/sing-box/config.json" <<'EOF'
@@ -116,7 +117,7 @@ assert_proxy_rule_and_order() {
            and .outbound == "proxy")
     and ([.route.rules[]
           | select((.package_name // []) | index("__magicnet_app_direct__"))][0]
-         | .package_name == ["__magicnet_app_direct__", "com.example.direct-force"]
+         | .package_name == ["__magicnet_app_direct__", "com.example.directforce"]
            and .outbound == "direct")
     and (([.route.rules | to_entries[]
             | select(.value | (has("action") or (.protocol == "icmp" and .outbound == "block")))
@@ -146,42 +147,24 @@ assert_proxy_rule_and_order() {
 }
 
 assert_blacklist() {
-  if [ "$EXPECT_UID_POLICY" = 1 ]; then
-    "$JQ_BIN" -e '
-      (.inbounds[] | select(.type == "tun")
-        | .exclude_package == ["com.example.bypass"]
-          and .exclude_uid == [0, 42, 11001, 1011001]
-          and (has("include_package") | not)
-          and (has("include_uid") | not))
-    ' "$MODDIR/.config/sing-box/config.json" >/dev/null
-  else
-    "$JQ_BIN" -e '
-      (.inbounds[] | select(.type == "tun")
-        | .exclude_package == ["com.example.bypass"]
-          and .exclude_uid == [0, 42]
-          and (has("include_package") | not))
-    ' "$MODDIR/.config/sing-box/config.json" >/dev/null
-  fi
+  "$JQ_BIN" -e '
+    (.inbounds[] | select(.type == "tun")
+      | (.exclude_uid | sort) == [0, 42, 11001, 1011001]
+        and (has("include_uid") | not)
+        and (has("include_package") | not)
+        and (has("exclude_package") | not))
+  ' "$MODDIR/.config/sing-box/config.json" >/dev/null
   assert_proxy_rule_and_order
 }
 
 assert_whitelist() {
-  if [ "$EXPECT_UID_POLICY" = 1 ]; then
-    "$JQ_BIN" -e '
-      (.inbounds[] | select(.type == "tun")
-        | .include_package == ["com.example.direct-force", "com.example.proxy"]
-          and .include_uid == [11002, 11003]
-          and .exclude_uid == [0, 42]
-          and (has("exclude_package") | not))
-    ' "$MODDIR/.config/sing-box/config.json" >/dev/null
-  else
-    "$JQ_BIN" -e '
-      (.inbounds[] | select(.type == "tun")
-        | .include_package == ["com.example.direct-force", "com.example.proxy"]
-          and .exclude_uid == [0, 42]
-          and (has("exclude_package") | not))
-    ' "$MODDIR/.config/sing-box/config.json" >/dev/null
-  fi
+  "$JQ_BIN" -e '
+    (.inbounds[] | select(.type == "tun")
+      | (.include_uid | sort) == [11002, 11003]
+        and (.exclude_uid | sort) == [0, 42]
+        and (has("include_package") | not)
+        and (has("exclude_package") | not))
+  ' "$MODDIR/.config/sing-box/config.json" >/dev/null
   assert_proxy_rule_and_order
 }
 
@@ -196,12 +179,6 @@ apply_policy() {
 
 run_case() {
   implementation="$1"
-  if [ "$implementation" = jq ]; then
-    EXPECT_UID_POLICY=1
-  else
-    EXPECT_UID_POLICY=0
-  fi
-  export EXPECT_UID_POLICY
   MODDIR="$WORK/$implementation/module"
   export MODDIR
   mkdir -p "$MODDIR/.config/magicnet" "$MODDIR/.config/sing-box"
@@ -213,8 +190,8 @@ com.example.proxy
 com.example.proxy
 EOF
   cat >"$MODDIR/.config/magicnet/app-direct.list" <<'EOF'
-com.example.direct-force
-com.example.direct-force
+	com.example.directforce
+	com.example.directforce
 EOF
   cat >"$MODDIR/.config/magicnet/app-bypass.list" <<'EOF'
 com.example.bypass
@@ -242,6 +219,17 @@ EOF
   apply_policy "$implementation"
   apply_policy "$implementation"
   assert_whitelist
+
+  : >"$MODDIR/.config/magicnet/app-proxy.list"
+  : >"$MODDIR/.config/magicnet/app-direct.list"
+  apply_policy "$implementation"
+  "$JQ_BIN" -e '
+    (.inbounds[] | select(.type == "tun")
+      | .include_uid == [4294967294]
+        and (.exclude_uid | sort) == [0, 42]
+        and (has("include_package") | not)
+        and (has("exclude_package") | not))
+  ' "$MODDIR/.config/sing-box/config.json" >/dev/null
 }
 
 run_case jq
@@ -254,7 +242,7 @@ assert_jq_removes_legacy_dns_package_rules() {
   write_base_config
   printf '%s\n' 'MAGICNET_APP_MODE=blacklist' >"$MODDIR/.config/magicnet/app-mode.conf"
   printf '%s\n' 'com.example.proxy' >"$MODDIR/.config/magicnet/app-proxy.list"
-  printf '%s\n' 'com.example.direct-force' >"$MODDIR/.config/magicnet/app-direct.list"
+  printf '%s\n' 'com.example.directforce' >"$MODDIR/.config/magicnet/app-direct.list"
   printf '%s\n' 'com.example.bypass' >"$MODDIR/.config/magicnet/app-bypass.list"
   "$JQ_BIN" '.dns = {"rules": [
     {"package_name": ["com.example.legacy"], "server": "bootstrap-local-dns"},

--- a/src/MagicNet/README.md
+++ b/src/MagicNet/README.md
@@ -95,7 +95,83 @@ su -c /data/adb/modules/MagicNet/cli support bundle
 
 提交 Issue 前检查脱敏结果，不要公开订阅 URL、token、secret、password、完整节点地址或设备标识。
 
-Discord：[https://discord.gg/asRwgK9FpA](https://discord.gg/asRwgK9FpA)
+可以按当前 Wi-Fi 的 SSID 或 BSSID 自动切换 sing-box `rule` / `direct` 模式。黑名单命中时使用 `direct`，离开后恢复 `rule`：
+
+```bash
+su -c '/data/adb/modules/MagicNet/cli wifi add-ssid "Home WiFi"'
+su -c /data/adb/modules/MagicNet/cli wifi enable
+su -c /data/adb/modules/MagicNet/cli wifi status
+```
+
+也可在 WebUI“模块控制”页启用和维护名单。`cli wifi disable` 会停止自动切换并恢复 `rule`。
+
+MagicNet 现在只内置 sing-box。核心选择命令保留为兼容入口，使用 `cli core select sing-box` 写入 `.config/magicnet/current-core.conf`。旧的 `.disable_sing_box` 隐藏开关已经移除，不再作为禁用 sing-box 的设计。
+
+## Clash-style subscription to sing-box
+
+如果你的合法订阅仍标注为 Clash、Clash Premium 或 mihomo，直接把同一个订阅 URL 作为 sing-box 来源：
+
+```bash
+su -c '/data/adb/modules/MagicNet/cli setup "https://example.com/subscription"'
+su -c /data/adb/modules/MagicNet/cli sub update sing-box
+```
+
+MagicNet 会抓取常见 Clash-style 节点 payload，并重新生成 `.config/sing-box/config.json` 里的 sing-box `outbounds`。旧的 mihomo 配置目录不会再被写入或启动。
+
+MagicNet 新安装默认按节点名过滤 `免费`、`free`、`HK`、`香港`、`TW`、`台湾`，可在 WebUI 的订阅页删除部分关键词，或清空并保存以关闭过滤。过滤规则会同时作用于新下载、缓存回放与配置修复后的节点列表。导入后的其余节点统一放进 `proxy` 选择器；AI 选择器固定排除中国大陆、香港和台湾标签，并按美国、日本、其他地区的顺序排列候选节点。规则选择器只在 `proxy`、`direct`、`block` 之间切换，不再生成固定的地区桶。如果节点数量明显少于订阅内容，也可能是订阅里包含当前 shell 导入器不支持的协议或字段；安装了 proxylink 时会优先用它生成 sing-box outbounds，以覆盖更多协议。
+
+## 透明代理边界
+
+MagicNet 目前只支持 `tun` 透明模式，使用 `sing-box` `magicnet0` TUN 接管透明流量。旧配置中的 `proxy`、`external-tun`、`hybrid` 会安全归一为 `tun`，CLI 不再接受这些模式。
+
+- 分应用策略分为三类：`Proxy` 强制走代理；`Direct` 仍进入 TUN，但强制走 `direct` 出站；`Bypass TUN` 则让应用完全离开 MagicNet。
+- WebUI 的“全局接管”对应黑名单语义：默认应用进入 TUN，`Bypass TUN` 名单走系统网络；“仅名单接管”对应白名单语义：只有 `Proxy` 和 `Direct` 名单进入 TUN。
+- Root 命令行模式会把包名解析为 Android UID，再通过 TUN 的 `include_uid` / `exclude_uid` 执行边界，避免包名过滤在重启后失效。共享同一 UID 的应用会一起生效。
+- `Bypass TUN` 不等于断网或阻止访问。应用离开 MagicNet 后会使用系统上游网络；如果上游网络或另一个 VPN 能访问 Google，加入 Bypass 后的 Chrome 仍然可以访问。
+- 要验证 Chrome 没有使用 MagicNet 代理，请在 WebUI“应用策略”中选择 `Direct`，或执行 `cli app add com.android.chrome direct`。只有多 VPN 共存或明确需要完全避开 MagicNet 时才选择 `Bypass TUN`。
+- 默认网络策略是双栈、DNS 优先 IPv4、`mixed` TUN 栈、MTU `1400` 和 UDP 会话超时 `5m`。
+- 可在 WebUI 的“UDP / IPv6”卡片切换，或执行 `cli network set <ipv4_only|prefer_ipv4|prefer_ipv6> <1280-1500> <1m|3m|5m|10m|15m|30m>`。
+- `ipv4_only` 是网络或代理节点不支持 IPv6 时的兼容回退；切回双栈会自动移除 MagicNet 管理的 IPv6 拦截规则。
+- 可用性以 `cli health` 和物理出口抓包为准。
+- 发布前请用 `tcpdump` 验证没有 `port 53 or port 853` 泄露。
+
+## MCP 自动化
+
+```bash
+adb forward tcp:8766 tcp:8766
+su -c /data/adb/modules/MagicNet/cli mcp enable
+su -c /data/adb/modules/MagicNet/cli mcp secret
+```
+
+MCP 工具可管理配置源、黑名单、备份、状态检查和脱敏上下文。默认关闭，需要用户显式启用。MCP server 启动时会生成 `MAGICNET_MCP_SECRET` 并以 `0600` 权限保存在模块私有配置中；客户端请求需要带 `Authorization: Bearer <secret>` 或 `X-MagicNet-MCP-Secret: <secret>`。只有 root 命令行应读取这个 secret，可用 `cli mcp rotate-secret` 轮换。
+
+## 社区
+
+- 官方 Discord 群聊：[https://discord.gg/vXffnGge6](https://discord.gg/vXffnGge6)
+
+## DNS 泄露验证
+
+```bash
+adb shell 'su -M -c "ip route get 1.1.1.1; ip -br link"'
+adb shell 'su -M -c "timeout 10 tcpdump -ni rmnet_data0 \"port 53 or port 853\""'
+```
+
+目标状态是访问测试期间没有明文 DNS/DoT 流量从物理出口泄露。MagicNet 会在物理出口接口上拦截直连 53/853，避免绕过 TUN 的 DNS 直接出网；如需临时关闭，可设置 `MAGIC_DNS_LEAK_GUARD=0` 后重新应用配置。
+
+DNS 模板保留 `bootstrap-local-dns` 作为启动和直连例外：它解析代理节点域名、局域网、国内直连域名和连通性检测，避免代理尚未建立时让 DNS detour 到代理造成自引用循环，也避免国内网站拿到错误 CDN。代理域名、AI、GFW 和海外媒体仍按规则走海外 DoH 和代理 detour；如果把 `default_domain_resolver` 指向走代理的 DNS，可能出现 `DNS query loopback in transport[...]` 并导致大量站点超时。
+
+DNS 泄露检测站点会生成一次性探测域名，并根据收到查询的递归解析器判断是否泄露。为了避免这类探测域名被 `bootstrap-local-dns` 或运营商 DNS 解析，模板在所有国内/本地 DNS 规则之前放置高优先级规则，将 BrowserScan、BrowserLeaks、IPLeak、DNSLeakTest、Perfect Privacy、Surfshark、Whoer、DoILeak、Bash.ws、DNS.SB、NextDNS test 等泄露检测域名强制交给 `doh-cloudflare`。`doh-cloudflare` 本身配置了 `detour: proxy`，所以这些探测查询会从代理出口的远端 DoH 发出，而不是从手机本地运营商 DNS 发出。
+
+## 设计取舍
+
+MagicNet 借鉴成熟 Android root 网络模块的“核心启动器、透明规则分层、配置合法性检查、手动控制、日志可追踪”思路，但把对外定位收敛为网络安全分析与设备侧流量审计。IPSET_LKM 和 MCP 都是显式启用或可选增强，不会在默认路径里隐式接管用户网络。
+
+## 使用说明与免责声明
+
+- MagicNet 仅用于合法的自有网络和自有设备测试，请勿用于未经授权的网络、设备或其他违法用途。
+- 用户需自行确认配置来源、网络策略和实际用途合法合规，并对配置与使用结果负责。
+- root 权限和网络栈改动可能造成断网、配置损坏或设备行为异常；操作前请备份现有模块配置，并保留可用的恢复方式。
+- 本软件按现状提供，不保证持续可用、适合特定用途或在所有设备与系统版本上正常工作。
 
 ## 许可证
 

--- a/src/MagicNet/lib/magicnet/apps.sh
+++ b/src/MagicNet/lib/magicnet/apps.sh
@@ -21,6 +21,97 @@ magicnet_app_policy_mode() {
 # Do not auto-seed large “domestic app catalogs” into bypass — that does not scale and
 # duplicates work already done by rule-sets (lyc/metacubex geosite-cn / geoip-cn).
 
+# Standalone sing-box on rooted Android does not have the graphical client's
+# VpnService package filter.  Package filters have also been observed to let
+# unlisted traffic reach the TUN.  Resolve packages to Linux UIDs and apply the
+# TUN boundary with include_uid/exclude_uid instead.
+MAGICNET_APP_UID_SENTINEL=4294967294
+
+magicnet_uid_array_block() {
+    _key="$1"
+    _file="$2"
+    _comma="${3:-,}"
+    _force_empty="${4:-0}"
+    _items=$(sed '/^[[:space:]]*$/d; /^[[:space:]]*#/d' "$_file" 2>/dev/null |
+        awk '/^[0-9]+$/ && !seen[$0]++ { print }')
+    if [ -z "$_items" ]; then
+        [ "$_force_empty" = "1" ] || {
+            unset _key _file _comma _force_empty _items
+            return 0
+        }
+        printf '      "%s": []%s\n' "$_key" "$_comma"
+        unset _key _file _comma _force_empty _items
+        return 0
+    fi
+
+    printf '      "%s": [\n' "$_key"
+    _count=$(printf '%s\n' "$_items" | wc -l | tr -d ' ')
+    _idx=0
+    printf '%s\n' "$_items" | while IFS= read -r _uid; do
+        [ -n "$_uid" ] || continue
+        _idx=$((_idx + 1))
+        _line_comma=","
+        [ "$_idx" -eq "$_count" ] && _line_comma=""
+        printf '        %s%s\n' "$_uid" "$_line_comma"
+    done
+    printf '      ]%s\n' "$_comma"
+    unset _key _file _comma _force_empty _items _count _idx _line_comma _uid
+}
+
+magicnet_singbox_tun_uid_values() {
+    _uid_config="$1"
+    _uid_key="$2"
+    awk -v key="$_uid_key" '
+        function emit_numbers(text, rest) {
+            rest = text
+            while (match(rest, /[0-9]+/)) {
+                print substr(rest, RSTART, RLENGTH)
+                rest = substr(rest, RSTART + RLENGTH)
+            }
+        }
+        {
+            if ($0 ~ /"type"[[:space:]]*:[[:space:]]*"tun"/) {
+                in_tun = 1
+            }
+            if (in_tun && !collecting && index($0, "\"" key "\"") > 0 &&
+                $0 ~ /:[[:space:]]*\[/) {
+                collecting = 1
+                line = $0
+                sub(/^[^[]*\[/, "", line)
+                emit_numbers(line)
+                if (index(line, "]") > 0) {
+                    collecting = 0
+                }
+                next
+            }
+            if (in_tun && collecting) {
+                emit_numbers($0)
+                if (index($0, "]") > 0) {
+                    collecting = 0
+                }
+                next
+            }
+            if (in_tun && $0 ~ /^    }[,]?[[:space:]]*$/) {
+                in_tun = 0
+            }
+        }
+    ' "$_uid_config"
+    unset _uid_config _uid_key
+}
+
+magicnet_uid_values_without_managed() {
+    _managed_uids="$1"
+    _current_uids="$2"
+    awk -v managed_file="$_managed_uids" '
+        FILENAME == managed_file {
+            if ($0 ~ /^[0-9]+$/) managed[$0] = 1
+            next
+        }
+        /^[0-9]+$/ && !managed[$0] && !seen[$0]++ { print }
+    ' "$_managed_uids" "$_current_uids"
+    unset _managed_uids _current_uids
+}
+
 
 magicnet_package_array_block() {
     _key="$1"
@@ -77,17 +168,32 @@ magicnet_android_user_ids() {
 
 magicnet_package_uids() {
     _uid_packages_file="$1"
-    command -v cmd >/dev/null 2>&1 || {
-        unset _uid_packages_file
-        return 0
-    }
-    _uid_users="$(magicnet_android_user_ids | awk '/^[0-9]+$/ && !seen[$0]++')"
-    [ -n "$_uid_users" ] || _uid_users=0
-    magicnet_app_proxy_packages "$_uid_packages_file" |
-        while IFS= read -r _uid_package; do
-            [ -n "$_uid_package" ] || continue
-            for _uid_user in $_uid_users; do
-                cmd package list packages --user "$_uid_user" -U "$_uid_package" 2>/dev/null |
+    if command -v cmd >/dev/null 2>&1; then
+        _uid_users="$(magicnet_android_user_ids | awk '/^[0-9]+$/ && !seen[$0]++')"
+        [ -n "$_uid_users" ] || _uid_users=0
+        magicnet_app_proxy_packages "$_uid_packages_file" |
+            while IFS= read -r _uid_package; do
+                [ -n "$_uid_package" ] || continue
+                for _uid_user in $_uid_users; do
+                    cmd package list packages --user "$_uid_user" -U "$_uid_package" 2>/dev/null |
+                        awk -v expected="package:${_uid_package}" '
+                            $1 == expected {
+                                for (field = 2; field <= NF; field++) {
+                                    if ($field ~ /^uid:[0-9]+$/) {
+                                        sub(/^uid:/, "", $field)
+                                        print $field
+                                    }
+                                }
+                            }
+                        '
+                done
+            done |
+            awk '/^[0-9]+$/ && !seen[$0]++'
+    elif command -v pm >/dev/null 2>&1; then
+        magicnet_app_proxy_packages "$_uid_packages_file" |
+            while IFS= read -r _uid_package; do
+                [ -n "$_uid_package" ] || continue
+                pm list packages -U "$_uid_package" 2>/dev/null |
                     awk -v expected="package:${_uid_package}" '
                         $1 == expected {
                             for (field = 2; field <= NF; field++) {
@@ -98,9 +204,9 @@ magicnet_package_uids() {
                             }
                         }
                     '
-            done
-        done |
-        awk '/^[0-9]+$/ && !seen[$0]++'
+            done |
+            awk '/^[0-9]+$/ && !seen[$0]++'
+    fi
     unset _uid_packages_file _uid_users _uid_package _uid_user
 }
 
@@ -236,6 +342,10 @@ magicnet_singbox_apply_app_policy() {
     _include_packages_tmp="${_config}.include-packages.tmp"
     _include_uids_tmp="${_config}.include-uids.tmp"
     _exclude_uids_tmp="${_config}.exclude-uids.tmp"
+    _base_include_uids_tmp="${_config}.base-include-uids.tmp"
+    _base_exclude_uids_tmp="${_config}.base-exclude-uids.tmp"
+    _render_include_uids_tmp="${_config}.render-include-uids.tmp"
+    _render_exclude_uids_tmp="${_config}.render-exclude-uids.tmp"
     _uid_state_dir="${MODDIR}/.state/app-policy"
     _old_include_uids="${_uid_state_dir}/include-uids.list"
     _old_exclude_uids="${_uid_state_dir}/exclude-uids.list"
@@ -248,11 +358,21 @@ magicnet_singbox_apply_app_policy() {
             magicnet_app_proxy_packages "$_proxy_file"
         } | awk 'NF && !seen[$0]++' >"$_include_packages_tmp"
         magicnet_package_uids "$_include_packages_tmp" >"$_include_uids_tmp"
-        _include_block="$(magicnet_package_array_block include_package "$_include_packages_tmp" "," 1)"
+        awk '/^[0-9]+$/ && !seen[$0]++ { print }' "$_include_uids_tmp" >"${_include_uids_tmp}.new"
+        # An empty include list means “unrestricted” in sing-box.  Keep
+        # whitelist mode fail-closed when no selected package resolves.
+        [ -s "${_include_uids_tmp}.new" ] || printf '%s\n' "$MAGICNET_APP_UID_SENTINEL" >"${_include_uids_tmp}.new"
+        mv -f "${_include_uids_tmp}.new" "$_include_uids_tmp"
+        _include_block="$(magicnet_uid_array_block include_uid "$_include_uids_tmp" "," 1)"
+        : >"$_exclude_uids_tmp"
     else
         magicnet_package_uids "$_bypass_file" >"$_exclude_uids_tmp"
-        _exclude_block="$(magicnet_package_array_block exclude_package "$_bypass_file" ",")"
+        awk 'BEGIN { print 0 } /^[0-9]+$/ && !seen[$0]++ { print }' \
+            "$_exclude_uids_tmp" >"${_exclude_uids_tmp}.new"
+        mv -f "${_exclude_uids_tmp}.new" "$_exclude_uids_tmp"
+        _exclude_block="$(magicnet_uid_array_block exclude_uid "$_exclude_uids_tmp" "," 1)"
         rm -f "$_include_packages_tmp" 2>/dev/null || true
+        : >"$_include_uids_tmp"
     fi
 
     _tmp="${_config}.app-policy.new"
@@ -264,13 +384,15 @@ magicnet_singbox_apply_app_policy() {
     if [ ! -x "$_jq" ]; then
         _jq="$(command -v jq 2>/dev/null || true)"
     fi
+    [ -f "$_old_include_uids" ] || : >"$_old_include_uids"
+    [ -f "$_old_exclude_uids" ] || : >"$_old_exclude_uids"
     if [ -n "$_jq" ]; then
         [ -f "$_proxy_file" ] || : >"$_proxy_file"
         [ -f "$_direct_file" ] || : >"$_direct_file"
         [ -f "$_bypass_file" ] || : >"$_bypass_file"
-        [ -f "$_old_include_uids" ] || : >"$_old_include_uids"
-        [ -f "$_old_exclude_uids" ] || : >"$_old_exclude_uids"
-        if "$_jq" --arg mode "$_mode" \
+        [ -f "$_include_uids_tmp" ] || : >"$_include_uids_tmp"
+        [ -f "$_exclude_uids_tmp" ] || : >"$_exclude_uids_tmp"
+        if "$_jq" --arg mode "$_mode" --argjson uid_sentinel "$MAGICNET_APP_UID_SENTINEL" \
             --rawfile proxy "$_proxy_file" \
             --rawfile direct "$_direct_file" \
             --rawfile bypass "$_bypass_file" \
@@ -298,6 +420,7 @@ magicnet_singbox_apply_app_policy() {
             | (uids($exclude_uids)) as $exclude_uid_values
             | (uids($old_include_uids)) as $old_include_uid_values
             | (uids($old_exclude_uids)) as $old_exclude_uid_values
+            | (if ($include_uid_values | length) == 0 then [$uid_sentinel] else $include_uid_values end) as $managed_include_uid_values
             | .inbounds = (
                 (.inbounds // []) | map(
                   if (.type // "") == "tun" then
@@ -305,17 +428,11 @@ magicnet_singbox_apply_app_policy() {
                     | ((.exclude_uid // []) | without($old_exclude_uid_values)) as $base_exclude_uids
                     | del(.include_package, .exclude_package, .include_uid, .exclude_uid)
                     | if $mode == "whitelist" then
-                        .include_package = (($proxy_packages + $direct_packages) | unique)
-                        | .include_uid = (($base_include_uids + $include_uid_values) | unique)
-                        | .exclude_uid = ($base_exclude_uids | unique)
+                        .include_uid = (($base_include_uids + $managed_include_uid_values) | unique)
+                        | .exclude_uid = (([0] + $base_exclude_uids) | unique)
                       else
                         .include_uid = ($base_include_uids | unique)
-                        | .exclude_uid = (($base_exclude_uids + $exclude_uid_values) | unique)
-                        | if ($bypass_packages | length) > 0 then
-                            .exclude_package = $bypass_packages
-                          else
-                            .
-                          end
+                        | .exclude_uid = (([0] + $base_exclude_uids + $exclude_uid_values) | unique)
                       end
                     | if ((.include_uid // []) | length) == 0 then del(.include_uid) else . end
                     | if ((.exclude_uid // []) | length) == 0 then del(.exclude_uid) else . end
@@ -355,7 +472,9 @@ magicnet_singbox_apply_app_policy() {
               )
         ' "$_config" >"$_tmp" && mv -f "$_tmp" "$_config" &&
             magicnet_app_uid_state_commit "$_uid_state_dir" "$_include_uids_tmp" "$_exclude_uids_tmp"; then
-            rm -f "$_include_packages_tmp" "$_include_uids_tmp" "$_exclude_uids_tmp" 2>/dev/null || true
+            rm -f "$_include_packages_tmp" "$_include_uids_tmp" "$_exclude_uids_tmp" \
+                "$_base_include_uids_tmp" "$_base_exclude_uids_tmp" \
+                "$_render_include_uids_tmp" "$_render_exclude_uids_tmp" 2>/dev/null || true
             unset _config _dir _mode _proxy_file _direct_file _bypass_file _include_block _exclude_block
             unset _include_packages_tmp _include_uids_tmp _exclude_uids_tmp _uid_state_dir
             unset _old_include_uids _old_exclude_uids _tmp _include_tmp _exclude_tmp
@@ -373,6 +492,8 @@ magicnet_singbox_apply_app_policy() {
     if [ -z "$_jq" ] && magicnet_singbox_dns_has_package_rules "$_config"; then
         magicnet_warn "legacy DNS application rules require jq cleanup; refusing to start with them"
         rm -f "$_include_packages_tmp" "$_include_uids_tmp" "$_exclude_uids_tmp" \
+            "$_base_include_uids_tmp" "$_base_exclude_uids_tmp" \
+            "$_render_include_uids_tmp" "$_render_exclude_uids_tmp" \
             "$_include_tmp" "$_exclude_tmp" "$_proxy_rule_tmp" "$_direct_rule_tmp" \
             "$_tmp" 2>/dev/null || true
         unset _config _dir _mode _proxy_file _direct_file _bypass_file _include_block _exclude_block
@@ -380,6 +501,31 @@ magicnet_singbox_apply_app_policy() {
         unset _old_include_uids _old_exclude_uids _tmp _include_tmp _exclude_tmp
         unset _proxy_rule_tmp _direct_rule_tmp _jq
         return 1
+    fi
+
+    magicnet_singbox_tun_uid_values "$_config" include_uid |
+        awk '/^[0-9]+$/ && !seen[$0]++ { print }' >"$_base_include_uids_tmp"
+    magicnet_singbox_tun_uid_values "$_config" exclude_uid |
+        awk '/^[0-9]+$/ && !seen[$0]++ { print }' >"$_base_exclude_uids_tmp"
+    magicnet_uid_values_without_managed "$_old_include_uids" "$_base_include_uids_tmp" >"${_base_include_uids_tmp}.new"
+    mv -f "${_base_include_uids_tmp}.new" "$_base_include_uids_tmp"
+    magicnet_uid_values_without_managed "$_old_exclude_uids" "$_base_exclude_uids_tmp" >"${_base_exclude_uids_tmp}.new"
+    mv -f "${_base_exclude_uids_tmp}.new" "$_base_exclude_uids_tmp"
+    awk '/^[0-9]+$/ && !seen[$0]++ { print }' \
+        "$_base_include_uids_tmp" "$_include_uids_tmp" >"$_render_include_uids_tmp"
+    if [ "$_mode" = "whitelist" ]; then
+        awk 'BEGIN { print 0 } /^[0-9]+$/ && !seen[$0]++ { print }' \
+            "$_base_exclude_uids_tmp" "$_exclude_uids_tmp" >"$_render_exclude_uids_tmp"
+    else
+        awk '/^[0-9]+$/ && !seen[$0]++ { print }' \
+            "$_base_exclude_uids_tmp" "$_exclude_uids_tmp" >"$_render_exclude_uids_tmp"
+    fi
+    if [ "$_mode" = "whitelist" ]; then
+        _include_block="$(magicnet_uid_array_block include_uid "$_render_include_uids_tmp" "," 1)"
+        _exclude_block="$(magicnet_uid_array_block exclude_uid "$_render_exclude_uids_tmp" ",")"
+    else
+        _include_block=""
+        _exclude_block="$(magicnet_uid_array_block exclude_uid "$_render_exclude_uids_tmp" ",")"
     fi
 
     if [ -n "$_include_block" ]; then
@@ -554,7 +700,7 @@ magicnet_singbox_apply_app_policy() {
             if ($0 ~ /"type"[[:space:]]*:[[:space:]]*"tun"/) {
                 in_tun = 1
             }
-            if (in_tun && $0 ~ /^[[:space:]]*"(include_package|exclude_package)"[[:space:]]*:/) {
+            if (in_tun && $0 ~ /^[[:space:]]*"(include_package|exclude_package|include_uid|exclude_uid)"[[:space:]]*:/) {
                 if ($0 !~ /\[[^]]*][[:space:]]*,?[[:space:]]*$/) {
                     skip_package_array = 1
                 }
@@ -569,14 +715,21 @@ magicnet_singbox_apply_app_policy() {
                 in_tun = 0
             }
         }
-    ' "$_config" >"$_tmp" && mv -f "$_tmp" "$_config"; then
+    ' "$_config" >"$_tmp" && mv -f "$_tmp" "$_config" &&
+        magicnet_app_uid_state_commit "$_uid_state_dir" "$_include_uids_tmp" "$_exclude_uids_tmp"; then
         :
     else
         rm -f "$_tmp" 2>/dev/null || true
-        rm -f "$_include_packages_tmp" "$_include_uids_tmp" "$_exclude_uids_tmp" "$_include_tmp" "$_exclude_tmp" "$_proxy_rule_tmp" "$_direct_rule_tmp" 2>/dev/null || true
+        rm -f "$_include_packages_tmp" "$_include_uids_tmp" "$_exclude_uids_tmp" \
+            "$_base_include_uids_tmp" "$_base_exclude_uids_tmp" \
+            "$_render_include_uids_tmp" "$_render_exclude_uids_tmp" \
+            "$_include_tmp" "$_exclude_tmp" "$_proxy_rule_tmp" "$_direct_rule_tmp" 2>/dev/null || true
         return 1
     fi
-    rm -f "$_include_packages_tmp" "$_include_uids_tmp" "$_exclude_uids_tmp" "$_include_tmp" "$_exclude_tmp" "$_proxy_rule_tmp" "$_direct_rule_tmp" 2>/dev/null || true
+    rm -f "$_include_packages_tmp" "$_include_uids_tmp" "$_exclude_uids_tmp" \
+        "$_base_include_uids_tmp" "$_base_exclude_uids_tmp" \
+        "$_render_include_uids_tmp" "$_render_exclude_uids_tmp" \
+        "$_include_tmp" "$_exclude_tmp" "$_proxy_rule_tmp" "$_direct_rule_tmp" 2>/dev/null || true
 }
 
 magicnet_app_policy_apply_unlocked() {

--- a/src/MagicNet/lib/magicnet/core.sh
+++ b/src/MagicNet/lib/magicnet/core.sh
@@ -25,6 +25,9 @@ magicnet_start_singbox_unlocked() {
     magicnet_singbox_apply_transparent_mode || return 1
     magicnet_singbox_apply_hotspot_policy || return 1
     magicnet_tailscale_apply_unlocked || return 1
+    # The preceding normalizers rebuild the managed TUN inbound.  Materialize
+    # per-app UID boundaries after all of them and before sing-box starts; a
+    # deferred rewrite cannot change the already-running core's in-memory routes.
     magicnet_app_policy_apply_unlocked || return 1
     magicnet_tailscale_inject_auth_key || return 1
     import __singbox__

--- a/webui/src/components/pages/AppsPage.vue
+++ b/webui/src/components/pages/AppsPage.vue
@@ -258,7 +258,7 @@ async function restoreBypass(pkg: string): Promise<void> {
 
 async function setMode(mode: "blacklist" | "whitelist"): Promise<void> {
   await withAction(`mode-${mode}`, async () => {
-    await runCli(`app mode ${mode}`, mode === "blacklist" ? "切换黑名单模式" : "切换白名单模式");
+    await runCli(`app mode ${mode}`, mode === "blacklist" ? "切换全局接管" : "切换仅名单接管");
     await refreshApps(true);
   });
 }
@@ -267,7 +267,9 @@ function requestSetMode(mode: "blacklist" | "whitelist"): void {
   pendingAppAction.value = {
     key: `mode-${mode}`,
     command: `app mode ${mode}`,
-    message: mode === "blacklist" ? "确认切换到黑名单模式？未列出应用将正常进入 TUN。" : "确认切换到白名单模式？未列出应用将绕过 TUN。",
+    message: mode === "blacklist"
+      ? "确认切换到全局接管？未列出应用会进入 TUN，只有 Bypass TUN 名单走系统网络。"
+      : "确认切换到仅名单接管？只有 Proxy 和 Direct 名单进入 TUN，未列出应用走系统网络。",
     plan: actionPlan({ type: "mode", mode }),
     run: () => setMode(mode)
   };
@@ -391,46 +393,66 @@ onMounted(() => {
       </div>
     </PageHeader>
 
-    <Card v-if="pendingAppAction" class="grid gap-3 mn-panel-warn">
-      <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <div class="min-w-0">
-          <span class="text-[11px] font-bold uppercase tracking-wide text-[var(--mn-warning)]">Confirm app policy</span>
-          <p class="mt-1 text-sm leading-6 text-[var(--mn-warning)]">{{ pendingAppAction.message }}</p>
-          <code class="mt-2 block break-all rounded-md bg-[var(--mn-ivory)]/60 px-3 py-2 text-xs text-[var(--mn-ink)]">{{ pendingAppAction.command }}</code>
-          <div class="mt-3 grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-5">
-            <span
-              v-for="item in pendingAppAction.plan.items"
-              :key="item.label"
-              class="rounded border px-2 py-1"
-              :class="{
-                'mn-chip-ok': item.tone === 'success',
-                'mn-chip-warn': item.tone === 'warning',
-                'border-[color-mix(in_srgb,var(--mn-coral)_70%,transparent)] text-[var(--mn-danger)]': item.tone === 'danger',
-                'mn-chip-neutral': item.tone === 'neutral',
-              }"
-            >
-              {{ item.label }}: <b class="font-medium">{{ item.value }}</b>
-            </span>
+    <Teleport to="body">
+      <Transition name="sheet">
+        <div v-if="pendingAppAction" class="fixed inset-0 z-[70]" role="presentation">
+          <button
+            class="absolute inset-0 size-full bg-[color-mix(in_srgb,var(--mn-ink)_38%,transparent)]"
+            type="button"
+            aria-label="取消应用策略操作"
+            @click="cancelAppAction"
+          />
+          <div
+            class="mn-chrome absolute inset-x-3 bottom-[max(1rem,env(safe-area-inset-bottom))] mx-auto grid max-h-[min(80dvh,680px)] max-w-3xl gap-3 overflow-auto rounded-md p-1"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="app-policy-confirm-title"
+          >
+            <div class="rounded-[5px] bg-[color-mix(in_srgb,var(--mn-warning)_14%,var(--mn-carrier))] p-4">
+              <span class="text-[11px] font-bold uppercase tracking-wide text-[var(--mn-warning)]">Confirm app policy</span>
+              <p id="app-policy-confirm-title" class="mt-1 text-sm leading-6 text-[var(--mn-warning)]">{{ pendingAppAction.message }}</p>
+              <code class="mt-2 block break-all rounded-md bg-[var(--mn-ivory)]/60 px-3 py-2 text-xs text-[var(--mn-ink)]">{{ pendingAppAction.command }}</code>
+              <div class="mt-3 grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-5">
+                <span
+                  v-for="item in pendingAppAction.plan.items"
+                  :key="item.label"
+                  class="rounded border px-2 py-1"
+                  :class="{
+                    'mn-chip-ok': item.tone === 'success',
+                    'mn-chip-warn': item.tone === 'warning',
+                    'border-[color-mix(in_srgb,var(--mn-coral)_70%,transparent)] text-[var(--mn-danger)]': item.tone === 'danger',
+                    'mn-chip-neutral': item.tone === 'neutral',
+                  }"
+                >
+                  {{ item.label }}: <b class="font-medium">{{ item.value }}</b>
+                </span>
+              </div>
+              <p v-if="pendingAppAction.plan.warnings.length" class="mt-2 text-xs leading-5 text-[var(--mn-warning)]/80">
+                {{ pendingAppAction.plan.warnings.join("；") }}
+              </p>
+              <div class="mt-4 grid grid-cols-2 gap-2">
+                <Button variant="secondary" :loading="isRunning(pendingAppAction.key)" @click="confirmAppAction">确认执行</Button>
+                <Button variant="outline" @click="cancelAppAction">取消</Button>
+              </div>
+            </div>
           </div>
-          <p v-if="pendingAppAction.plan.warnings.length" class="mt-2 text-xs leading-5 text-[var(--mn-warning)]/80">
-            {{ pendingAppAction.plan.warnings.join("；") }}
-          </p>
         </div>
-        <div class="flex shrink-0 gap-2">
-          <Button variant="secondary" :loading="isRunning(pendingAppAction.key)" @click="confirmAppAction">确认</Button>
-          <Button variant="outline" @click="cancelAppAction">取消</Button>
-        </div>
-      </div>
-    </Card>
+      </Transition>
+    </Teleport>
 
     <Card class="grid gap-3">
       <div class="flex flex-wrap items-center gap-3">
         <div class="inline-flex w-fit rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] p-1">
-          <button class="min-h-12 rounded px-3 text-sm font-medium text-[var(--mn-ink-muted)] transition-colors disabled:cursor-progress disabled:opacity-60" :disabled="isRunning('mode-blacklist') || state.appPolicy.mode === 'blacklist'" :class="{ 'bg-[var(--mn-cactus)] text-[var(--mn-on-accent)]': state.appPolicy.mode === 'blacklist' }" @click="requestSetMode('blacklist')">黑名单</button>
-          <button class="min-h-12 rounded px-3 text-sm font-medium text-[var(--mn-ink-muted)] transition-colors disabled:cursor-progress disabled:opacity-60" :disabled="isRunning('mode-whitelist') || state.appPolicy.mode === 'whitelist'" :class="{ 'bg-[var(--mn-cactus)] text-[var(--mn-on-accent)]': state.appPolicy.mode === 'whitelist' }" @click="requestSetMode('whitelist')">白名单</button>
+          <button class="min-h-12 rounded px-3 text-sm font-medium text-[var(--mn-ink-muted)] transition-colors disabled:cursor-progress disabled:opacity-60" :disabled="isRunning('mode-blacklist') || state.appPolicy.mode === 'blacklist'" :class="{ 'bg-[var(--mn-cactus)] text-[var(--mn-on-accent)]': state.appPolicy.mode === 'blacklist' }" @click="requestSetMode('blacklist')">全局接管</button>
+          <button class="min-h-12 rounded px-3 text-sm font-medium text-[var(--mn-ink-muted)] transition-colors disabled:cursor-progress disabled:opacity-60" :disabled="isRunning('mode-whitelist') || state.appPolicy.mode === 'whitelist'" :class="{ 'bg-[var(--mn-cactus)] text-[var(--mn-on-accent)]': state.appPolicy.mode === 'whitelist' }" @click="requestSetMode('whitelist')">仅名单接管</button>
         </div>
-        <span class="text-sm text-[var(--mn-ink-muted)]">想验证应用没有使用代理，请选 Direct。Bypass TUN 不等于断网；上游网络或其他 VPN 仍可能让应用访问 Google。</span>
+        <span class="text-sm text-[var(--mn-ink-muted)]">
+          {{ state.appPolicy.mode === 'whitelist'
+            ? '仅 Proxy 和 Direct 名单中的应用进入 TUN；未列出应用直接走系统网络。'
+            : '默认所有应用进入 TUN；Bypass TUN 名单中的应用走系统网络。' }}
+        </span>
       </div>
+      <p class="text-xs leading-5 text-[var(--mn-ink-faint)]">Proxy 强制代理，Direct 在 TUN 内直连。应用名单会解析成 Android UID；共享同一 UID 的应用会一起生效。</p>
       <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto_auto_auto]">
         <Input v-model="state.packageInput" placeholder="com.android.chrome" spellcheck="false" />
         <Button variant="secondary" :loading="isRunning('add-proxy')" @click="addApp('proxy')"><Plus :size="16" />{{ isRunning('add-proxy') ? '保存中' : 'Proxy' }}</Button>

--- a/webui/src/components/pages/appPolicyChangePlan.ts
+++ b/webui/src/components/pages/appPolicyChangePlan.ts
@@ -98,9 +98,9 @@ function changedPackages(
 function modeWarnings(beforeMode: AppPolicyMode, after: { mode: AppPolicyMode; proxy: string[]; direct: string[]; bypass: string[] }): string[] {
   if (beforeMode === after.mode) return [];
   if (after.mode === "whitelist" && !after.proxy.length && !after.direct.length) {
-    return ["白名单模式下 Proxy 和 Direct 均为空，所有应用都将绕过 TUN。"];
+    return ["仅名单接管下 Proxy 和 Direct 均为空，所有应用都将绕过 TUN。"];
   }
-  if (after.mode === "blacklist" && !after.bypass.length) return ["黑名单模式下 Bypass 为空，除系统排除外应用会默认进入 TUN。"];
+  if (after.mode === "blacklist" && !after.bypass.length) return ["全局接管下 Bypass 为空，除系统排除外应用会默认进入 TUN。"];
   return [];
 }
 


### PR DESCRIPTION
## Summary

- replace fragile TUN package filters with Android UID-based `include_uid` / `exclude_uid` boundaries
- resolve package UIDs across Android users, with a `pm` fallback and fail-closed handling for an empty whitelist
- preserve unmanaged UID rules and make both jq and awk paths idempotent
- apply the app policy after startup normalizers and before sing-box starts
- fix the WebUI app-policy confirmation sheet and clarify global/allowlist semantics

## Validation

- `./scripts/test-app-routing-policy.sh`
- `cd webui && npm test`
- `cd webui && npm run typecheck`
- `cd webui && npm run build`

Rust tests were not available in the submission environment because `cargo` is not installed.

## Summary by Sourcery

在 TUN 层使用基于 UID 的包含/排除列表强制执行 Android 按应用的路由边界，更新 WebUI 语义以匹配新的应用策略行为，并扩展 MagicNet 关于透明代理和 DNS 安全性的文档和测试。

New Features:
- 在 sing-box 的 TUN 入站上为 Android 应用引入基于 UID 的包含/排除边界，并通过哨兵（sentinel）处理，在没有包解析成功时保持白名单模式以“故障关闭”（fail-closed）。
- 支持在多用户 Android 环境中解析应用包 UID，并在已 root 的环境下通过基于 `cmd/pm` 的查找路径获取 UID。
- 新增基于 Wi-Fi SSID/BSSID 的自动切换功能，可在 sing-box 规则模式和直连模式之间自动切换，并可通过 CLI 和 WebUI 进行配置。
- 允许以 Clash 风格的订阅直接导入到 sing-box 出站配置中，而无需维护单独的 mihomo 配置。
- 暴露基于 MCP 的自动化钩子，用于配置管理、黑名单管理、备份、状态检查以及脱敏（redaction）工作流。

Enhancements:
- 使按应用的 UID 路由策略在 `jq` 和 `awk` 两种路径上应用时都保持幂等性，同时保留未托管的 TUN UID 规则。
- 在启动归一化（normalizers）之后、sing-box 启动之前应用应用级 UID 路由策略，确保内存中的路由能够反映已配置的边界。
- 优化 WebUI 中 app-policy 的交互体验，引入模态确认窗口、更清晰的“全局 vs 允许列表”措辞，以及更新的模式标签，以解释 TUN 行为。
- 在 MagicNet 的 README 中进一步阐明透明代理的边界、网络调优选项、DNS 泄漏防护以及相关设计权衡。

Tests:
- 扩展应用路由策略测试脚本，覆盖基于 UID 的 TUN 过滤、`cmd/pm` UID 解析、哨兵 UID 行为，以及对遗留 DNS 包规则进行幂等清理的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce Android per-app routing boundaries at the TUN level using UID-based include/exclude lists, update WebUI semantics to match the new app-policy behavior, and expand MagicNet documentation and tests around transparent proxying and DNS safety.

New Features:
- Introduce UID-based include/exclude boundaries for Android apps on the sing-box TUN inbound, with sentinel handling to keep whitelist mode fail-closed when no packages resolve.
- Support resolving app package UIDs across multiple Android users, with a cmd/pm-based lookup path for rooted environments.
- Add Wi-Fi SSID/BSSID-based automatic switching between sing-box rule and direct modes, configurable via CLI and WebUI.
- Enable Clash-style subscriptions to be ingested directly into sing-box outbounds without maintaining separate mihomo configs.
- Expose MCP-based automation hooks for configuration, blacklist management, backups, status checks, and redaction workflows.

Enhancements:
- Make per-app UID routing policy application idempotent for both jq and awk paths while preserving unmanaged TUN UID rules.
- Apply app-level UID routing policy after startup normalizers and before sing-box starts to ensure in-memory routes reflect the configured boundaries.
- Refine WebUI app-policy UX with a modal confirmation sheet, clearer global-vs-allowlist wording, and updated mode labels explaining TUN behavior.
- Clarify transparent proxy boundaries, network tuning options, DNS leak protection, and design tradeoffs in the MagicNet README.

Tests:
- Expand the app routing policy test script to cover UID-based TUN filtering, cmd/pm UID resolution, sentinel UID behavior, and idempotent cleanup of legacy DNS package rules.

</details>

新特性：
- 支持在多用户环境下将 Android 应用包解析为 UID，并对基于 TUN 的透明代理应用 `include_uid` / `exclude_uid` 边界。
- 在白名单模式下，当选定的应用包均无法解析时，引入失败关闭（fail-closed）行为，使用哨兵 UID 以保持 TUN 限制生效。

改进：
- 使应用策略的应用过程在基于 jq 和基于 awk 的路径上都具备幂等性，同时保留未托管的 TUN UID 规则。
- 在启动归一化步骤之后、sing-box 核心启动之前应用按应用 UID 路由策略，以确保内存中的路由有效。
- 改善 WebUI 中应用策略的用户体验，引入模态确认面板、更清晰的模式标签，并更新黑名单 / 白名单语义的描述。
- 扩展 MagicNet README，加入关于基于 Wi-Fi 的模式切换、仅使用 sing-box 作为核心、Clash 风格订阅、透明代理边界、DNS 泄露防护、MCP 自动化以及设计权衡的最新指导。

测试：
- 扩展应用路由策略测试脚本，以覆盖基于 UID 的 TUN 过滤、`cmd/pm` 解析、哨兵 UID 行为以及传统 DNS 规则清理的幂等性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 TUN 层使用基于 UID 的包含/排除列表强制执行 Android 按应用的路由边界，更新 WebUI 语义以匹配新的应用策略行为，并扩展 MagicNet 关于透明代理和 DNS 安全性的文档和测试。

New Features:
- 在 sing-box 的 TUN 入站上为 Android 应用引入基于 UID 的包含/排除边界，并通过哨兵（sentinel）处理，在没有包解析成功时保持白名单模式以“故障关闭”（fail-closed）。
- 支持在多用户 Android 环境中解析应用包 UID，并在已 root 的环境下通过基于 `cmd/pm` 的查找路径获取 UID。
- 新增基于 Wi-Fi SSID/BSSID 的自动切换功能，可在 sing-box 规则模式和直连模式之间自动切换，并可通过 CLI 和 WebUI 进行配置。
- 允许以 Clash 风格的订阅直接导入到 sing-box 出站配置中，而无需维护单独的 mihomo 配置。
- 暴露基于 MCP 的自动化钩子，用于配置管理、黑名单管理、备份、状态检查以及脱敏（redaction）工作流。

Enhancements:
- 使按应用的 UID 路由策略在 `jq` 和 `awk` 两种路径上应用时都保持幂等性，同时保留未托管的 TUN UID 规则。
- 在启动归一化（normalizers）之后、sing-box 启动之前应用应用级 UID 路由策略，确保内存中的路由能够反映已配置的边界。
- 优化 WebUI 中 app-policy 的交互体验，引入模态确认窗口、更清晰的“全局 vs 允许列表”措辞，以及更新的模式标签，以解释 TUN 行为。
- 在 MagicNet 的 README 中进一步阐明透明代理的边界、网络调优选项、DNS 泄漏防护以及相关设计权衡。

Tests:
- 扩展应用路由策略测试脚本，覆盖基于 UID 的 TUN 过滤、`cmd/pm` UID 解析、哨兵 UID 行为，以及对遗留 DNS 包规则进行幂等清理的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce Android per-app routing boundaries at the TUN level using UID-based include/exclude lists, update WebUI semantics to match the new app-policy behavior, and expand MagicNet documentation and tests around transparent proxying and DNS safety.

New Features:
- Introduce UID-based include/exclude boundaries for Android apps on the sing-box TUN inbound, with sentinel handling to keep whitelist mode fail-closed when no packages resolve.
- Support resolving app package UIDs across multiple Android users, with a cmd/pm-based lookup path for rooted environments.
- Add Wi-Fi SSID/BSSID-based automatic switching between sing-box rule and direct modes, configurable via CLI and WebUI.
- Enable Clash-style subscriptions to be ingested directly into sing-box outbounds without maintaining separate mihomo configs.
- Expose MCP-based automation hooks for configuration, blacklist management, backups, status checks, and redaction workflows.

Enhancements:
- Make per-app UID routing policy application idempotent for both jq and awk paths while preserving unmanaged TUN UID rules.
- Apply app-level UID routing policy after startup normalizers and before sing-box starts to ensure in-memory routes reflect the configured boundaries.
- Refine WebUI app-policy UX with a modal confirmation sheet, clearer global-vs-allowlist wording, and updated mode labels explaining TUN behavior.
- Clarify transparent proxy boundaries, network tuning options, DNS leak protection, and design tradeoffs in the MagicNet README.

Tests:
- Expand the app routing policy test script to cover UID-based TUN filtering, cmd/pm UID resolution, sentinel UID behavior, and idempotent cleanup of legacy DNS package rules.

</details>

</details>