### PR TITLE
feat(webui): add onboarding and open-source support note

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ su -c '/data/adb/modules/MagicNet/cli app add com.example.vpn bypass'
 su -c '/data/adb/modules/MagicNet/cli wifi add-ssid "Home WiFi"'
 su -c /data/adb/modules/MagicNet/cli wifi enable
 su -c /data/adb/modules/MagicNet/cli hotspot enable
+su -c /data/adb/modules/MagicNet/cli hotspot status
 
 # 网络兼容与支持包
 su -c /data/adb/modules/MagicNet/cli network status
@@ -124,7 +125,7 @@ kam build
 - Discord：[加入官方群聊](https://discord.gg/asRwgK9FpA)
 - GitHub Issue：建议附上 `cli health`、`cli transparent status` 和 `cli support bundle` 的脱敏结果。
 
-WebUI 的“反馈问题 / 创建 Issue”会按问题类型生成脱敏上下文。提交前仍应检查正文，不要公开订阅 URL、token、secret、password、完整节点地址或设备标识。
+WebUI 的“反馈问题 / 创建 Issue”会先选择问题类型，再按类型生成脱敏上下文。提交前仍应检查正文，不要公开订阅 URL、token、secret、password、完整节点地址或设备标识。
 
 ## 推广
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2,6 +2,15 @@
 
 MagicNet 的目标是让 Android root 设备通过一条可观察、可回滚的 `sing-box` TUN 路径完成代理、直连、应用分流和网络诊断。透明数据面固定为 `magicnet0`；模块不占用 Android 系统 VPN slot，也不提供 TProxy 或 eBPF 模式。
 
+## 第一次使用：跟着新手引导完成
+
+WebUI 首次打开会自动弹出“新手引导”，后续也可以从页面里的“新手引导”入口重新打开。引导只讲当前主线支持的流程，不会提供订阅 URL、节点、token、password 或示例密钥。
+
+- 确认设备前提：模块已安装、Root 可用、Private DNS 已关闭，MagicNet 只走 `sing-box` + `magicnet0` TUN。
+- 添加来源：在“订阅”里填写你自己的订阅 URL，或者导入本地配置/订阅文件。MagicNet 不提供订阅服务，也不生成节点。
+- 交给 MagicNet 校验并应用：保存后由 MagicNet 拉取、解析、校验并生成运行配置；节点选择通过现有控制流程完成，不要手工改运行中的 `sing-box` 配置文件。
+- 验证链路后再做进阶策略：优先看“运行状态”和“诊断”，确认基础链路已经可用，再考虑应用、Wi‑Fi、热点等策略；异常细节继续看“输出”。
+
 ## 安装与控制入口
 
 从 [MagicNet Releases](https://github.com/LIghtJUNction/MagicNet/releases) 下载 ZIP，在 Magisk、KernelSU 或 APatch 中安装并重启。系统“私人 DNS / 私密 DNS / Private DNS”应关闭，避免 DoT 绕过模块的 DNS 路径。

--- a/webui/onboarding-dialog.test.mjs
+++ b/webui/onboarding-dialog.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const app = readFileSync(new URL("./src/App.vue", import.meta.url), "utf8");
+const dialog = readFileSync(new URL("./src/components/OnboardingDialog.vue", import.meta.url), "utf8");
+const guide = readFileSync(new URL("../docs/user-guide.md", import.meta.url), "utf8");
+
+for (const copy of [
+  "第一次使用 MagicNet",
+  "MagicNet 当前主线只支持 sing-box + magicnet0 TUN",
+  "MagicNet 不提供订阅链接、节点或账号",
+  "不需要手工覆盖 runtime config",
+  "验证通过后再碰应用、Wi‑Fi、热点",
+  "MagicNet 不提供订阅 URL、节点、token、password 或账号",
+]) {
+  assert.match(dialog, new RegExp(copy.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+}
+
+assert.match(app, /const ONBOARDING_STORAGE_KEY = "magicnet\.webui\.onboarding\.v1"/);
+assert.match(app, /window\.localStorage\.getItem\(ONBOARDING_STORAGE_KEY\)/);
+assert.match(app, /window\.localStorage\.setItem\(ONBOARDING_STORAGE_KEY, value\)/);
+assert.match(app, /if \(!readOnboardingPreference\(\)\)/);
+assert.match(app, /<OnboardingDialog/);
+assert.match(app, /@dismiss="closeOnboarding\(\)"/);
+assert.match(app, /@complete="completeOnboarding"/);
+assert.match(app, /@navigate="handleOnboardingNavigate"/);
+assert.match(app, /closeAdvancedNav\(false\)/);
+assert.match(app, /launchOnboarding\(advancedNavTrigger\.value\)/);
+assert.match(app, /trigger instanceof HTMLElement/);
+assert.match(app, /trigger\.isConnected/);
+assert.match(app, /trigger\.focus\(\)/);
+assert.match(app, /<ScrollText :size="16" \/><span>新手引导<\/span>/);
+assert.match(app, /<ScrollText :size="18" \/>新手引导/);
+
+for (const invariant of [
+  'role="dialog"',
+  'aria-modal="true"',
+  'aria-labelledby="onboarding-title"',
+  'aria-describedby="onboarding-description"',
+  "data-dialog-initial-focus",
+  "@keydown.esc.prevent.stop",
+  "document.body.style.overflow = \"hidden\"",
+  "document.body.style.overflow = previousBodyOverflow",
+  "event.key !== \"Tab\"",
+  "event.shiftKey",
+  "!dialog.value.contains(active)",
+  "emit('navigate', activeStep.target)",
+  "emit('complete')",
+  "emit('dismiss')",
+  "稍后再看",
+  "完成引导",
+]) {
+  assert.ok(dialog.includes(invariant), `onboarding dialog missing ${invariant}`);
+}
+
+assert.match(dialog, /type GuideTarget = "subs" \| "control" \| "health" \| "output"/);
+assert.match(dialog, /第 \{\{ currentStep \+ 1 \}\} \/ \{\{ steps\.length \}\} 步|const progressLabel = computed/);
+assert.match(dialog, /if \(event\.shiftKey && \(active === first \|\| !dialog\.value\.contains\(active\)\)\)/);
+assert.match(dialog, /else if \(!event\.shiftKey && \(active === last \|\| !dialog\.value\.contains\(active\)\)\)/);
+
+for (const target of ["subs", "control", "health", "output"]) {
+  assert.match(dialog, new RegExp(`"${target}"`), `missing onboarding navigation target ${target}`);
+}
+
+for (const required of [
+  "## 第一次使用：跟着新手引导完成",
+  "MagicNet 只走 `sing-box` + `magicnet0` TUN",
+  "MagicNet 不提供订阅服务，也不生成节点",
+  "不要手工改运行中的 `sing-box` 配置文件",
+  "异常细节继续看“输出”",
+]) {
+  assert.match(guide, new RegExp(required.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+}
+
+for (const forbidden of [
+  /TProxy/,
+  /eBPF/,
+  /ALLOW_MULTI/,
+  /subscription url/i,
+  /secret/i,
+  /https?:\/\/example\.com/,
+]) {
+  assert.doesNotMatch(dialog, forbidden);
+}
+
+for (const forbidden of [
+  /ALLOW_MULTI/,
+  /token[:：]\s*\S+/i,
+  /password[:：]\s*\S+/i,
+]) {
+  assert.doesNotMatch(guide, forbidden);
+}
+
+console.log("onboarding dialog tests passed");

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -21,6 +21,8 @@ import {
 } from "lucide-vue-next";
 import { computed, defineAsyncComponent, nextTick, onMounted, onUnmounted, ref, type Component } from "vue";
 import { MAGICNET_LOGO_URL } from "@/branding";
+import OnboardingDialog from "@/components/OnboardingDialog.vue";
+import OpenSourceSupportNote from "@/components/OpenSourceSupportNote.vue";
 import Badge from "@/components/ui/Badge.vue";
 import Button from "@/components/ui/Button.vue";
 import IssueReporterDialog from "@/components/IssueReporterDialog.vue";
@@ -28,6 +30,10 @@ import { useMagicNet } from "@/composables/useMagicNet";
 import { useTheme } from "@/composables/useTheme";
 
 type TabKey = "control" | "config" | "apps" | "block" | "subs" | "tools" | "health" | "webui" | "output";
+type OnboardingTarget = Extract<TabKey, "control" | "subs" | "health" | "output">;
+type OnboardingPreference = "dismissed" | "completed";
+
+const ONBOARDING_STORAGE_KEY = "magicnet.webui.onboarding.v1";
 
 const pageLoaders: Record<TabKey, () => Promise<{ default: Component }>> = {
   control: () => import("@/components/pages/ControlPage.vue"),
@@ -77,8 +83,10 @@ const activeTab = ref<TabKey>("control");
 /** Keep visited panels mounted so forms/lists survive tab switches. */
 const visitedTabs = ref<TabKey[]>(["control"]);
 const showAdvancedNav = ref(false);
+const showOnboarding = ref(false);
 const advancedDialog = ref<HTMLElement | null>(null);
 const advancedNavTrigger = ref<HTMLElement | null>(null);
+const onboardingTrigger = ref<HTMLElement | null>(null);
 const easterEggVisitors = [
   {
     name: "SOL",
@@ -159,6 +167,69 @@ function setTab(tab: TabKey): void {
     ).find((item) => item.offsetParent !== null);
     target?.scrollIntoView({ block: "nearest", inline: "center" });
   });
+}
+
+function readOnboardingPreference(): OnboardingPreference | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const stored = window.localStorage.getItem(ONBOARDING_STORAGE_KEY);
+    if (stored === "dismissed" || stored === "completed") return stored;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function persistOnboardingPreference(value: OnboardingPreference): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(ONBOARDING_STORAGE_KEY, value);
+  } catch {
+    // Ignore storage failures; the dialog remains usable for the current session.
+  }
+}
+
+function restoreOnboardingTriggerFocus(): void {
+  const trigger = onboardingTrigger.value;
+  onboardingTrigger.value = null;
+  if (!(trigger instanceof HTMLElement) || typeof trigger.focus !== "function") return;
+  void nextTick(() => {
+    if (trigger instanceof HTMLElement && trigger.isConnected && typeof trigger.focus === "function") {
+      trigger.focus();
+    }
+  });
+}
+
+function launchOnboarding(trigger: HTMLElement | null = null): void {
+  onboardingTrigger.value = trigger;
+  showOnboarding.value = true;
+}
+
+async function requestOnboarding(event?: MouseEvent): Promise<void> {
+  const trigger = event?.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+  if (showAdvancedNav.value) {
+    closeAdvancedNav(false);
+    await nextTick();
+    launchOnboarding(advancedNavTrigger.value);
+    return;
+  }
+  launchOnboarding(trigger);
+}
+
+function closeOnboarding(preference: OnboardingPreference = "dismissed"): void {
+  if (!showOnboarding.value) return;
+  persistOnboardingPreference(preference);
+  showOnboarding.value = false;
+  restoreOnboardingTriggerFocus();
+}
+
+function completeOnboarding(): void {
+  closeOnboarding("completed");
+}
+
+function handleOnboardingNavigate(target: OnboardingTarget): void {
+  closeOnboarding("dismissed");
+  setTab(target);
 }
 
 async function requestIssue(): Promise<void> {
@@ -271,6 +342,11 @@ onMounted(() => {
   void refreshStatus();
   document.addEventListener("keydown", handleEscape);
   void pageLoaders.control();
+  if (!readOnboardingPreference()) {
+    void nextTick(() => {
+      if (!showOnboarding.value) launchOnboarding();
+    });
+  }
   // Warm common tabs after first paint so switches feel instant.
   const warm = () => {
     void pageLoaders.config();
@@ -327,6 +403,16 @@ onUnmounted(() => {
           <Moon v-else-if="themePreference === 'dark'" :size="16" aria-hidden="true" />
           <Monitor v-else :size="16" aria-hidden="true" />
           <span class="hidden sm:inline">{{ themeLabel }}</span>
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          class="hidden size-11 px-0 md:inline-flex md:w-auto md:px-4"
+          aria-label="打开新手引导"
+          title="打开新手引导"
+          @click="requestOnboarding"
+        >
+          <ScrollText :size="16" /><span>新手引导</span>
         </Button>
         <Button
           size="sm"
@@ -467,6 +553,8 @@ onUnmounted(() => {
       </section>
     </main>
 
+    <OpenSourceSupportNote />
+
     <nav class="mobile-nav mn-chrome fixed inset-x-3 bottom-[max(0.75rem,env(safe-area-inset-bottom))] z-30 grid grid-cols-6 gap-0.5 rounded-[1.35rem] p-1.5 md:hidden" aria-label="MagicNet 移动导航">
       <button
         v-for="item in primaryTabs"
@@ -528,6 +616,13 @@ onUnmounted(() => {
               <span>{{ item.label }}</span>
             </button>
             <Button
+              variant="outline"
+              class="min-h-11"
+              @click="requestOnboarding"
+            >
+              <ScrollText :size="18" />新手引导
+            </Button>
+            <Button
               class="min-h-11"
               :loading="state.task === '创建 GitHub issue'"
               @click="requestIssue"
@@ -545,6 +640,13 @@ onUnmounted(() => {
         </div>
       </div>
     </Transition>
+
+    <OnboardingDialog
+      v-if="showOnboarding"
+      @dismiss="closeOnboarding()"
+      @complete="completeOnboarding"
+      @navigate="handleOnboardingNavigate"
+    />
 
     <IssueReporterDialog
       v-if="state.issueReporter.open"

--- a/webui/src/components/OnboardingDialog.vue
+++ b/webui/src/components/OnboardingDialog.vue
@@ -1,0 +1,259 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, ref } from "vue";
+import { ArrowRight, CheckCircle2, DownloadCloud, Gauge, Stethoscope, Terminal, X } from "lucide-vue-next";
+import Button from "@/components/ui/Button.vue";
+
+type GuideTarget = "subs" | "control" | "health" | "output";
+
+type Step = {
+  eyebrow: string;
+  title: string;
+  summary: string;
+  details: string[];
+  target: GuideTarget;
+  targetLabel: string;
+  secondaryTarget?: GuideTarget;
+  secondaryLabel?: string;
+};
+
+const emit = defineEmits<{
+  dismiss: [];
+  complete: [];
+  navigate: [target: GuideTarget];
+}>();
+
+const dialog = ref<HTMLElement | null>(null);
+const currentStep = ref(0);
+let previousBodyOverflow = "";
+
+const steps: Step[] = [
+  {
+    eyebrow: "步骤 1",
+    title: "确认设备已经准备好走 TUN",
+    summary: "MagicNet 当前主线只支持 sing-box + magicnet0 TUN。Root 模块安装完成后，再从 WebUI 开始配置。",
+    details: [
+      "Private DNS 需要保持关闭，避免域名请求绕过 MagicNet。",
+      "不要寻找其他透明模式或系统 VPN slot。",
+      "运行状态页能先帮你确认核心是否已经起来。",
+    ],
+    target: "control",
+    targetLabel: "查看运行状态",
+  },
+  {
+    eyebrow: "步骤 2",
+    title: "添加你自己的订阅或本地文件",
+    summary: "订阅页支持填写订阅 URL，也支持导入本地配置或订阅文件。MagicNet 不提供订阅链接、节点或账号。",
+    details: [
+      "把来源交给你自己的服务商或本地文件，不要期待 MagicNet 生成节点。",
+      "URL、token、密码、账号和示例密钥都不应该写进截图、反馈或共享文档。",
+      "本地导入会进入和 URL 一样的候选解析与校验流程。",
+    ],
+    target: "subs",
+    targetLabel: "打开订阅页",
+  },
+  {
+    eyebrow: "步骤 3",
+    title: "让 MagicNet 校验、应用并选择节点",
+    summary: "保存后由 MagicNet 拉取、解析、校验并应用运行配置；节点选择放在现有控制流程里完成。",
+    details: [
+      "失败时会保留上一次有效配置，不需要手工覆盖 runtime config。",
+      "节点切换、自动组和当前运行状态都在现有控制入口处理。",
+      "如果想看失败细节，直接去输出页，不要跳过校验流程。",
+    ],
+    target: "control",
+    targetLabel: "打开控制页",
+    secondaryTarget: "output",
+    secondaryLabel: "查看输出",
+  },
+  {
+    eyebrow: "步骤 4",
+    title: "验证通过后再碰应用、Wi‑Fi、热点",
+    summary: "把基础链路跑通后，再考虑分流和网络策略。先看运行状态与诊断，再决定是否调整进阶策略。",
+    details: [
+      "优先确认 sing-box 状态、transparent/TUN 状态和诊断结果。",
+      "应用、Wi‑Fi、热点策略都建立在已经可用的 magicnet0 路径之上。",
+      "诊断仍有异常时继续查输出，不要直接改底层运行文件。",
+    ],
+    target: "health",
+    targetLabel: "打开诊断",
+    secondaryTarget: "output",
+    secondaryLabel: "查看输出",
+  },
+];
+
+const activeStep = computed(() => steps[currentStep.value] ?? steps[0]);
+const isFirstStep = computed(() => currentStep.value === 0);
+const isLastStep = computed(() => currentStep.value === steps.length - 1);
+const progressLabel = computed(() => `第 ${currentStep.value + 1} / ${steps.length} 步`);
+
+function previous(): void {
+  if (isFirstStep.value) return;
+  currentStep.value -= 1;
+}
+
+function next(): void {
+  if (isLastStep.value) return;
+  currentStep.value += 1;
+}
+
+function trapFocus(event: KeyboardEvent): void {
+  if (event.key !== "Tab" || !dialog.value) return;
+  const focusable = Array.from(
+    dialog.value.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter((element) => element.getClientRects().length > 0);
+  if (!focusable.length) {
+    event.preventDefault();
+    dialog.value.focus();
+    return;
+  }
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement;
+  if (event.shiftKey && (active === first || !dialog.value.contains(active))) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && (active === last || !dialog.value.contains(active))) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
+onMounted(() => {
+  previousBodyOverflow = document.body.style.overflow;
+  document.body.style.overflow = "hidden";
+  void nextTick(() => {
+    dialog.value?.querySelector<HTMLElement>("[data-dialog-initial-focus]")?.focus();
+  });
+});
+
+onUnmounted(() => {
+  document.body.style.overflow = previousBodyOverflow;
+});
+</script>
+
+<template>
+  <div class="fixed inset-0 z-[70] grid place-items-end p-3 sm:place-items-center sm:p-6">
+    <button
+      class="absolute inset-0 size-full bg-[color-mix(in_srgb,var(--mn-ink)_42%,transparent)]"
+      type="button"
+      aria-label="关闭新手引导"
+      @click="emit('dismiss')"
+    />
+    <section
+      ref="dialog"
+      class="mn-chrome relative z-10 grid max-h-[calc(100dvh-1.5rem)] w-full max-w-3xl gap-4 overflow-y-auto rounded-md p-1.5"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="onboarding-title"
+      aria-describedby="onboarding-description"
+      tabindex="-1"
+      @keydown="trapFocus"
+      @keydown.esc.prevent.stop="emit('dismiss')"
+    >
+      <div class="rounded-[5px] bg-[var(--mn-ivory)] p-4 sm:p-5">
+        <div class="flex items-start justify-between gap-4">
+          <div class="min-w-0">
+            <span class="inline-flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--mn-clay)]">
+              <CheckCircle2 :size="14" /> 新手引导
+            </span>
+            <h2 id="onboarding-title" class="mt-2 text-xl font-semibold tracking-[-0.03em] text-[var(--mn-ink)]">
+              第一次使用 MagicNet
+            </h2>
+            <p id="onboarding-description" class="mt-1 text-sm leading-6 text-[var(--mn-ink-muted)]">
+              跟着这 4 步完成首次配置：确认 TUN 前提、添加来源、让 MagicNet 校验并应用，再用运行状态与诊断确认链路。
+            </p>
+          </div>
+          <Button data-dialog-initial-focus variant="ghost" size="icon" aria-label="关闭新手引导" @click="emit('dismiss')">
+            <X :size="18" />
+          </Button>
+        </div>
+
+        <div class="mt-4 grid gap-3 lg:grid-cols-[220px_minmax(0,1fr)]">
+          <ol class="grid gap-2" aria-label="引导进度">
+            <li
+              v-for="(step, index) in steps"
+              :key="step.title"
+              :class="[
+                'rounded-md border p-3 text-left',
+                index === currentStep
+                  ? 'border-[var(--mn-cactus)] bg-[color-mix(in_srgb,var(--mn-cactus)_12%,var(--mn-ivory))]'
+                  : 'border-[var(--mn-border)] bg-[var(--mn-carrier)] text-[var(--mn-ink-soft)]',
+              ]"
+            >
+              <div class="flex items-center justify-between gap-3">
+                <strong class="text-sm font-semibold text-[var(--mn-ink)]">{{ index + 1 }}. {{ step.title }}</strong>
+                <span class="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--mn-clay)]">
+                  {{ index === currentStep ? "当前" : "待完成" }}
+                </span>
+              </div>
+              <p class="mt-1 text-xs leading-5 text-[var(--mn-ink-muted)]">{{ step.eyebrow }}</p>
+            </li>
+          </ol>
+
+          <article class="rounded-md border border-[var(--mn-border)] bg-[var(--mn-carrier)] p-4 sm:p-5">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <span class="text-[10px] font-semibold uppercase tracking-[0.2em] text-[var(--mn-clay)]">{{ progressLabel }}</span>
+              <div class="flex items-center gap-2 text-xs text-[var(--mn-ink-muted)]">
+                <span class="inline-flex size-2.5 rounded-full bg-[var(--mn-cactus)]" aria-hidden="true" />
+                <span>可随时重新打开，不会修改现有运行状态</span>
+              </div>
+            </div>
+
+            <div class="mt-4 flex items-start gap-3">
+              <div class="grid size-11 shrink-0 place-items-center rounded-[0.85rem] bg-[color-mix(in_srgb,var(--mn-cactus)_18%,var(--mn-carrier))] text-[var(--mn-cactus-deep)]">
+                <DownloadCloud v-if="activeStep.target === 'subs'" :size="20" />
+                <Gauge v-else-if="activeStep.target === 'control'" :size="20" />
+                <Stethoscope v-else-if="activeStep.target === 'health'" :size="20" />
+                <Terminal v-else :size="20" />
+              </div>
+              <div class="min-w-0">
+                <h3 class="text-lg font-semibold tracking-[-0.03em] text-[var(--mn-ink)]">{{ activeStep.title }}</h3>
+                <p class="mt-2 text-sm leading-6 text-[var(--mn-ink-muted)]">{{ activeStep.summary }}</p>
+              </div>
+            </div>
+
+            <ul class="mt-4 grid gap-2 text-sm leading-6 text-[var(--mn-ink-muted)]">
+              <li
+                v-for="detail in activeStep.details"
+                :key="detail"
+                class="rounded-[0.85rem] bg-[var(--mn-ivory)] px-3 py-2.5"
+              >
+                {{ detail }}
+              </li>
+            </ul>
+
+            <div class="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+              <Button class="sm:flex-none" @click="emit('navigate', activeStep.target)">
+                {{ activeStep.targetLabel }} <ArrowRight :size="16" />
+              </Button>
+              <Button
+                v-if="activeStep.secondaryTarget && activeStep.secondaryLabel"
+                variant="outline"
+                class="sm:flex-none"
+                @click="emit('navigate', activeStep.secondaryTarget)"
+              >
+                {{ activeStep.secondaryLabel }}
+              </Button>
+            </div>
+          </article>
+        </div>
+
+        <div class="mt-4 flex flex-col gap-3 border-t border-[var(--mn-border)] pt-4 sm:flex-row sm:items-center sm:justify-between">
+          <p class="text-xs leading-5 text-[var(--mn-ink-muted)]">
+            MagicNet 不提供订阅 URL、节点、token、password 或账号。把敏感信息留在你自己的来源里。
+          </p>
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <Button variant="ghost" class="sm:flex-none" @click="emit('dismiss')">稍后再看</Button>
+            <div class="flex gap-2">
+              <Button class="flex-1 sm:flex-none" variant="outline" :disabled="isFirstStep" @click="previous">上一步</Button>
+              <Button v-if="!isLastStep" class="flex-1 sm:flex-none" @click="next">下一步</Button>
+              <Button v-else class="flex-1 sm:flex-none" @click="emit('complete')">完成引导</Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/webui/src/components/OpenSourceSupportNote.vue
+++ b/webui/src/components/OpenSourceSupportNote.vue
@@ -1,0 +1,48 @@
+<template>
+  <details
+    class="mn-chrome mt-5 rounded-[1.25rem] p-1.5 text-sm text-[var(--mn-ink-muted)]"
+    aria-label="MagicNet 开源支持说明"
+  >
+    <summary
+      class="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 rounded-[0.95rem] bg-[color-mix(in_srgb,var(--mn-ink)_3%,transparent)] px-4 py-3 text-left text-[var(--mn-ink)] transition-[background-color,transform,opacity] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.99]"
+    >
+      <span class="min-w-0">
+        <span class="block text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--mn-ink-faint)]">可选</span>
+        <span class="mt-1 block text-sm font-semibold text-[var(--mn-ink)]">关于 MagicNet 的维护与支持</span>
+      </span>
+      <span
+        class="shrink-0 rounded-full border border-[var(--mn-border)] bg-[var(--mn-carrier)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--mn-clay)]"
+      >
+        展开
+      </span>
+    </summary>
+
+    <div class="rounded-[0.95rem] bg-[var(--mn-carrier)] px-4 py-4 sm:px-5">
+      <div class="max-w-3xl space-y-3">
+        <p class="leading-6">
+          如果你对 MagicNet 感兴趣，也许会想知道：这个项目一直由我个人持续维护。我是一名大学生，长期用自己的时间和精力处理真机兼容、TUN 链路、文档整理、用户反馈和问题排查。
+        </p>
+        <p class="leading-6">
+          这些工作除了写代码，还包含长期测试、调试和反复验证。AI 辅助开发、持续调用、服务器开销和排障本身都会消耗真实的 Token、时间和资源。
+        </p>
+        <p class="leading-6">
+          我不太想把它做成一段单纯的捐赠请求，所以开了一个 AI API 中转站：如果你刚好有实际使用需求，可以在那里购买 AI 使用额度，在满足自己需求的同时，也顺手支持 MagicNet 继续做开源维护。
+          <a
+            class="font-medium text-[var(--mn-sky)] underline decoration-[color-mix(in_srgb,var(--mn-sky)_45%,transparent)] underline-offset-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))]"
+            href="https://api.lmm.best/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            访问中转站
+          </a>
+        </p>
+        <p class="leading-6">
+          它是一个独立的外部服务，是否使用完全自愿，不使用也不会影响 MagicNet 的任何功能。其中一部分收入也会尽量继续投入到 MagicNet 这样的开源维护里。
+        </p>
+        <p class="leading-6">
+          如果你不打算使用它，提交 Issue、Pull Request、建议，或者帮忙测试新版本，也都是很实际的支持。对愿意长期帮助项目的人，合适的时候我也会尽量提供一些使用额度回馈。
+        </p>
+      </div>
+    </div>
+  </details>
+</template>

--- a/webui/support-note.test.mjs
+++ b/webui/support-note.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const app = readFileSync(new URL("./src/App.vue", import.meta.url), "utf8");
+const note = readFileSync(new URL("./src/components/OpenSourceSupportNote.vue", import.meta.url), "utf8");
+
+for (const copy of [
+  "关于 MagicNet 的维护与支持",
+  "这个项目一直由我个人持续维护",
+  "我是一名大学生",
+  "AI 辅助开发、持续调用、服务器开销和排障本身都会消耗真实的 Token、时间和资源",
+  "我不太想把它做成一段单纯的捐赠请求",
+  "如果你刚好有实际使用需求，可以在那里购买 AI 使用额度",
+  "支持 MagicNet 继续做开源维护",
+  "它是一个独立的外部服务，是否使用完全自愿，不使用也不会影响 MagicNet 的任何功能",
+  "一部分收入也会尽量继续投入到 MagicNet 这样的开源维护里",
+  "提交 Issue、Pull Request、建议，或者帮忙测试新版本",
+  "合适的时候我也会尽量提供一些使用额度回馈",
+  "访问中转站",
+]) {
+  assert.match(note, new RegExp(copy.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+}
+
+assert.match(note, /<details[\s\S]*aria-label="MagicNet 开源支持说明"/);
+assert.doesNotMatch(note, /<details[^>]*\sopen(?:\s|=|>)/);
+assert.match(note, /<summary[\s\S]*关于 MagicNet 的维护与支持/);
+assert.match(note, /href="https:\/\/api\.lmm\.best\/"/);
+assert.match(note, /target="_blank"/);
+assert.match(note, /rel="noopener noreferrer"/);
+
+for (const forbidden of [
+  /localStorage/,
+  /setTimeout/,
+  /setInterval/,
+  /onMounted/,
+  /onUnmounted/,
+  /position:\s*fixed/i,
+  /fixed inset/i,
+  /dialog/i,
+  /toast/i,
+  /modal/i,
+  /打赏/,
+  /返利/,
+  /固定比例/,
+  /保证/,
+]) {
+  assert.doesNotMatch(note, forbidden);
+}
+
+assert.match(app, /import OpenSourceSupportNote from "@\/components\/OpenSourceSupportNote\.vue";/);
+assert.match(app, /<\/main>\s*<OpenSourceSupportNote \/>\s*<nav class="mobile-nav/m);
+assert.doesNotMatch(app, /showSupportNote|supportNoteVisible|SUPPORT_NOTE_STORAGE_KEY/);
+
+console.log("support note tests passed");


### PR DESCRIPTION
## Summary
- Add a first-use 4-step onboarding dialog in the WebUI.
- Add a default-collapsed voluntary open-source support note linking to https://api.lmm.best/.
- Update README and user guide copy so the onboarding/support flow and hotspot selector documentation stay aligned with repository hygiene checks.

## Validation
- ./scripts/test-repository-hygiene.sh
- cd webui && npm test  # 23/23 passed
- cd webui && npm run typecheck
- git diff --check

## Residual risk
- Full build was not run in this delivery step.
- Real browser interaction and real device interaction were not run.

## Summary by Sourcery

在 WebUI 中引入首次使用的入门引导流程，并添加自愿的开源支持说明，同时让面向用户的文档和测试与新的使用体验保持一致。

新功能：
- 添加多步骤的 WebUI 新手引导弹窗，引导首次使用的用户完成 TUN 前置条件检查、订阅设置、配置应用以及结果验证。
- 在桌面端和移动端导航中暴露「新手引导」入口，让用户可以在任何时候重新打开引导流程。
- 在 WebUI 中添加默认折叠的开源支持说明，解释项目维护情况，并链接到可选的外部 AI API 中继服务。

改进：
- 将新手引导的完成/关闭状态持久化到本地存储，避免在后续访问中不必要地重复显示弹窗。
- 将 README 和用户指南的措辞与新手引导流程以及热点/健康状况/输出说明保持一致。
- 改进新手引导弹窗的焦点处理和可访问性，包括键盘操作约束以及初始焦点管理。

测试：
- 添加自动化测试以验证新手引导弹窗文案、导航目标、可访问性不变性以及与存储的集成。
- 添加自动化测试以确保开源支持说明的内容、外部链接行为以及不打扰用户的呈现方式在时间推移中保持不变。
- 扩展 CLI 使用示例的测试范围，以覆盖热点状态相关文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a first-use onboarding flow in the WebUI and add a voluntary open-source support note, while aligning user-facing documentation and tests with the new experience.

New Features:
- Add a multi-step WebUI onboarding dialog that guides first-time users through TUN prerequisites, subscription setup, configuration application, and verification.
- Expose "新手引导" entry points in desktop and mobile navigation so users can reopen the onboarding at any time.
- Add a default-collapsed open-source support note in the WebUI that explains project maintenance and links to an optional external AI API relay service.

Enhancements:
- Persist onboarding completion/dismissal state in local storage to avoid re-showing the dialog unnecessarily on subsequent visits.
- Align README and user guide wording with the onboarding flow and hotspot/health/output guidance.
- Improve focus handling and accessibility for the onboarding dialog, including keyboard trapping and initial focus management.

Tests:
- Add automated tests to validate onboarding dialog copy, navigation targets, accessibility invariants, and storage integration.
- Add automated tests to ensure the open-source support note content, external link behavior, and non-intrusive presentation remain invariant over time.
- Extend CLI usage examples tests to cover hotspot status documentation.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 WebUI 中引入首次使用的入门引导流程，并添加自愿的开源支持说明，同时让面向用户的文档和测试与新的使用体验保持一致。

新功能：
- 添加多步骤的 WebUI 新手引导弹窗，引导首次使用的用户完成 TUN 前置条件检查、订阅设置、配置应用以及结果验证。
- 在桌面端和移动端导航中暴露「新手引导」入口，让用户可以在任何时候重新打开引导流程。
- 在 WebUI 中添加默认折叠的开源支持说明，解释项目维护情况，并链接到可选的外部 AI API 中继服务。

改进：
- 将新手引导的完成/关闭状态持久化到本地存储，避免在后续访问中不必要地重复显示弹窗。
- 将 README 和用户指南的措辞与新手引导流程以及热点/健康状况/输出说明保持一致。
- 改进新手引导弹窗的焦点处理和可访问性，包括键盘操作约束以及初始焦点管理。

测试：
- 添加自动化测试以验证新手引导弹窗文案、导航目标、可访问性不变性以及与存储的集成。
- 添加自动化测试以确保开源支持说明的内容、外部链接行为以及不打扰用户的呈现方式在时间推移中保持不变。
- 扩展 CLI 使用示例的测试范围，以覆盖热点状态相关文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a first-use onboarding flow in the WebUI and add a voluntary open-source support note, while aligning user-facing documentation and tests with the new experience.

New Features:
- Add a multi-step WebUI onboarding dialog that guides first-time users through TUN prerequisites, subscription setup, configuration application, and verification.
- Expose "新手引导" entry points in desktop and mobile navigation so users can reopen the onboarding at any time.
- Add a default-collapsed open-source support note in the WebUI that explains project maintenance and links to an optional external AI API relay service.

Enhancements:
- Persist onboarding completion/dismissal state in local storage to avoid re-showing the dialog unnecessarily on subsequent visits.
- Align README and user guide wording with the onboarding flow and hotspot/health/output guidance.
- Improve focus handling and accessibility for the onboarding dialog, including keyboard trapping and initial focus management.

Tests:
- Add automated tests to validate onboarding dialog copy, navigation targets, accessibility invariants, and storage integration.
- Add automated tests to ensure the open-source support note content, external link behavior, and non-intrusive presentation remain invariant over time.
- Extend CLI usage examples tests to cover hotspot status documentation.

</details>

</details>