### PR TITLE
fix: harden DNS diagnostics and routing regressions

### DIFF
--- a/crates/magicnet-cli/src/dns.rs
+++ b/crates/magicnet-cli/src/dns.rs
@@ -28,13 +28,18 @@ fn dns_test(domain: &str) -> Result<(), String> {
     let url = format!("https://{domain}/");
     let output = Command::new("curl")
         .args([
-            "-fsS",
+            // A DNS/transport probe must not fail merely because a healthy
+            // endpoint returns HTTP 4xx/5xx (for example, www.gstatic.com/
+            // commonly returns 404).  Curl still fails on DNS, connect, and
+            // TLS errors, which are the failures this command is intended to
+            // report.
+            "-sS",
             "--max-time",
             "6",
             "-o",
             "/dev/null",
             "-w",
-            "domain=%{url_effective}\nremote_ip=%{remote_ip}\ntime_total=%{time_total}\n",
+            "domain=%{url_effective}\nhttp_code=%{http_code}\nremote_ip=%{remote_ip}\ntime_total=%{time_total}\n",
             &url,
         ])
         .output()

--- a/scripts/test-action-routing.sh
+++ b/scripts/test-action-routing.sh
@@ -125,6 +125,18 @@ for domain in ("api.x.com", "upload.twitter.com", "abs.twimg.com"):
             f"index={index} outbound={outbound}"
         )
 
+for domain in ("api.openai.com", "auth.openai.com", "ws.chatgpt.com", "events.oaistatsig.com"):
+    index, outbound = first_modeled_outbound(
+        domain,
+        "203.0.113.10",
+        "com.openai.chatgpt",
+    )
+    if (index, outbound) != (chatgpt_indexes[0], "ai-chatgpt"):
+        raise AssertionError(
+            f"ChatGPT voice/auth domain {domain} did not keep the package-first ai-chatgpt route: "
+            f"index={index} outbound={outbound}"
+        )
+
 chatgpt_domain_rules = [
     rule
     for rule in route_rules

--- a/scripts/test-app-routing-policy.sh
+++ b/scripts/test-app-routing-policy.sh
@@ -16,6 +16,7 @@ fi
 . "$ROOT/src/MagicNet/lib/magicnet/apps.sh"
 . "$ROOT/src/MagicNet/lib/magicnet/core.sh"
 . "$ROOT/src/MagicNet/lib/magicnet/network.sh"
+. "$ROOT/src/MagicNet/lib/magicnet/runtime_config.sh"
 
 magicnet_warn() { :; }
 
@@ -377,5 +378,34 @@ EOF
 }
 
 assert_startup_policy_order
+
+assert_deferred_failure_disables_dns_controls() (
+  events="$WORK/deferred-failure-events.log"
+  : >"$events"
+
+  magicnet_dns_apply_unlocked() { printf '%s\n' dns-apply >>"$events"; return 1; }
+  magicnet_transparent_apply_unlocked() { printf '%s\n' transparent >>"$events"; }
+  magicnet_app_policy_apply_unlocked() { printf '%s\n' app-policy >>"$events"; }
+  magicnet_warp_apply_unlocked() { printf '%s\n' warp >>"$events"; }
+  magicnet_singbox_apply_hotspot_policy() { printf '%s\n' hotspot >>"$events"; }
+  magicnet_enable_dns_capture() { printf '%s\n' capture-enable >>"$events"; }
+  magicnet_enable_dns_leak_guard() { printf '%s\n' guard-enable >>"$events"; }
+  magicnet_disable_dns_capture() { printf '%s\n' capture-disable >>"$events"; }
+  magicnet_disable_dns_leak_guard() { printf '%s\n' guard-disable >>"$events"; }
+
+  if magicnet_after_kernel_start_deferred_unlocked; then
+    printf '%s\n' 'deferred config failure must return non-zero' >&2
+    exit 1
+  fi
+  grep -qx capture-disable "$events"
+  grep -qx guard-disable "$events"
+  if grep -Eq '^(capture|guard)-enable$' "$events"; then
+    printf '%s\n' 'deferred config failure enabled DNS controls' >&2
+    cat "$events" >&2
+    exit 1
+  fi
+)
+
+assert_deferred_failure_disables_dns_controls
 
 printf '%s\n' 'app routing policy regression tests passed'

--- a/src/MagicNet/lib/magicnet/network.sh
+++ b/src/MagicNet/lib/magicnet/network.sh
@@ -195,16 +195,32 @@ magicnet_after_kernel_start() {
 }
 
 magicnet_after_kernel_start_deferred_unlocked() {
-    magicnet_dns_apply_unlocked || true
-    magicnet_transparent_apply_unlocked || true
-    magicnet_app_policy_apply_unlocked || true
-    magicnet_warp_apply_unlocked || true
+    _deferred_rc=0
+    magicnet_dns_apply_unlocked || _deferred_rc=1
+    magicnet_transparent_apply_unlocked || _deferred_rc=1
+    magicnet_app_policy_apply_unlocked || _deferred_rc=1
+    magicnet_warp_apply_unlocked || _deferred_rc=1
     # Keep the hotspot route authoritative after every deferred config rewrite.
     # These rewrites run asynchronously after the core starts and may otherwise
     # publish a snapshot that predates the startup-time hotspot normalization.
-    magicnet_singbox_apply_hotspot_policy || true
-    magicnet_enable_dns_capture || true
-    magicnet_enable_dns_leak_guard || true
+    magicnet_singbox_apply_hotspot_policy || _deferred_rc=1
+    if [ "$_deferred_rc" -ne 0 ]; then
+        # A partially applied configuration must not leave stale interception
+        # or leak-guard rules pointing at a failed DNS/core setup.
+        magicnet_disable_dns_capture || true
+        magicnet_disable_dns_leak_guard || true
+        unset _deferred_rc
+        return 1
+    fi
+    magicnet_enable_dns_capture || _deferred_rc=1
+    magicnet_enable_dns_leak_guard || _deferred_rc=1
+    _deferred_result="$_deferred_rc"
+    if [ "$_deferred_rc" -ne 0 ]; then
+        magicnet_disable_dns_capture || true
+        magicnet_disable_dns_leak_guard || true
+    fi
+    unset _deferred_rc
+    return "$_deferred_result"
 }
 
 magicnet_after_kernel_start_deferred() {

--- a/webui/dns-test-summary.test.mjs
+++ b/webui/dns-test-summary.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "./node_modules/typescript/lib/typescript.js";
+
+function transpile(source) {
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText;
+}
+
+const dir = await mkdtemp(join(tmpdir(), "magicnet-dns-summary-"));
+try {
+  const tone = readFileSync(new URL("./src/lib/statusTone.ts", import.meta.url), "utf8");
+  await writeFile(join(dir, "statusTone.mjs"), transpile(tone), "utf8");
+  const source = readFileSync(new URL("./src/components/pages/dnsTestSummary.ts", import.meta.url), "utf8")
+    .replace(/from\s+["']@\/lib\/statusTone["']/g, 'from "./statusTone.mjs"');
+  await writeFile(join(dir, "dnsTestSummary.mjs"), transpile(source), "utf8");
+  const summary = await import(pathToFileURL(join(dir, "dnsTestSummary.mjs")).href);
+
+  const httpError = summary.parseDnsTestSummary(
+    "domain=https://www.gstatic.com/\nhttp_code=404\nremote_ip=203.0.113.10\ntime_total=0.42\n",
+  );
+  assert.equal(httpError.httpStatus, 404);
+  assert.equal(httpError.issueCount, 0);
+  assert.equal(httpError.status, "warn");
+  assert.match(httpError.summary, /DNS\/网络链路可达/);
+  assert.match(summary.formatDnsTestReport(httpError, "default", "bootstrap", "", "default", "raw"), /http_code=404/);
+
+  const transportError = summary.parseDnsTestSummary(
+    "domain=https://example.invalid/\nhttp_code=000\nremote_ip=\ntime_total=6.00\ncurl: (6) Could not resolve host\n",
+  );
+  assert.equal(transportError.httpStatus, 0);
+  assert.equal(transportError.status, "fail");
+  assert.equal(transportError.issueCount, 1);
+} finally {
+  await rm(dir, { recursive: true, force: true });
+}
+
+console.log("dns test summary tests passed");

--- a/webui/runtime-log-insights.test.mjs
+++ b/webui/runtime-log-insights.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "./node_modules/typescript/lib/typescript.js";
+
+function transpile(source) {
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText;
+}
+
+const root = new URL("./src/", import.meta.url);
+const dir = await mkdtemp(join(tmpdir(), "magicnet-runtime-log-"));
+try {
+  const tone = readFileSync(new URL("./lib/statusTone.ts", root), "utf8");
+  const drafts = readFileSync(new URL("./composables/issueDrafts.ts", root), "utf8");
+  const source = readFileSync(new URL("./components/pages/runtimeLogInsights.ts", root), "utf8")
+    .replace(/from\s+["']@\/lib\/statusTone["']/g, 'from "./statusTone.mjs"')
+    .replace(/from\s+["']@\/composables\/issueDrafts["']/g, 'from "./issueDrafts.mjs"');
+  await Promise.all([
+    writeFile(join(dir, "statusTone.mjs"), transpile(tone), "utf8"),
+    writeFile(join(dir, "issueDrafts.mjs"), transpile(drafts), "utf8"),
+    writeFile(join(dir, "runtimeLogInsights.mjs"), transpile(source), "utf8"),
+  ]);
+  const insights = await import(pathToFileURL(join(dir, "runtimeLogInsights.mjs")).href);
+  const issue = "ERROR connection from 192.0.2.7:443 to https://private.example.invalid/path?token=secret";
+  const report = insights.formatRuntimeLogIssueReport({
+    target: "sing-box",
+    lines: [issue],
+    issueLines: [issue],
+    warningCount: 0,
+    errorCount: 1,
+    otherIssueCount: 0,
+  });
+  assert.doesNotMatch(report, /192\.0\.2\.7|private\.example\.invalid|token=secret/);
+  assert.match(report, /\[filtered-ip\]/);
+  assert.match(report, /\[filtered-url\]/);
+  const insight = insights.buildRuntimeLogInsight([issue], 0, 1, [issue]);
+  assert.doesNotMatch(insight.lastIssue, /192\.0\.2\.7|private\.example\.invalid/);
+} finally {
+  await rm(dir, { recursive: true, force: true });
+}
+
+console.log("runtime log insight tests passed");

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -508,7 +508,7 @@ onUnmounted(() => {
           :key="item.key"
           :data-tab="item.key"
           :class="[
-            'flex min-h-11 min-w-0 items-center gap-3 rounded-[0.85rem] px-3 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.98]',
+            'flex min-h-11 min-w-0 items-center gap-3 whitespace-nowrap rounded-[0.85rem] px-3 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.98]',
             activeTab === item.key ? 'mn-nav-active' : 'mn-nav-idle',
           ]"
           type="button"
@@ -525,7 +525,7 @@ onUnmounted(() => {
           :key="item.key"
           :data-tab="item.key"
           :class="[
-            'flex min-h-11 min-w-0 items-center gap-3 rounded-[0.85rem] px-3 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.98]',
+            'flex min-h-11 min-w-0 items-center gap-3 whitespace-nowrap rounded-[0.85rem] px-3 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.98]',
             activeTab === item.key ? 'mn-nav-advanced-active' : 'mn-nav-idle',
           ]"
           type="button"
@@ -561,7 +561,7 @@ onUnmounted(() => {
         :key="item.key"
         :data-tab="item.key"
         :class="[
-          'flex min-h-11 min-w-0 flex-col items-center justify-center gap-0.5 rounded-[0.85rem] px-1 text-[10px] font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.95]',
+          'flex min-h-11 min-w-0 flex-col items-center justify-center gap-0.5 whitespace-nowrap rounded-[0.85rem] px-1 text-[10px] font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.95]',
           activeTab === item.key ? 'mn-nav-active' : 'mn-nav-idle',
         ]"
         type="button"
@@ -574,7 +574,7 @@ onUnmounted(() => {
       <button
         ref="advancedNavTrigger"
         :class="[
-          'flex min-h-11 min-w-0 flex-col items-center justify-center gap-0.5 rounded-[0.85rem] px-1 text-[10px] font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.95]',
+          'flex min-h-11 min-w-0 flex-col items-center justify-center gap-0.5 whitespace-nowrap rounded-[0.85rem] px-1 text-[10px] font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.95]',
           activeAdvancedTab ? 'mn-nav-advanced-active' : 'mn-nav-idle',
         ]"
         type="button"

--- a/webui/src/components/pages/AppsPage.vue
+++ b/webui/src/components/pages/AppsPage.vue
@@ -443,8 +443,8 @@ onMounted(() => {
     <Card class="grid gap-3">
       <div class="flex flex-wrap items-center gap-3">
         <div class="inline-flex w-fit rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] p-1">
-          <button class="min-h-12 rounded px-3 text-sm font-medium text-[var(--mn-ink-muted)] transition-colors disabled:cursor-progress disabled:opacity-60" :disabled="isRunning('mode-blacklist') || state.appPolicy.mode === 'blacklist'" :class="{ 'bg-[var(--mn-cactus)] text-[var(--mn-on-accent)]': state.appPolicy.mode === 'blacklist' }" @click="requestSetMode('blacklist')">全局接管</button>
-          <button class="min-h-12 rounded px-3 text-sm font-medium text-[var(--mn-ink-muted)] transition-colors disabled:cursor-progress disabled:opacity-60" :disabled="isRunning('mode-whitelist') || state.appPolicy.mode === 'whitelist'" :class="{ 'bg-[var(--mn-cactus)] text-[var(--mn-on-accent)]': state.appPolicy.mode === 'whitelist' }" @click="requestSetMode('whitelist')">仅名单接管</button>
+          <button class="min-h-12 whitespace-nowrap rounded px-3 text-sm font-medium text-[var(--mn-ink-muted)] transition-colors disabled:cursor-progress disabled:opacity-60" :disabled="isRunning('mode-blacklist') || state.appPolicy.mode === 'blacklist'" :class="{ 'bg-[var(--mn-cactus)] text-[var(--mn-on-accent)]': state.appPolicy.mode === 'blacklist' }" @click="requestSetMode('blacklist')">全局接管</button>
+          <button class="min-h-12 whitespace-nowrap rounded px-3 text-sm font-medium text-[var(--mn-ink-muted)] transition-colors disabled:cursor-progress disabled:opacity-60" :disabled="isRunning('mode-whitelist') || state.appPolicy.mode === 'whitelist'" :class="{ 'bg-[var(--mn-cactus)] text-[var(--mn-on-accent)]': state.appPolicy.mode === 'whitelist' }" @click="requestSetMode('whitelist')">仅名单接管</button>
         </div>
         <span class="text-sm text-[var(--mn-ink-muted)]">
           {{ state.appPolicy.mode === 'whitelist'

--- a/webui/src/components/pages/DnsToolsCard.vue
+++ b/webui/src/components/pages/DnsToolsCard.vue
@@ -209,9 +209,10 @@ transport={{ state.dns.transport }}</pre>
         <p class="text-sm font-semibold">DNS 测试摘要</p>
         <p class="mt-1 text-sm leading-6 opacity-80">{{ dnsSummary.summary }}</p>
       </div>
-      <div class="grid gap-2 text-xs text-[var(--mn-ink-muted)] sm:grid-cols-4">
+      <div class="grid gap-2 text-xs text-[var(--mn-ink-muted)] sm:grid-cols-5">
         <span>{{ dnsSummary.lineCount }} 行输出</span>
         <span>{{ dnsSummary.issueCount }} 条问题线索</span>
+        <span>http_code={{ dnsSummary.httpStatus ?? "none" }}</span>
         <span>remote_ip={{ dnsSummary.remoteIp || "none" }}</span>
         <span>time={{ dnsSummary.timeTotalMillis ?? "none" }}ms</span>
       </div>

--- a/webui/src/components/pages/dnsTestSummary.ts
+++ b/webui/src/components/pages/dnsTestSummary.ts
@@ -3,6 +3,7 @@ export type DnsTestSummary = {
   lineCount: number;
   issueCount: number;
   domain: string;
+  httpStatus: number | null;
   remoteIp: string;
   timeTotalMillis: number | null;
   status: "ok" | "warn" | "fail" | "idle";
@@ -16,18 +17,20 @@ export function parseDnsTestSummary(text: string, fallbackDomain = ""): DnsTestS
   const lines = text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
   const fields = parseFields(lines);
   const issueLines = lines.filter((line) => ISSUE_PATTERN.test(line));
+  const httpStatus = parseHttpStatus(fields.http_code || "");
   const remoteIp = fields.remote_ip || "";
   const timeTotalMillis = parseSecondsToMillis(fields.time_total || "");
   const domain = cleanDomain(fields.domain || fallbackDomain);
-  const status = dnsStatus(lines.length, issueLines.length, remoteIp, timeTotalMillis);
+  const status = dnsStatus(lines.length, issueLines.length, httpStatus, remoteIp, timeTotalMillis);
   return {
     lineCount: lines.length,
     issueCount: issueLines.length,
     domain,
+    httpStatus,
     remoteIp,
     timeTotalMillis,
     status,
-    summary: dnsSummary(status, domain, remoteIp, timeTotalMillis, issueLines.length),
+    summary: dnsSummary(status, domain, httpStatus, remoteIp, timeTotalMillis, issueLines.length),
     issueLines
   };
 }
@@ -40,6 +43,7 @@ export function formatDnsTestReport(summary: DnsTestSummary, profile: string, pr
     `secondary=${secondary || "-"}`,
     `transport=${transport}`,
     `domain=${summary.domain || "unknown"}`,
+    `http_code=${summary.httpStatus ?? "none"}`,
     `remote_ip=${summary.remoteIp || "none"}`,
     `time_total_ms=${summary.timeTotalMillis ?? "none"}`,
     `status=${summary.status}`,
@@ -67,20 +71,29 @@ function parseSecondsToMillis(value: string): number | null {
   return Math.round(Number(value) * 1000);
 }
 
+function parseHttpStatus(value: string): number | null {
+  if (!/^\d{3}$/.test(value)) return null;
+  return Number(value);
+}
+
 function cleanDomain(value: string): string {
   return value.replace(/^https?:\/\//i, "").replace(/\/.*$/, "");
 }
 
-function dnsStatus(lineCount: number, issueCount: number, remoteIp: string, timeTotalMillis: number | null): DnsTestSummary["status"] {
+function dnsStatus(lineCount: number, issueCount: number, httpStatus: number | null, remoteIp: string, timeTotalMillis: number | null): DnsTestSummary["status"] {
   if (!lineCount) return "idle";
   if (!remoteIp || issueCount) return "fail";
+  if (httpStatus !== null && httpStatus >= 400) return "warn";
   if (timeTotalMillis !== null && timeTotalMillis > 2500) return "warn";
   return "ok";
 }
 
-function dnsSummary(status: DnsTestSummary["status"], domain: string, remoteIp: string, timeTotalMillis: number | null, issueCount: number): string {
+function dnsSummary(status: DnsTestSummary["status"], domain: string, httpStatus: number | null, remoteIp: string, timeTotalMillis: number | null, issueCount: number): string {
   if (status === "idle") return "尚未运行 DNS 测试。";
   if (status === "fail") return issueCount ? `发现 ${issueCount} 条 DNS/连接问题线索。` : "未解析到 remote_ip，DNS 或 HTTPS 连通性需要检查。";
+  if (httpStatus !== null && httpStatus >= 400) {
+    return `${domain || "目标域名"} 已解析到 ${remoteIp}，但 HTTPS 返回 HTTP ${httpStatus}；DNS/网络链路可达。`;
+  }
   if (status === "warn") return `${domain || "目标域名"} 解析到 ${remoteIp}，但总耗时 ${timeTotalMillis}ms 偏高。`;
   return `${domain || "目标域名"} 解析到 ${remoteIp}，总耗时 ${timeTotalMillis ?? "未知"}ms。`;
 }

--- a/webui/src/components/pages/runtimeLogInsights.ts
+++ b/webui/src/components/pages/runtimeLogInsights.ts
@@ -1,4 +1,4 @@
-import { sanitizeOutputText } from "./outputDiagnostics";
+import { sanitizeDiagnosticText } from "@/composables/issueDrafts";
 import { statusToneClasses } from "@/lib/statusTone";
 
 export type RuntimeLogInsight = {
@@ -26,7 +26,7 @@ export function buildRuntimeLogInsight(lines: string[], warningCount: number, er
       lastIssue: ""
     };
   }
-  const lastIssue = sanitizeOutputText(issueLines.at(-1) || "");
+  const lastIssue = sanitizeDiagnosticText(issueLines.at(-1) || "");
   if (errorCount) {
     return {
       status: "error",
@@ -68,7 +68,7 @@ export function formatRuntimeLogIssueReport(input: RuntimeLogIssueReportInput): 
     `errors=${input.errorCount}`,
     `other_issues=${input.otherIssueCount}`,
     "",
-    ...input.issueLines.map((line) => sanitizeOutputText(line))
+    ...input.issueLines.map((line) => sanitizeDiagnosticText(line))
   ].join("\n").trim();
 }
 

--- a/webui/ui-layout-regression.test.mjs
+++ b/webui/ui-layout-regression.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const app = readFileSync(new URL("./src/App.vue", import.meta.url), "utf8");
+const apps = readFileSync(new URL("./src/components/pages/AppsPage.vue", import.meta.url), "utf8");
+
+assert.match(app, /desktop-rail[\s\S]*whitespace-nowrap/, "desktop navigation labels must stay on one line");
+assert.match(app, /mobile-nav[\s\S]*whitespace-nowrap/, "mobile navigation labels must stay on one line");
+assert.match(apps, /min-h-12 whitespace-nowrap[\s\S]*全局接管/);
+assert.match(apps, /min-h-12 whitespace-nowrap[\s\S]*仅名单接管/);
+
+console.log("UI layout regression tests passed");


### PR DESCRIPTION
## What changed
- Treat HTTP error responses as reachable DNS/HTTPS diagnostics instead of curl transport failures.
- Fail closed and disable DNS interception/leak-guard controls when deferred startup configuration partially fails.
- Keep navigation and app-policy labels on one line across desktop and mobile layouts.
- Reuse the shared diagnostic sanitizer for runtime-log summaries.
- Add routing, DNS summary, runtime-log privacy, and layout regression tests.

## Validation
- `bash scripts/test-action-routing.sh`
- `bash scripts/test-app-routing-policy.sh`
- `node --test dns-test-summary.test.mjs runtime-log-insights.test.mjs ui-layout-regression.test.mjs`
- `npm test` (26 passed)
- `npm run typecheck`
- `cargo test -p magicnet-cli` (303 passed)

The repository pre-commit hook completed once but a duplicate invocation was stopped after it continued running the same long fake-Magisk path.

## Summary by Sourcery

通过将 HTTP 错误响应视为可达端点、在部分延迟配置失败时默认关闭相关功能，以及收紧隐私和布局保证，从而强化 DNS 诊断、路由行为以及 UI/布局。

New Features:
- 在 DNS 测试摘要和报告中暴露 HTTP 状态码，以提供更清晰的 DNS/HTTPS 诊断。
- 为 DNS 摘要解析、运行时日志隐私过滤，以及 UI 导航/应用策略布局添加回归测试。
- 扩展针对 ChatGPT 语音/认证域名的路由回归覆盖，确保优先使用包级路由（package-first routes）。

Bug Fixes:
- 确保延迟启动配置失败时会禁用 DNS 拦截和泄露防护控制，而不是让它们处于部分启用状态。
- 在 DNS 测试中将 HTTP 4xx/5xx 响应视为传输成功，仅将 DNS/连接/TLS 错误视为失败。
- 在桌面和移动布局中保持导航和应用策略模式标签为单行显示，避免换行导致的回归问题。
- 对运行时日志洞察和问题报告应用共享的诊断脱敏逻辑，防止在摘要中泄露 IP 和 URL。

Enhancements:
- 优化延迟配置处理逻辑，将失败状态从 DNS、透明代理、应用策略、warp 和热点（hotspot）应用步骤中进行传递。
- 改进 DNS 测试状态分类和摘要，以区分传输失败与 HTTP 错误响应。
- 将运行时配置接入应用路由策略测试，以获得更完整的启动行为覆盖。

Tests:
- 添加针对 DNS 测试摘要在 HTTP 错误与传输错误场景下行为的专项测试。
- 添加运行时日志洞察测试，用于验证对敏感 IP 和 URL 数据的诊断脱敏处理。
- 添加 UI 布局回归测试，确保导航和应用策略模式控件不会发生换行。
- 扩展动作路由测试，覆盖 ChatGPT 语音/认证域名，并确认预期的出站路径选择。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden DNS diagnostics, routing behavior, and UI/layout by treating HTTP error responses as reachable endpoints, failing closed on partial deferred configuration, and tightening privacy and layout guarantees.

New Features:
- Expose HTTP status in DNS test summaries and reports for clearer DNS/HTTPS diagnostics.
- Add regression tests for DNS summary parsing, runtime log privacy filtering, and UI navigation/app-policy layout.
- Extend routing regression coverage for ChatGPT voice/auth domains to ensure package-first routes are preserved.

Bug Fixes:
- Ensure deferred startup configuration failures disable DNS interception and leak-guard controls instead of leaving them partially enabled.
- Treat HTTP 4xx/5xx responses as successful transport for DNS tests, reserving failures for DNS/connect/TLS errors.
- Keep navigation and app-policy mode labels on a single line across desktop and mobile layouts to avoid wrapping regressions.
- Apply shared diagnostic sanitization to runtime log insights and issue reports to prevent leaking IPs and URLs in summaries.

Enhancements:
- Refine deferred configuration handling to propagate failure status from DNS, transparent, app-policy, warp, and hotspot application steps.
- Improve DNS test status classification and summaries to distinguish transport failures from HTTP error responses.
- Wire runtime configuration into app routing policy tests for more complete startup behavior coverage.

Tests:
- Add dedicated tests for DNS test summary behavior on HTTP vs transport errors.
- Add runtime log insight tests verifying diagnostic sanitization of sensitive IP and URL data.
- Add UI layout regression tests enforcing non-wrapping navigation and app-policy mode controls.
- Extend action routing tests to cover ChatGPT voice/auth domains and confirm expected outbound selection.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过将 HTTP 错误响应视为可达端点、在部分延迟配置失败时默认关闭相关功能，以及收紧隐私和布局保证，从而强化 DNS 诊断、路由行为以及 UI/布局。

New Features:
- 在 DNS 测试摘要和报告中暴露 HTTP 状态码，以提供更清晰的 DNS/HTTPS 诊断。
- 为 DNS 摘要解析、运行时日志隐私过滤，以及 UI 导航/应用策略布局添加回归测试。
- 扩展针对 ChatGPT 语音/认证域名的路由回归覆盖，确保优先使用包级路由（package-first routes）。

Bug Fixes:
- 确保延迟启动配置失败时会禁用 DNS 拦截和泄露防护控制，而不是让它们处于部分启用状态。
- 在 DNS 测试中将 HTTP 4xx/5xx 响应视为传输成功，仅将 DNS/连接/TLS 错误视为失败。
- 在桌面和移动布局中保持导航和应用策略模式标签为单行显示，避免换行导致的回归问题。
- 对运行时日志洞察和问题报告应用共享的诊断脱敏逻辑，防止在摘要中泄露 IP 和 URL。

Enhancements:
- 优化延迟配置处理逻辑，将失败状态从 DNS、透明代理、应用策略、warp 和热点（hotspot）应用步骤中进行传递。
- 改进 DNS 测试状态分类和摘要，以区分传输失败与 HTTP 错误响应。
- 将运行时配置接入应用路由策略测试，以获得更完整的启动行为覆盖。

Tests:
- 添加针对 DNS 测试摘要在 HTTP 错误与传输错误场景下行为的专项测试。
- 添加运行时日志洞察测试，用于验证对敏感 IP 和 URL 数据的诊断脱敏处理。
- 添加 UI 布局回归测试，确保导航和应用策略模式控件不会发生换行。
- 扩展动作路由测试，覆盖 ChatGPT 语音/认证域名，并确认预期的出站路径选择。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden DNS diagnostics, routing behavior, and UI/layout by treating HTTP error responses as reachable endpoints, failing closed on partial deferred configuration, and tightening privacy and layout guarantees.

New Features:
- Expose HTTP status in DNS test summaries and reports for clearer DNS/HTTPS diagnostics.
- Add regression tests for DNS summary parsing, runtime log privacy filtering, and UI navigation/app-policy layout.
- Extend routing regression coverage for ChatGPT voice/auth domains to ensure package-first routes are preserved.

Bug Fixes:
- Ensure deferred startup configuration failures disable DNS interception and leak-guard controls instead of leaving them partially enabled.
- Treat HTTP 4xx/5xx responses as successful transport for DNS tests, reserving failures for DNS/connect/TLS errors.
- Keep navigation and app-policy mode labels on a single line across desktop and mobile layouts to avoid wrapping regressions.
- Apply shared diagnostic sanitization to runtime log insights and issue reports to prevent leaking IPs and URLs in summaries.

Enhancements:
- Refine deferred configuration handling to propagate failure status from DNS, transparent, app-policy, warp, and hotspot application steps.
- Improve DNS test status classification and summaries to distinguish transport failures from HTTP error responses.
- Wire runtime configuration into app routing policy tests for more complete startup behavior coverage.

Tests:
- Add dedicated tests for DNS test summary behavior on HTTP vs transport errors.
- Add runtime log insight tests verifying diagnostic sanitization of sensitive IP and URL data.
- Add UI layout regression tests enforcing non-wrapping navigation and app-policy mode controls.
- Extend action routing tests to cover ChatGPT voice/auth domains and confirm expected outbound selection.

</details>

</details>