### PR TITLE
fix: resolve app routing and upgrade WebUI diagnostics

### DIFF
--- a/crates/magicnet-cli/src/dns.rs
+++ b/crates/magicnet-cli/src/dns.rs
@@ -6,6 +6,7 @@ use crate::service::restart_current_core;
 use crate::{run_magicnet_function, write_text_file, App};
 
 const DNS_CONF: &str = ".config/magicnet/dns.conf";
+const DNS_TEST_PROXY: &str = "http://127.0.0.1:7892";
 
 pub(crate) fn dns_cmd(app: &App, args: &[String]) -> Result<(), String> {
     match args.first().map(String::as_str).unwrap_or("status") {
@@ -27,21 +28,7 @@ fn dns_test(domain: &str) -> Result<(), String> {
     let domain = normalize_test_domain(domain)?;
     let url = format!("https://{domain}/");
     let output = Command::new("curl")
-        .args([
-            // A DNS/transport probe must not fail merely because a healthy
-            // endpoint returns HTTP 4xx/5xx (for example, www.gstatic.com/
-            // commonly returns 404).  Curl still fails on DNS, connect, and
-            // TLS errors, which are the failures this command is intended to
-            // report.
-            "-sS",
-            "--max-time",
-            "6",
-            "-o",
-            "/dev/null",
-            "-w",
-            "domain=%{url_effective}\nhttp_code=%{http_code}\nremote_ip=%{remote_ip}\ntime_total=%{time_total}\n",
-            &url,
-        ])
+        .args(dns_test_curl_args(&url))
         .output()
         .map_err(|err| format!("run curl: {err}"))?;
     print!("{}", String::from_utf8_lossy(&output.stdout));
@@ -50,6 +37,29 @@ fn dns_test(domain: &str) -> Result<(), String> {
     } else {
         Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
     }
+}
+
+fn dns_test_curl_args(url: &str) -> Vec<&str> {
+    vec![
+        // Root is deliberately outside the magicnet0 TUN boundary. Route the
+        // probe through MagicNet's loopback mixed inbound so it exercises the
+        // same managed DNS and outbound path as proxied applications.
+        "--noproxy",
+        "",
+        "-x",
+        DNS_TEST_PROXY,
+        // A DNS/transport probe must not fail merely because a healthy
+        // endpoint returns HTTP 4xx/5xx (for example, www.gstatic.com/
+        // commonly returns 404). Curl still fails on DNS, connect, and TLS.
+        "-sS",
+        "--max-time",
+        "6",
+        "-o",
+        "/dev/null",
+        "-w",
+        "domain=%{url_effective}\nhttp_code=%{http_code}\nremote_ip=%{remote_ip}\ntime_total=%{time_total}\n",
+        url,
+    ]
 }
 
 fn dns_status(app: &App) {
@@ -143,7 +153,7 @@ fn dns_usage() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_test_domain;
+    use super::{dns_test_curl_args, normalize_test_domain, DNS_TEST_PROXY};
 
     #[test]
     fn dns_test_domain_rejects_urls_and_shell_fragments() {
@@ -151,5 +161,12 @@ mod tests {
         assert!(normalize_test_domain("https://example.com").is_err());
         assert!(normalize_test_domain("example.com;id").is_err());
         assert!(normalize_test_domain("localhost").is_err());
+    }
+
+    #[test]
+    fn dns_test_curl_uses_local_proxy_for_root_callers() {
+        let args = dns_test_curl_args("https://www.gstatic.com/");
+        assert!(args.windows(2).any(|pair| pair == ["--noproxy", ""]));
+        assert!(args.windows(2).any(|pair| pair == ["-x", DNS_TEST_PROXY]));
     }
 }

--- a/crates/magicnet-cli/src/dns.rs
+++ b/crates/magicnet-cli/src/dns.rs
@@ -57,7 +57,7 @@ fn dns_test_curl_args(url: &str) -> Vec<&str> {
         "-o",
         "/dev/null",
         "-w",
-        "domain=%{url_effective}\nhttp_code=%{http_code}\nremote_ip=%{remote_ip}\ntime_total=%{time_total}\n",
+        "domain=%{url_effective}\nprobe_path=magicnet-mixed\nhttp_code=%{http_code}\nproxy_ip=%{remote_ip}\ntime_total=%{time_total}\n",
         url,
     ]
 }
@@ -168,5 +168,13 @@ mod tests {
         let args = dns_test_curl_args("https://www.gstatic.com/");
         assert!(args.windows(2).any(|pair| pair == ["--noproxy", ""]));
         assert!(args.windows(2).any(|pair| pair == ["-x", DNS_TEST_PROXY]));
+        let write_out = args
+            .windows(2)
+            .find(|pair| pair[0] == "-w")
+            .map(|pair| pair[1])
+            .expect("curl write-out format");
+        assert!(write_out.contains("\nprobe_path=magicnet-mixed\n"));
+        assert!(write_out.contains("\nproxy_ip=%{remote_ip}\n"));
+        assert!(!write_out.contains("\nremote_ip="));
     }
 }

--- a/hooks/pre-build/5460.update_chatgpt_voice_rules.sh
+++ b/hooks/pre-build/5460.update_chatgpt_voice_rules.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# shellcheck source=hooks/lib/utils.sh
+
+set -euo pipefail
+
+. "$KAM_HOOKS_ROOT/lib/utils.sh"
+
+require_command curl "curl not found!"
+require_command jq "jq not found!"
+require_command python3 "python3 not found!"
+
+CONFIG_FILE="$KAM_MODULE_ROOT/.config/sing-box/config.json"
+STATE_DIR="$KAM_MODULE_ROOT/.local/state/chatgpt-voice"
+VOICE_URL="${MAGICNET_CHATGPT_VOICE_URL:-https://openai.com/chatgpt-voice.json}"
+
+[ -f "$CONFIG_FILE" ] || {
+    log_warn "sing-box config not found; ChatGPT Voice rule update skipped"
+    exit 0
+}
+
+mkdir -p "$STATE_DIR"
+VOICE_RESPONSE="$STATE_DIR/voice.json.tmp.$$"
+CONFIG_CANDIDATE="$STATE_DIR/config.json.tmp.$$"
+
+cleanup() {
+    rm -f "$VOICE_RESPONSE" "$CONFIG_CANDIDATE"
+}
+trap cleanup EXIT HUP INT TERM
+
+log_info "Refreshing ChatGPT Voice IP prefixes from OpenAI"
+curl -fsSL --retry 3 --retry-delay 1 "$VOICE_URL" -o "$VOICE_RESPONSE" || {
+    log_error "ChatGPT Voice prefix download failed"
+    exit 1
+}
+
+jq -e '
+  type == "object"
+  and (.creationTime | type == "string" and length > 0)
+  and (.prefixes | type == "array" and length > 0)
+  and all(.prefixes[];
+    type == "object"
+    and ((has("ipv4Prefix") and (has("ipv6Prefix") | not))
+      or (has("ipv6Prefix") and (has("ipv4Prefix") | not)))
+    and ((.ipv4Prefix // .ipv6Prefix) | type == "string")
+    and ((.ipv4Prefix // .ipv6Prefix) | test("^[0-9A-Fa-f:.]+/[0-9]{1,3}$"))
+  )
+' "$VOICE_RESPONSE" >/dev/null || {
+    log_error "ChatGPT Voice prefix response is invalid or empty"
+    exit 1
+}
+
+python3 - "$VOICE_RESPONSE" <<'PY' || {
+import ipaddress
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    response = json.load(handle)
+
+for item in response["prefixes"]:
+    ipaddress.ip_network(item.get("ipv4Prefix") or item["ipv6Prefix"], strict=True)
+PY
+    log_error "ChatGPT Voice response contains an invalid IP prefix"
+    exit 1
+}
+
+jq --slurpfile voice "$VOICE_RESPONSE" '
+  ($voice[0].prefixes
+    | map(.ipv4Prefix // .ipv6Prefix)
+    | reduce .[] as $prefix ([]; if index($prefix) == null then . + [$prefix] else . end)
+  ) as $prefixes
+  | ([.route.rules | to_entries[]
+      | select(
+          .value.network == "udp"
+          and .value.port == 3478
+          and .value.outbound == "ai-chatgpt"
+          and (.value.ip_cidr | type) == "array"
+        )]) as $voice_rules
+  | if ($voice_rules | length) != 1
+    then error("expected exactly one canonical ChatGPT Voice route")
+    else .route.rules[$voice_rules[0].key].ip_cidr = $prefixes
+    end
+' "$CONFIG_FILE" >"$CONFIG_CANDIDATE" || {
+    log_error "Canonical ChatGPT Voice route is missing or ambiguous"
+    exit 1
+}
+
+jq empty "$CONFIG_CANDIDATE"
+if cmp -s "$CONFIG_FILE" "$CONFIG_CANDIDATE"; then
+    log_info "ChatGPT Voice prefixes are already current"
+else
+    mv "$CONFIG_CANDIDATE" "$CONFIG_FILE"
+    log_success "ChatGPT Voice prefixes updated"
+fi
+jq -r '.creationTime' "$VOICE_RESPONSE" >"$STATE_DIR/creation-time"

--- a/scripts/package-smoke.sh
+++ b/scripts/package-smoke.sh
@@ -271,6 +271,7 @@ jq -e '
 
 python3 - "$ZIP_PATH" <<'PY'
 import functools
+import ipaddress
 import json
 import os
 import posixpath
@@ -1404,6 +1405,35 @@ ai_domain_routes = {
 for outbound, required_domains in ai_domain_routes.items():
     if find_rule(route_rules, required_domains, outbound=outbound) < 0:
         raise SystemExit(f"missing dedicated domain route for {outbound}")
+
+if config.get("dns", {}).get("reverse_mapping") is not True:
+    raise SystemExit("packaged DNS must preserve reverse mappings for IP-only app flows")
+
+chatgpt_voice_routes = [
+    (index, rule)
+    for index, rule in enumerate(route_rules)
+    if rule.get("network") == "udp"
+    and rule.get("port") == 3478
+    and rule.get("outbound") == "ai-chatgpt"
+    and set(rule) == {"network", "port", "ip_cidr", "outbound"}
+]
+if len(chatgpt_voice_routes) != 1:
+    raise SystemExit(f"packaged ChatGPT Voice route is non-canonical: {chatgpt_voice_routes}")
+voice_index, voice_rule = chatgpt_voice_routes[0]
+if not voice_rule["ip_cidr"]:
+    raise SystemExit("packaged ChatGPT Voice route has no official IP prefixes")
+for prefix in voice_rule["ip_cidr"]:
+    ipaddress.ip_network(prefix)
+cn_ip_indexes = [
+    index
+    for index, rule in enumerate(route_rules)
+    if rule.get("outbound") == "cn-direct" and (rule.get("ip_cidr") or rule.get("rule_set"))
+]
+if not cn_ip_indexes or voice_index >= min(cn_ip_indexes):
+    raise SystemExit(
+        f"packaged ChatGPT Voice route must precede CN IP ownership: "
+        f"voice={voice_index} cn={cn_ip_indexes}"
+    )
 
 x_package_routes = [
     index

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -45,6 +45,7 @@ bash scripts/test-wechat-routing.sh
 bash scripts/test-action-routing.sh
 bash scripts/test-anthropic-routing.sh
 bash scripts/test-mcp-phase-config.sh
+bash scripts/test-chatgpt-voice-rules.sh
 bash scripts/test-rule-hash-retry.sh
 bash scripts/singbox-subscription-protocol-smoke.sh
 bash scripts/test-singbox-pid-discovery.sh

--- a/scripts/test-action-routing.sh
+++ b/scripts/test-action-routing.sh
@@ -26,6 +26,11 @@ route_rules = config["route"]["rules"]
 chatgpt_packages = {"com.openai.chatgpt", "com.openai.chat", "ai.openai.chatgpt"}
 x_packages = {"com.twitter.android"}
 
+if config.get("dns", {}).get("reverse_mapping") is not True:
+    raise AssertionError(
+        "DNS reverse_mapping must preserve domain ownership for IP-only Android flows"
+    )
+
 
 def values(value):
     if value is None:
@@ -74,7 +79,14 @@ def package_matches(rule, package_name):
     return not packages or package_name in packages
 
 
-def first_modeled_outbound(domain, destination_ip, package_name):
+def first_modeled_outbound(
+    domain,
+    destination_ip,
+    package_name,
+    *,
+    network="tcp",
+    port=443,
+):
     for index, rule in enumerate(route_rules):
         if "outbound" not in rule:
             continue
@@ -82,10 +94,11 @@ def first_modeled_outbound(domain, destination_ip, package_name):
             continue
         if rule.get("protocol") not in (None, "tls"):
             continue
-        if rule.get("network") not in (None, "tcp"):
+        networks = values(rule.get("network"))
+        if networks and network not in networks:
             continue
         ports = values(rule.get("port"))
-        if ports and 443 not in ports:
+        if ports and port not in ports:
             continue
         if not package_matches(rule, package_name):
             continue
@@ -125,6 +138,17 @@ for domain in ("api.x.com", "upload.twitter.com", "abs.twimg.com"):
             f"index={index} outbound={outbound}"
         )
 
+    mapped_index, mapped_outbound = first_modeled_outbound(
+        domain,
+        "203.0.113.10",
+        "",
+    )
+    if mapped_outbound != "social-proxy":
+        raise AssertionError(
+            f"reverse-mapped X domain {domain} did not select social-proxy: "
+            f"index={mapped_index} outbound={mapped_outbound}"
+        )
+
 for domain in ("api.openai.com", "auth.openai.com", "ws.chatgpt.com", "events.oaistatsig.com"):
     index, outbound = first_modeled_outbound(
         domain,
@@ -136,6 +160,59 @@ for domain in ("api.openai.com", "auth.openai.com", "ws.chatgpt.com", "events.oa
             f"ChatGPT voice/auth domain {domain} did not keep the package-first ai-chatgpt route: "
             f"index={index} outbound={outbound}"
         )
+
+    mapped_index, mapped_outbound = first_modeled_outbound(
+        domain,
+        "203.0.113.10",
+        "",
+    )
+    if mapped_outbound != "ai-chatgpt":
+        raise AssertionError(
+            f"reverse-mapped ChatGPT domain {domain} did not select ai-chatgpt: "
+            f"index={mapped_index} outbound={mapped_outbound}"
+        )
+
+voice_rules = [
+    (index, rule)
+    for index, rule in enumerate(route_rules)
+    if rule.get("network") == "udp"
+    and rule.get("port") == 3478
+    and rule.get("outbound") == "ai-chatgpt"
+    and set(rule) == {"network", "port", "ip_cidr", "outbound"}
+]
+if len(voice_rules) != 1:
+    raise AssertionError(f"expected one exact ChatGPT Voice route, got {voice_rules}")
+voice_index, voice_rule = voice_rules[0]
+voice_cidrs = values(voice_rule.get("ip_cidr"))
+if not voice_cidrs:
+    raise AssertionError("ChatGPT Voice route must contain the official IP prefixes")
+for prefix in voice_cidrs:
+    ipaddress.ip_network(prefix)
+
+cn_ip_indexes = [
+    index
+    for index, rule in enumerate(route_rules)
+    if rule.get("outbound") == "cn-direct"
+    and (rule.get("ip_cidr") or rule.get("rule_set"))
+]
+if not cn_ip_indexes or voice_index >= min(cn_ip_indexes):
+    raise AssertionError(
+        f"ChatGPT Voice route must precede CN IP ownership: voice={voice_index} cn={cn_ip_indexes}"
+    )
+
+voice_address = str(ipaddress.ip_network(voice_cidrs[0]).network_address)
+matched_index, matched_outbound = first_modeled_outbound(
+    "",
+    voice_address,
+    "",
+    network="udp",
+    port=3478,
+)
+if (matched_index, matched_outbound) != (voice_index, "ai-chatgpt"):
+    raise AssertionError(
+        "official ChatGPT Voice IP-only flow did not select ai-chatgpt: "
+        f"index={matched_index} outbound={matched_outbound}"
+    )
 
 chatgpt_domain_rules = [
     rule

--- a/scripts/test-chatgpt-voice-rules.sh
+++ b/scripts/test-chatgpt-voice-rules.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$ROOT/hooks/pre-build/5460.update_chatgpt_voice_rules.sh"
+TEST_ROOT="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+    printf 'ChatGPT Voice rule update test failed: %s\n' "$*" >&2
+    exit 1
+}
+
+mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/module/.config/sing-box"
+cat >"$TEST_ROOT/module/.config/sing-box/config.json" <<'JSON'
+{
+  "route": {
+    "rules": [
+      {
+        "network": "udp",
+        "port": 3478,
+        "ip_cidr": ["192.0.2.1/32"],
+        "outbound": "ai-chatgpt"
+      },
+      {"rule_set": ["lyc-geoip-cn"], "outbound": "cn-direct"}
+    ]
+  }
+}
+JSON
+
+cat >"$TEST_ROOT/bin/curl" <<'SH'
+#!/bin/bash
+set -euo pipefail
+output=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o) output="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+[ -n "$output" ] || exit 64
+case "${FAKE_VOICE_RESPONSE:-valid}" in
+    valid)
+        cat >"$output" <<'JSON'
+{"creationTime":"2026-08-10T00:00:00Z","prefixes":[{"ipv4Prefix":"203.0.113.8/32"},{"ipv6Prefix":"2001:db8::8/128"}]}
+JSON
+        ;;
+    invalid) printf '%s\n' '{"creationTime":"2026-08-10T00:00:00Z","prefixes":[]}' >"$output" ;;
+    invalid-prefix) printf '%s\n' '{"creationTime":"2026-08-10T00:00:00Z","prefixes":[{"ipv4Prefix":"999.999.999.999/32"}]}' >"$output" ;;
+    failure) exit 22 ;;
+    *) exit 64 ;;
+esac
+SH
+chmod +x "$TEST_ROOT/bin/curl"
+
+run_hook() {
+    env \
+        PATH="$TEST_ROOT/bin:$PATH" \
+        KAM_HOOKS_ROOT="$ROOT/hooks" \
+        KAM_MODULE_ROOT="$TEST_ROOT/module" \
+        FAKE_VOICE_RESPONSE="$1" \
+        bash "$HOOK"
+}
+
+run_hook valid >/dev/null || fail "valid official response was rejected"
+jq -e '
+  .route.rules[0] == {
+    "network": "udp",
+    "port": 3478,
+    "ip_cidr": ["203.0.113.8/32", "2001:db8::8/128"],
+    "outbound": "ai-chatgpt"
+  }
+  and .route.rules[1] == {"rule_set": ["lyc-geoip-cn"], "outbound": "cn-direct"}
+' "$TEST_ROOT/module/.config/sing-box/config.json" >/dev/null ||
+    fail "valid response was not applied atomically to the canonical rule"
+
+cp "$TEST_ROOT/module/.config/sing-box/config.json" "$TEST_ROOT/before-invalid.json"
+if run_hook invalid >/dev/null 2>&1; then
+    fail "empty official prefix list was accepted"
+fi
+cmp -s "$TEST_ROOT/before-invalid.json" "$TEST_ROOT/module/.config/sing-box/config.json" ||
+    fail "invalid response changed the active config"
+
+if run_hook invalid-prefix >/dev/null 2>&1; then
+    fail "invalid official IP prefix was accepted"
+fi
+cmp -s "$TEST_ROOT/before-invalid.json" "$TEST_ROOT/module/.config/sing-box/config.json" ||
+    fail "invalid IP prefix changed the active config"
+
+if run_hook failure >/dev/null 2>&1; then
+    fail "download failure was accepted"
+fi
+cmp -s "$TEST_ROOT/before-invalid.json" "$TEST_ROOT/module/.config/sing-box/config.json" ||
+    fail "download failure changed the active config"
+
+printf 'ChatGPT Voice rule update test passed\n'

--- a/webui/anthropic-style-contract.test.mjs
+++ b/webui/anthropic-style-contract.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (relativePath) =>
+  readFileSync(new URL(relativePath, import.meta.url), "utf8");
+
+const styles = read("./src/styles.css");
+const app = read("./src/App.vue");
+const button = read("./src/components/ui/Button.vue");
+
+// The named light-theme accents must stay on the verified Anthropic palette.
+for (const [token, value] of [
+  ["clay", "#d97757"],
+  ["olive", "#788c5d"],
+  ["sky", "#6a9bcc"],
+  ["coral", "#ebcece"],
+]) {
+  assert.match(
+    styles,
+    new RegExp(`--mn-${token}:\\s*${value}`, "i"),
+    `light-theme ${token} must use the verified ${value} accent`,
+  );
+}
+
+// Pale accents are surfaces. Small editorial labels use a dedicated contrast-safe ink.
+assert.match(styles, /--mn-clay-ink:/, "clay labels need a separate high-contrast ink token");
+assert.match(
+  button,
+  /bg-\[var\(--mn-clay\)\]\s+text-\[var\(--mn-on-accent\)\]/,
+  "clay buttons must keep near-black marks instead of white text",
+);
+
+// The runtime summary is the page's single editorial field: accent, carrier, then ink.
+assert.match(app, /runtime-cockpit mn-editorial-field/, "runtime summary must use the editorial accent field");
+assert.match(app, /mn-editorial-carrier/, "runtime summary must include an ivory carrier");
+assert.match(styles, /\.mn-editorial-field\s*\{[\s\S]*?background:\s*var\(--mn-cactus\)/);
+assert.match(styles, /\.mn-editorial-carrier\s*\{[\s\S]*?background:\s*var\(--mn-ivory\)/);
+
+// Structural separators stay flat and materially quiet.
+assert.doesNotMatch(styles, /linear-gradient\(/, "shell chrome must not use decorative gradients");
+
+console.log("anthropic style contract tests passed");

--- a/webui/background-tasks.test.mjs
+++ b/webui/background-tasks.test.mjs
@@ -15,6 +15,8 @@ const useMagicNetSource = readFileSync(new URL("./src/composables/useMagicNet.ts
 assert.match(useMagicNetSource, /async function startBackgroundCli[\s\S]*?const operationSequence = trackRedactedOperation\(\s*previewOverride \|\| redactedCliPreview\(displayArgs\),\s*label,\s*\);/);
 assert.match(useMagicNetSource, /function followBackgroundLogs\([\s\S]*?operationSequence: number,[\s\S]*?publishTrackedOperation\(\s*operationSequence,/);
 assert.match(useMagicNetSource, /function followBackgroundLogs[\s\S]*?refreshSubs\(true, false\)/);
+assert.match(useMagicNetSource, /async function startBackgroundCli[\s\S]*?const operationId = createBackgroundOperationId\(\);[\s\S]*?await refreshSubs\(true, false\)/);
+assert.match(useMagicNetSource, /const ownsBackgroundTask = state\.backgroundTask\.id === operationId;[\s\S]*?if \(ownsBackgroundTask\) \{\s*followBackgroundLogs/);
 
 const firstId = createBackgroundOperationId(1000);
 const secondId = createBackgroundOperationId(1000);

--- a/webui/background-tasks.test.mjs
+++ b/webui/background-tasks.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import {
   backgroundAccepted,
   backgroundLaunchCommand,
@@ -9,6 +10,11 @@ import {
   reconcileSubscriptionCompletion,
   subscriptionLifecycleRunning,
 } from "./src/composables/backgroundTasks.ts";
+
+const useMagicNetSource = readFileSync(new URL("./src/composables/useMagicNet.ts", import.meta.url), "utf8");
+assert.match(useMagicNetSource, /async function startBackgroundCli[\s\S]*?const operationSequence = trackRedactedOperation\(\s*previewOverride \|\| redactedCliPreview\(displayArgs\),\s*label,\s*\);/);
+assert.match(useMagicNetSource, /function followBackgroundLogs\([\s\S]*?operationSequence: number,[\s\S]*?publishTrackedOperation\(\s*operationSequence,/);
+assert.match(useMagicNetSource, /function followBackgroundLogs[\s\S]*?refreshSubs\(true, false\)/);
 
 const firstId = createBackgroundOperationId(1000);
 const secondId = createBackgroundOperationId(1000);

--- a/webui/dns-test-summary.test.mjs
+++ b/webui/dns-test-summary.test.mjs
@@ -34,6 +34,19 @@ try {
   assert.match(httpError.summary, /DNS\/网络链路可达/);
   assert.match(summary.formatDnsTestReport(httpError, "default", "bootstrap", "", "default", "raw"), /http_code=404/);
 
+  const proxied = summary.parseDnsTestSummary(
+    "domain=https://chatgpt.com/\nprobe_path=magicnet-mixed\nhttp_code=200\nproxy_ip=127.0.0.1\ntime_total=0.31\n",
+  );
+  assert.equal(proxied.status, "ok");
+  assert.equal(proxied.probePath, "magicnet-mixed");
+  assert.equal(proxied.proxyIp, "127.0.0.1");
+  assert.equal(proxied.remoteIp, "");
+  assert.match(proxied.summary, /MagicNet 混合入口/);
+  const proxiedReport = summary.formatDnsTestReport(proxied, "default", "bootstrap", "", "default", "raw");
+  assert.match(proxiedReport, /probe_path=magicnet-mixed/);
+  assert.match(proxiedReport, /proxy_ip=127\.0\.0\.1/);
+  assert.match(proxiedReport, /remote_ip=none/);
+
   const transportError = summary.parseDnsTestSummary(
     "domain=https://example.invalid/\nhttp_code=000\nremote_ip=\ntime_total=6.00\ncurl: (6) Could not resolve host\n",
   );

--- a/webui/dns-test-summary.test.mjs
+++ b/webui/dns-test-summary.test.mjs
@@ -37,9 +37,16 @@ try {
   const transportError = summary.parseDnsTestSummary(
     "domain=https://example.invalid/\nhttp_code=000\nremote_ip=\ntime_total=6.00\ncurl: (6) Could not resolve host\n",
   );
-  assert.equal(transportError.httpStatus, 0);
+  assert.equal(transportError.httpStatus, null);
   assert.equal(transportError.status, "fail");
   assert.equal(transportError.issueCount, 1);
+
+  for (const invalidCode of ["000", "099", "600", "999"]) {
+    const invalid = summary.parseDnsTestSummary(
+      `domain=https://example.invalid/\nhttp_code=${invalidCode}\nremote_ip=\ntime_total=6.00\n`,
+    );
+    assert.equal(invalid.httpStatus, null, `${invalidCode} is not an HTTP status`);
+  }
 } finally {
   await rm(dir, { recursive: true, force: true });
 }

--- a/webui/issue-reporter.test.mjs
+++ b/webui/issue-reporter.test.mjs
@@ -9,6 +9,7 @@ import {
   sanitizeDiagnosticText,
   summarizeConnectionsForIssue,
 } from "./src/composables/issueDrafts.ts";
+import { redactedCliPreview } from "./src/utils.ts";
 
 const canaries = [
   "https://node.example.invalid/private/path?token=URL-CANARY",
@@ -38,6 +39,7 @@ const body = buildIssueBody(parts);
 assert.equal(body, buildIssueBody(parts), "canonical body must be deterministic");
 assert.ok(body.length <= 5200, "canonical body must fit the URL budget");
 assert.match(body, /## Module/);
+assert.equal((body.match(/## Module/g) || []).length, 1, "canonical body must not duplicate module metadata");
 assert.match(body, /## Device/);
 assert.match(body, /问题类型：命令或操作报错/);
 assert.match(body, /## Focused Context/);
@@ -68,6 +70,20 @@ for (const command of sensitiveCommands) {
   for (const secret of [reviewerBarePassword, "device-serial-123", "private.example.invalid", "token-canary", "secret-canary", "device-id-canary"]) {
     assert.equal(classified.includes(secret), false, `classified command leaked ${secret}`);
   }
+}
+for (const [displayArgs, expected] of [
+  ["app add [package] bypass", "command=app.add arguments=filtered"],
+  ["block add-domain [domain]", "command=block.add-domain arguments=filtered"],
+  ["config-editor get sing-box [private-output]", "command=config-editor.get arguments=filtered"],
+  ["backup export [private-output]", "command=backup.export arguments=filtered"],
+  ["support bundle [private-output]", "command=support.bundle arguments=filtered"],
+  ["webui verify [private-output]", "command=webui.verify arguments=filtered"],
+  ["route list [private-output]", "command=route.list arguments=filtered"],
+  ["api preflight [private-output]", "command=api.preflight arguments=filtered"],
+  ["refresh tools [private-output]", "command=refresh.tools arguments=filtered"],
+  ["open external [filtered-url]", "command=open.external arguments=filtered"],
+]) {
+  assert.equal(classifyOperationCommand(redactedCliPreview(displayArgs)), expected);
 }
 const passwordBody = buildIssueBody({
   ...parts,

--- a/webui/operation-capture.test.mjs
+++ b/webui/operation-capture.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "./node_modules/typescript/lib/typescript.js";
+
+const source = readFileSync(new URL("./src/composables/operationCapture.ts", import.meta.url), "utf8");
+const output = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.ES2022,
+    target: ts.ScriptTarget.ES2022,
+    verbatimModuleSyntax: true,
+  },
+}).outputText;
+
+const dir = await mkdtemp(join(tmpdir(), "magicnet-operation-capture-"));
+try {
+  const modulePath = join(dir, "operationCapture.mjs");
+  await writeFile(modulePath, output, "utf8");
+  const capture = await import(pathToFileURL(modulePath).href);
+  const state = capture.emptyOperationCapture();
+
+  const previous = capture.beginOperationCapture(
+    state,
+    "config-editor.get arguments=filtered",
+    "local_dir=zashboard\nversion=v3.16.0",
+  );
+  const dns = capture.beginOperationCapture(
+    state,
+    "dns.test arguments=filtered",
+    "DNS test running",
+  );
+
+  assert.equal(capture.updateOperationCapture(state, previous, {
+    phase: "done",
+    output: "local_dir=zashboard\nversion=v3.16.0",
+  }), false);
+  assert.equal(state.command, "dns.test arguments=filtered");
+  assert.equal(state.output, "DNS test running");
+
+  assert.equal(capture.updateOperationCapture(state, dns, {
+    phase: "error",
+    output: "curl: (6) Could not resolve host",
+  }), true);
+  assert.equal(state.phase, "error");
+  assert.match(state.output, /Could not resolve host/);
+} finally {
+  await rm(dir, { recursive: true, force: true });
+}
+
+console.log("operation capture tests passed");

--- a/webui/operation-capture.test.mjs
+++ b/webui/operation-capture.test.mjs
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 import ts from "./node_modules/typescript/lib/typescript.js";
 
 const source = readFileSync(new URL("./src/composables/operationCapture.ts", import.meta.url), "utf8");
+const useMagicNetSource = readFileSync(new URL("./src/composables/useMagicNet.ts", import.meta.url), "utf8");
 const output = ts.transpileModule(source, {
   compilerOptions: {
     module: ts.ModuleKind.ES2022,
@@ -56,6 +57,12 @@ try {
     phase: "done",
     output: "stale private output",
   }), false);
+
+  assert.match(useMagicNetSource, /let foregroundTaskSequence = 0;/);
+  assert.match(useMagicNetSource, /const foregroundSequence = quiet \? 0 : \+\+foregroundTaskSequence;/);
+  assert.match(useMagicNetSource, /function releaseForegroundTask\(sequence: number\)[\s\S]*?sequence !== foregroundTaskSequence[\s\S]*?state\.busy = false;[\s\S]*?state\.task = "";/);
+  assert.match(useMagicNetSource, /finally \{\s*releaseForegroundTask\(foregroundSequence\);\s*\}/);
+  assert.doesNotMatch(useMagicNetSource, /state\.operationCapture\.sequence === captureSequence\) \{\s*state\.busy = false;/);
 } finally {
   await rm(dir, { recursive: true, force: true });
 }

--- a/webui/operation-capture.test.mjs
+++ b/webui/operation-capture.test.mjs
@@ -46,6 +46,16 @@ try {
   }), true);
   assert.equal(state.phase, "error");
   assert.match(state.output, /Could not resolve host/);
+
+  const invalidatedSequence = capture.invalidateOperationCapture(state);
+  assert.equal(invalidatedSequence, dns + 1);
+  assert.equal(state.command, "");
+  assert.equal(state.output, "");
+  assert.equal(state.phase, "idle");
+  assert.equal(capture.updateOperationCapture(state, dns, {
+    phase: "done",
+    output: "stale private output",
+  }), false);
 } finally {
   await rm(dir, { recursive: true, force: true });
 }

--- a/webui/private-payload-contract.test.mjs
+++ b/webui/private-payload-contract.test.mjs
@@ -123,6 +123,8 @@ const linksSource = readFileSync(new URL("./src/composables/useExternalLinks.ts"
 for (const source of [toolsSource, subscriptionsSource]) {
   assert.doesNotMatch(source, /secureTempFilePrepareCommand|printf\s+%s|:\s*>|\bcat\s+|\brm\s+-f/);
 }
+assert.match(toolsSource, /const exported = outcome\.ok && Boolean\(payload\);[\s\S]*?state\.phase = exported \? "done" : "error";/);
+assert.match(toolsSource, /const restored = outcome\.ok && outcome\.stdout\.includes\("\[info\] Backup restored"\);[\s\S]*?state\.phase = restored \? "done" : "error";/);
 assert.match(webuiSource, /copyText\(safeCommand\)/);
 assert.doesNotMatch(webuiSource, /\{\{\s*installArgs/);
 assert.match(webuiSource, /startPrivateBackgroundCli/);
@@ -147,7 +149,9 @@ assert.match(installPlanSource, /webui install-local \[filtered-url\] \$\{sha256
 assert.match(linksSource, /isSensitiveExternalUrl\(url\)/);
 assert.match(linksSource, /redactedCliPreview\("open external \[filtered-url\]"\)/);
 assert.match(useMagicNetSource, /async function runPrivateCli[\s\S]*?trackRedactedOperation\(redactedPreview\)[\s\S]*?runShellOutcome/);
+assert.match(useMagicNetSource, /async function runPrivateCli[\s\S]*?state\.phase = outcome\.ok \? "done" : "error"/);
 assert.match(useMagicNetSource, /stagePrivatePayloadWithCli\(\s*runPrivatePayloadCli,/);
+assert.match(useMagicNetSource, /const staged = await stagePrivatePayloadWithCli[\s\S]*?state\.phase = staged \? "done" : "error"/);
 assert.match(useMagicNetSource, /removePrivatePayloadWithCli\(runPrivatePayloadCli,/);
 
 console.log("private payload and signed URL contract tests passed");

--- a/webui/private-payload-contract.test.mjs
+++ b/webui/private-payload-contract.test.mjs
@@ -117,6 +117,7 @@ assert.match(redactedBearerHeaders, /说明/);
 const toolsSource = readFileSync(new URL("./src/components/pages/ToolsPage.vue", import.meta.url), "utf8");
 const subscriptionsSource = readFileSync(new URL("./src/components/pages/SubscriptionsPage.vue", import.meta.url), "utf8");
 const webuiSource = readFileSync(new URL("./src/components/pages/WebuiPage.vue", import.meta.url), "utf8");
+const useMagicNetSource = readFileSync(new URL("./src/composables/useMagicNet.ts", import.meta.url), "utf8");
 const installPlanSource = readFileSync(new URL("./src/components/pages/webuiInstallPlan.ts", import.meta.url), "utf8");
 const linksSource = readFileSync(new URL("./src/composables/useExternalLinks.ts", import.meta.url), "utf8");
 for (const source of [toolsSource, subscriptionsSource]) {
@@ -145,5 +146,8 @@ assert.match(installPlanSource, /isSensitiveExternalUrl\(url\)/);
 assert.match(installPlanSource, /webui install-local \[filtered-url\] \$\{sha256 \|\| "\[sha256\]"\}/);
 assert.match(linksSource, /isSensitiveExternalUrl\(url\)/);
 assert.match(linksSource, /redactedCliPreview\("open external \[filtered-url\]"\)/);
+assert.match(useMagicNetSource, /async function runPrivateCli[\s\S]*?trackRedactedOperation\(redactedPreview\)[\s\S]*?runShellOutcome/);
+assert.match(useMagicNetSource, /stagePrivatePayloadWithCli\(\s*runPrivatePayloadCli,/);
+assert.match(useMagicNetSource, /removePrivatePayloadWithCli\(runPrivatePayloadCli,/);
 
 console.log("private payload and signed URL contract tests passed");

--- a/webui/private-payload-contract.test.mjs
+++ b/webui/private-payload-contract.test.mjs
@@ -153,13 +153,14 @@ assert.match(installPlanSource, /isSensitiveExternalUrl\(url\)/);
 assert.match(installPlanSource, /webui install-local \[filtered-url\] \$\{sha256 \|\| "\[sha256\]"\}/);
 assert.match(linksSource, /isSensitiveExternalUrl\(url\)/);
 assert.match(linksSource, /redactedCliPreview\("open external \[filtered-url\]"\)/);
-assert.match(useMagicNetSource, /async function runTrackedQuietShellOutcome[\s\S]*?trackRedactedOperation\(redactedPreview, label\)[\s\S]*?state\.phase = outcome\.ok \? "done" : "error"/);
-assert.match(useMagicNetSource, /function trackRedactedOperation[\s\S]*?state\.output = `\$ \$\{commandPreview\}\\n执行中；私密输出已隐藏。`/);
+assert.match(useMagicNetSource, /async function runTrackedQuietShellOutcome[\s\S]*?trackRedactedOperation\(redactedPreview, label\)[\s\S]*?publishTrackedOperation\(\s*operationSequence,\s*phase,/);
+assert.match(useMagicNetSource, /function trackRedactedOperation[\s\S]*?const output = `\$ \$\{commandPreview\}\\n执行中；私密输出已隐藏。`[\s\S]*?state\.output = output/);
+assert.match(useMagicNetSource, /function trackRedactedOperation[\s\S]*?beginOperationCapture\(state\.operationCapture, commandPreview, output\)/);
 assert.match(useMagicNetSource, /async function runTrackedQuietShellOutcome[\s\S]*?private output hidden/);
 assert.match(useMagicNetSource, /async function runShell[\s\S]*?quiet && previewOverride[\s\S]*?runTrackedQuietShellOutcome/);
 assert.match(useMagicNetSource, /async function runPrivateCli[\s\S]*?runTrackedQuietShellOutcome/);
 assert.match(useMagicNetSource, /stagePrivatePayloadWithCli\(\s*runPrivatePayloadCli,/);
-assert.match(useMagicNetSource, /const staged = await stagePrivatePayloadWithCli[\s\S]*?state\.phase = staged \? "done" : "error"/);
+assert.match(useMagicNetSource, /const staged = await stagePrivatePayloadWithCli[\s\S]*?publishTrackedOperation\(\s*operationSequence,\s*staged \? "done" : "error"/);
 assert.match(useMagicNetSource, /removePrivatePayloadWithCli\(runPrivatePayloadCli,/);
 assert.match(useMagicNetSource, /config-editor get \$\{target\}`,[\s\S]*?true,[\s\S]*?redactedCliPreview\(`config-editor get \$\{target\} \[private-output\]`\)/);
 for (const [source, preview] of [

--- a/webui/private-payload-contract.test.mjs
+++ b/webui/private-payload-contract.test.mjs
@@ -117,6 +117,11 @@ assert.match(redactedBearerHeaders, /说明/);
 const toolsSource = readFileSync(new URL("./src/components/pages/ToolsPage.vue", import.meta.url), "utf8");
 const subscriptionsSource = readFileSync(new URL("./src/components/pages/SubscriptionsPage.vue", import.meta.url), "utf8");
 const webuiSource = readFileSync(new URL("./src/components/pages/WebuiPage.vue", import.meta.url), "utf8");
+const diagnosticsSource = readFileSync(new URL("./src/components/pages/DiagnosticsPage.vue", import.meta.url), "utf8");
+const blocklistSource = readFileSync(new URL("./src/components/pages/BlocklistPage.vue", import.meta.url), "utf8");
+const appsSource = readFileSync(new URL("./src/components/pages/AppsPage.vue", import.meta.url), "utf8");
+const outputSource = readFileSync(new URL("./src/components/pages/OutputPage.vue", import.meta.url), "utf8");
+const warpRoutesSource = readFileSync(new URL("./src/components/pages/WarpRouteRulesPanel.vue", import.meta.url), "utf8");
 const useMagicNetSource = readFileSync(new URL("./src/composables/useMagicNet.ts", import.meta.url), "utf8");
 const installPlanSource = readFileSync(new URL("./src/components/pages/webuiInstallPlan.ts", import.meta.url), "utf8");
 const linksSource = readFileSync(new URL("./src/composables/useExternalLinks.ts", import.meta.url), "utf8");
@@ -128,9 +133,9 @@ assert.match(toolsSource, /const restored = outcome\.ok && outcome\.stdout\.incl
 assert.match(webuiSource, /copyText\(safeCommand\)/);
 assert.doesNotMatch(webuiSource, /\{\{\s*installArgs/);
 assert.match(webuiSource, /startPrivateBackgroundCli/);
-assert.match(webuiSource, /const rawStatus = await runCli\("webui status", "读取 WebUI 配置", true\);/);
+assert.match(webuiSource, /const rawStatus = await runCli\(\s*"webui status",[\s\S]*?redactedCliPreview\("webui status \[private-output\]"\)/);
 assert.match(webuiSource, /status\.value = redactSensitiveText\(rawStatus\);/);
-assert.match(webuiSource, /const rawVerifyOutput = await runCli\("webui verify", "校验 WebUI 面板", true\);/);
+assert.match(webuiSource, /const rawVerifyOutput = await runCli\(\s*"webui verify",[\s\S]*?redactedCliPreview\("webui verify \[private-output\]"\)/);
 assert.match(webuiSource, /const safeVerifyOutput = redactSensitiveText\(rawVerifyOutput\);/);
 assert.match(webuiSource, /verifyOutput\.value = safeVerifyOutput;\s*state\.output = safeVerifyOutput;/);
 assert.doesNotMatch(webuiSource, /verifyOutput\.value = await runCli\(/);
@@ -148,10 +153,24 @@ assert.match(installPlanSource, /isSensitiveExternalUrl\(url\)/);
 assert.match(installPlanSource, /webui install-local \[filtered-url\] \$\{sha256 \|\| "\[sha256\]"\}/);
 assert.match(linksSource, /isSensitiveExternalUrl\(url\)/);
 assert.match(linksSource, /redactedCliPreview\("open external \[filtered-url\]"\)/);
-assert.match(useMagicNetSource, /async function runPrivateCli[\s\S]*?trackRedactedOperation\(redactedPreview\)[\s\S]*?runShellOutcome/);
-assert.match(useMagicNetSource, /async function runPrivateCli[\s\S]*?state\.phase = outcome\.ok \? "done" : "error"/);
+assert.match(useMagicNetSource, /async function runTrackedQuietShellOutcome[\s\S]*?trackRedactedOperation\(redactedPreview\)[\s\S]*?state\.phase = outcome\.ok \? "done" : "error"/);
+assert.match(useMagicNetSource, /function trackRedactedOperation[\s\S]*?state\.output = `\$ \$\{commandPreview\}\\n执行中；私密输出已隐藏。`/);
+assert.match(useMagicNetSource, /async function runTrackedQuietShellOutcome[\s\S]*?private output hidden/);
+assert.match(useMagicNetSource, /async function runShell[\s\S]*?quiet && previewOverride[\s\S]*?runTrackedQuietShellOutcome/);
+assert.match(useMagicNetSource, /async function runPrivateCli[\s\S]*?runTrackedQuietShellOutcome/);
 assert.match(useMagicNetSource, /stagePrivatePayloadWithCli\(\s*runPrivatePayloadCli,/);
 assert.match(useMagicNetSource, /const staged = await stagePrivatePayloadWithCli[\s\S]*?state\.phase = staged \? "done" : "error"/);
 assert.match(useMagicNetSource, /removePrivatePayloadWithCli\(runPrivatePayloadCli,/);
+assert.match(useMagicNetSource, /config-editor get \$\{target\}`,[\s\S]*?true,[\s\S]*?redactedCliPreview\(`config-editor get \$\{target\} \[private-output\]`\)/);
+for (const [source, preview] of [
+  [diagnosticsSource, "support bundle [private-output]"],
+  [blocklistSource, "block add-domain [domain]"],
+  [appsSource, "app add [package] bypass"],
+  [outputSource, "refresh background log [private-output]"],
+  [toolsSource, "refresh tools [private-output]"],
+  [warpRoutesSource, "route list [private-output]"],
+]) {
+  assert.match(source, new RegExp(`redactedCliPreview\\("${preview.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"\\)`));
+}
 
 console.log("private payload and signed URL contract tests passed");

--- a/webui/private-payload-contract.test.mjs
+++ b/webui/private-payload-contract.test.mjs
@@ -153,7 +153,7 @@ assert.match(installPlanSource, /isSensitiveExternalUrl\(url\)/);
 assert.match(installPlanSource, /webui install-local \[filtered-url\] \$\{sha256 \|\| "\[sha256\]"\}/);
 assert.match(linksSource, /isSensitiveExternalUrl\(url\)/);
 assert.match(linksSource, /redactedCliPreview\("open external \[filtered-url\]"\)/);
-assert.match(useMagicNetSource, /async function runTrackedQuietShellOutcome[\s\S]*?trackRedactedOperation\(redactedPreview\)[\s\S]*?state\.phase = outcome\.ok \? "done" : "error"/);
+assert.match(useMagicNetSource, /async function runTrackedQuietShellOutcome[\s\S]*?trackRedactedOperation\(redactedPreview, label\)[\s\S]*?state\.phase = outcome\.ok \? "done" : "error"/);
 assert.match(useMagicNetSource, /function trackRedactedOperation[\s\S]*?state\.output = `\$ \$\{commandPreview\}\\n执行中；私密输出已隐藏。`/);
 assert.match(useMagicNetSource, /async function runTrackedQuietShellOutcome[\s\S]*?private output hidden/);
 assert.match(useMagicNetSource, /async function runShell[\s\S]*?quiet && previewOverride[\s\S]*?runTrackedQuietShellOutcome/);

--- a/webui/runtime-log-insights.test.mjs
+++ b/webui/runtime-log-insights.test.mjs
@@ -44,6 +44,33 @@ try {
   assert.match(report, /\[filtered-url\]/);
   const insight = insights.buildRuntimeLogInsight([issue], 0, 1, [issue]);
   assert.doesNotMatch(insight.lastIssue, /192\.0\.2\.7|private\.example\.invalid/);
+
+  const coloredError = "+0800 2026-08-08 01:02:45 \u001b[31mERROR\u001b[0m connection: dial tcp 0.0.0.1:23861: i/o timeout";
+  const analysis = insights.analyzeRuntimeLogLines([coloredError]);
+  assert.equal(analysis.warningCount, 0);
+  assert.equal(analysis.errorCount, 1);
+  assert.equal(analysis.otherIssueCount, 0);
+  assert.deepEqual(analysis.issueLines, [coloredError]);
+
+  const coloredReport = insights.formatRuntimeLogIssueReport({
+    target: "sing-box",
+    lines: [coloredError],
+    ...analysis,
+  });
+  assert.match(coloredReport, /errors=1/);
+  assert.match(coloredReport, /other_issues=0/);
+  assert.doesNotMatch(coloredReport, /\u001b\[|\^\[\[/);
+
+  const caretEncodedError = "+0800 2026-08-08 01:02:45 ^[[31mERROR^[[0m connection: i/o timeout";
+  const caretAnalysis = insights.analyzeRuntimeLogLines([caretEncodedError]);
+  assert.equal(caretAnalysis.errorCount, 1);
+  assert.equal(caretAnalysis.otherIssueCount, 0);
+  const caretReport = insights.formatRuntimeLogIssueReport({
+    target: "sing-box",
+    lines: [caretEncodedError],
+    ...caretAnalysis,
+  });
+  assert.doesNotMatch(caretReport, /\^\[\[/);
 } finally {
   await rm(dir, { recursive: true, force: true });
 }

--- a/webui/runtime-log-insights.test.mjs
+++ b/webui/runtime-log-insights.test.mjs
@@ -35,6 +35,7 @@ try {
     target: "sing-box",
     lines: [issue],
     issueLines: [issue],
+    issueCount: 1,
     warningCount: 0,
     errorCount: 1,
     otherIssueCount: 0,
@@ -71,6 +72,19 @@ try {
     ...caretAnalysis,
   });
   assert.doesNotMatch(caretReport, /\^\[\[/);
+
+  const timeoutLines = Array.from({ length: 90 }, (_, index) => `request ${index}: timeout`);
+  const cappedAnalysis = insights.analyzeRuntimeLogLines(timeoutLines);
+  assert.equal(cappedAnalysis.issueCount, 90);
+  assert.equal(cappedAnalysis.issueLines.length, 80);
+  assert.equal(cappedAnalysis.otherIssueCount, 90);
+  const cappedReport = insights.formatRuntimeLogIssueReport({
+    target: "sing-box",
+    lines: timeoutLines,
+    ...cappedAnalysis,
+  });
+  assert.match(cappedReport, /issues=90/);
+  assert.match(cappedReport, /excerpt_lines=80/);
 } finally {
   await rm(dir, { recursive: true, force: true });
 }

--- a/webui/runtime-log-insights.test.mjs
+++ b/webui/runtime-log-insights.test.mjs
@@ -83,6 +83,10 @@ try {
   assert.equal(cappedAnalysis.issueLines.length, 80);
   assert.equal(cappedAnalysis.errorCount, 90);
   assert.equal(cappedAnalysis.otherIssueCount, 0);
+  const latestExcerpt = insights.latestRuntimeLogIssueLines(timeoutLines);
+  assert.equal(latestExcerpt.length, 60);
+  assert.match(latestExcerpt[0], /request 30:/);
+  assert.match(latestExcerpt.at(-1), /request 89:/);
   const cappedReport = insights.formatRuntimeLogIssueReport({
     target: "sing-box",
     lines: timeoutLines,

--- a/webui/runtime-log-insights.test.mjs
+++ b/webui/runtime-log-insights.test.mjs
@@ -73,11 +73,16 @@ try {
   });
   assert.doesNotMatch(caretReport, /\^\[\[/);
 
+  for (const line of ["dial i/o timeout", "connection timed out", "permission denied", "route not found"]) {
+    assert.equal(insights.runtimeLogLevelMatches(line, "error"), true, `${line} must remain in the error filter`);
+  }
+
   const timeoutLines = Array.from({ length: 90 }, (_, index) => `request ${index}: timeout`);
   const cappedAnalysis = insights.analyzeRuntimeLogLines(timeoutLines);
   assert.equal(cappedAnalysis.issueCount, 90);
   assert.equal(cappedAnalysis.issueLines.length, 80);
-  assert.equal(cappedAnalysis.otherIssueCount, 90);
+  assert.equal(cappedAnalysis.errorCount, 90);
+  assert.equal(cappedAnalysis.otherIssueCount, 0);
   const cappedReport = insights.formatRuntimeLogIssueReport({
     target: "sing-box",
     lines: timeoutLines,

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -458,46 +458,48 @@ onUnmounted(() => {
       </div>
     </header>
 
-    <section class="runtime-cockpit mn-chrome relative z-20 mb-5 grid gap-3 rounded-[1.25rem] p-1.5 md:sticky md:top-4 md:grid-cols-[minmax(220px,1.05fr)_minmax(0,1fr)_auto] md:items-center md:gap-2">
-      <div class="rounded-[0.95rem] bg-[color-mix(in_srgb,var(--mn-cactus)_30%,var(--mn-material-heavy))] px-4 py-3 shadow-[inset_0_1px_0_color-mix(in_srgb,#fff_45%,transparent),inset_0_0_0_1px_color-mix(in_srgb,var(--mn-cactus)_45%,transparent)]">
-        <div class="flex items-center justify-between gap-3">
-          <div class="min-w-0 flex-1">
-            <span class="text-[9px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-faint)]">运行状态</span>
-            <div class="mt-1.5 flex min-w-0 items-center gap-2.5">
-              <span :class="['size-2.5 shrink-0 rounded-full', statusDotClass]" />
-              <strong class="w-0 min-w-0 flex-1 truncate text-lg font-semibold tracking-[-0.03em] text-[var(--mn-ink)]">
-                {{ runtimeStateLabel }}
-              </strong>
+    <section class="runtime-cockpit mn-editorial-field relative z-20 mb-5 rounded-[1.25rem] p-1.5 md:sticky md:top-4">
+      <div class="mn-editorial-carrier grid gap-3 p-1.5 md:grid-cols-[minmax(220px,1.05fr)_minmax(0,1fr)_auto] md:items-center md:gap-2">
+        <div class="rounded-[0.95rem] bg-[color-mix(in_srgb,var(--mn-cactus)_34%,var(--mn-carrier))] px-4 py-3">
+          <div class="flex items-center justify-between gap-3">
+            <div class="min-w-0 flex-1">
+              <span class="text-[9px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-faint)]">运行状态</span>
+              <div class="mt-1.5 flex min-w-0 items-center gap-2.5">
+                <span :class="['size-2.5 shrink-0 rounded-full', statusDotClass]" />
+                <strong class="w-0 min-w-0 flex-1 truncate text-lg font-semibold tracking-[-0.03em] text-[var(--mn-ink)]">
+                  {{ runtimeStateLabel }}
+                </strong>
+              </div>
             </div>
+            <Badge :tone="statusTone">{{ runtimeStateLabel }}</Badge>
           </div>
-          <Badge :tone="statusTone">{{ runtimeStateLabel }}</Badge>
         </div>
-      </div>
 
-      <div class="grid min-w-0 grid-cols-2 gap-2 px-2 pb-2 md:px-3 md:pb-0">
-        <div class="min-w-0">
-          <span class="text-[9px] font-semibold uppercase tracking-[0.2em] text-[var(--mn-ink-faint)]">模式</span>
-          <code class="mn-code mt-1 block truncate text-xs md:text-sm">TUN</code>
+        <div class="grid min-w-0 grid-cols-2 gap-2 px-2 pb-2 md:px-3 md:pb-0">
+          <div class="min-w-0">
+            <span class="text-[9px] font-semibold uppercase tracking-[0.2em] text-[var(--mn-ink-faint)]">模式</span>
+            <code class="mn-code mt-1 block truncate text-xs md:text-sm">TUN</code>
+          </div>
+          <div class="min-w-0">
+            <span class="text-[9px] font-semibold uppercase tracking-[0.2em] text-[var(--mn-ink-faint)]">核心</span>
+            <code class="mn-code mt-1 block truncate text-xs md:text-sm">{{ state.runtime.singBox }}</code>
+          </div>
+          <div class="col-span-2 flex min-w-0 items-center gap-2 text-xs leading-5 text-[var(--mn-ink-muted)] md:text-sm">
+            <ScrollText class="shrink-0 text-[var(--mn-clay)]" :size="14" />
+            <span class="min-w-0 truncate" :title="statusMessage">{{ statusMessage }}</span>
+          </div>
         </div>
-        <div class="min-w-0">
-          <span class="text-[9px] font-semibold uppercase tracking-[0.2em] text-[var(--mn-ink-faint)]">核心</span>
-          <code class="mn-code mt-1 block truncate text-xs md:text-sm">{{ state.runtime.singBox }}</code>
-        </div>
-        <div class="col-span-2 flex min-w-0 items-center gap-2 text-xs leading-5 text-[var(--mn-ink-muted)] md:text-sm">
-          <ScrollText class="shrink-0 text-[var(--mn-clay)]" :size="14" />
-          <span class="min-w-0 truncate" :title="statusMessage">{{ statusMessage }}</span>
-        </div>
-      </div>
 
-      <Button
-        v-if="state.backgroundTask.log"
-        variant="outline"
-        size="sm"
-        class="mx-2 mb-2 md:mx-1 md:mb-0"
-        @click="setTab('output')"
-      >
-        <Terminal :size="15" />后台日志
-      </Button>
+        <Button
+          v-if="state.backgroundTask.log"
+          variant="outline"
+          size="sm"
+          class="mx-2 mb-2 md:mx-1 md:mb-0"
+          @click="setTab('output')"
+        >
+          <Terminal :size="15" />后台日志
+        </Button>
+      </div>
     </section>
 
     <main class="grid min-w-0 gap-5 md:grid-cols-[204px_minmax(0,1fr)] md:items-start md:gap-6">

--- a/webui/src/components/IssueReporterDialog.vue
+++ b/webui/src/components/IssueReporterDialog.vue
@@ -83,7 +83,7 @@ onUnmounted(() => {
       <div class="rounded-[5px] bg-[var(--mn-ivory)] p-4 sm:p-5">
         <div class="flex items-start justify-between gap-4">
           <div class="min-w-0">
-            <span class="inline-flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--mn-clay)]">
+            <span class="inline-flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--mn-clay-ink)]">
               <Bug :size="14" /> Issue Context
             </span>
             <h2 id="issue-reporter-title" class="mt-2 text-xl font-semibold tracking-[-0.03em] text-[var(--mn-ink)]">

--- a/webui/src/components/OnboardingDialog.vue
+++ b/webui/src/components/OnboardingDialog.vue
@@ -155,7 +155,7 @@ onUnmounted(() => {
       <div class="rounded-[5px] bg-[var(--mn-ivory)] p-4 sm:p-5">
         <div class="flex items-start justify-between gap-4">
           <div class="min-w-0">
-            <span class="inline-flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--mn-clay)]">
+            <span class="inline-flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--mn-clay-ink)]">
               <CheckCircle2 :size="14" /> 新手引导
             </span>
             <h2 id="onboarding-title" class="mt-2 text-xl font-semibold tracking-[-0.03em] text-[var(--mn-ink)]">
@@ -184,7 +184,7 @@ onUnmounted(() => {
             >
               <div class="flex items-center justify-between gap-3">
                 <strong class="text-sm font-semibold text-[var(--mn-ink)]">{{ index + 1 }}. {{ step.title }}</strong>
-                <span class="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--mn-clay)]">
+                <span class="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--mn-clay-ink)]">
                   {{ index === currentStep ? "当前" : "待完成" }}
                 </span>
               </div>
@@ -194,7 +194,7 @@ onUnmounted(() => {
 
           <article class="rounded-md border border-[var(--mn-border)] bg-[var(--mn-carrier)] p-4 sm:p-5">
             <div class="flex flex-wrap items-center justify-between gap-3">
-              <span class="text-[10px] font-semibold uppercase tracking-[0.2em] text-[var(--mn-clay)]">{{ progressLabel }}</span>
+              <span class="text-[10px] font-semibold uppercase tracking-[0.2em] text-[var(--mn-clay-ink)]">{{ progressLabel }}</span>
               <div class="flex items-center gap-2 text-xs text-[var(--mn-ink-muted)]">
                 <span class="inline-flex size-2.5 rounded-full bg-[var(--mn-cactus)]" aria-hidden="true" />
                 <span>可随时重新打开，不会修改现有运行状态</span>

--- a/webui/src/components/OpenSourceSupportNote.vue
+++ b/webui/src/components/OpenSourceSupportNote.vue
@@ -11,7 +11,7 @@
         <span class="mt-1 block text-sm font-semibold text-[var(--mn-ink)]">关于 MagicNet 的维护与支持</span>
       </span>
       <span
-        class="shrink-0 rounded-full border border-[var(--mn-border)] bg-[var(--mn-carrier)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--mn-clay)]"
+        class="shrink-0 rounded-full border border-[var(--mn-border)] bg-[var(--mn-carrier)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--mn-clay-ink)]"
       >
         展开
       </span>
@@ -28,7 +28,7 @@
         <p class="leading-6">
           我不太想把它做成一段单纯的捐赠请求，所以开了一个 AI API 中转站：如果你刚好有实际使用需求，可以在那里购买 AI 使用额度，在满足自己需求的同时，也顺手支持 MagicNet 继续做开源维护。
           <a
-            class="font-medium text-[var(--mn-sky)] underline decoration-[color-mix(in_srgb,var(--mn-sky)_45%,transparent)] underline-offset-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))]"
+            class="font-medium text-[var(--mn-sky-ink)] underline decoration-[color-mix(in_srgb,var(--mn-sky)_55%,transparent)] underline-offset-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))]"
             href="https://api.lmm.best/"
             target="_blank"
             rel="noopener noreferrer"

--- a/webui/src/components/pages/AppsPage.vue
+++ b/webui/src/components/pages/AppsPage.vue
@@ -7,7 +7,7 @@ import Input from "@/components/ui/Input.vue";
 import PageHeader from "@/components/ui/PageHeader.vue";
 import { useActionLock } from "@/composables/useActionLock";
 import { useMagicNet } from "@/composables/useMagicNet";
-import { copyText } from "@/utils";
+import { copyText, redactedCliPreview } from "@/utils";
 import { buildAppPolicySummary, formatAppPolicyFullReport, formatAppPolicySafeReport, isValidPackageName } from "./appPolicyInsights";
 import { buildAppPolicyChangePlan, type AppPolicyChangeOperation, type AppPolicyChangePlan } from "./appPolicyChangePlan";
 
@@ -183,7 +183,12 @@ async function addPackage(pkg: string, target: AppTarget, key = `add-${target}`)
     state.packageInput = "";
     if (target === "bypass") forgetRemovedBypass(pkg);
     state.output = `已加入界面，正在保存 ${pkg}...`;
-    const text = await runCli(`app add ${shellQuote(pkg)} ${target}`, `添加应用 ${pkg}`, true);
+    const text = await runCli(
+      `app add ${shellQuote(pkg)} ${target}`,
+      `添加应用 ${pkg}`,
+      true,
+      redactedCliPreview(`app add [package] ${target}`),
+    );
     if (commandFailed(text)) {
       state.output = text;
       state.appPolicy.proxy = previousProxy;
@@ -224,7 +229,12 @@ async function removeApp(pkg: string, target: AppTarget): Promise<void> {
       rememberRemovedBypass(pkg);
     }
     state.output = `已从界面移除 ${pkg}，正在后台保存...`;
-    const text = await runCli(`app remove ${shellQuote(pkg)} ${target}`, `移除应用 ${pkg}`, true);
+    const text = await runCli(
+      `app remove ${shellQuote(pkg)} ${target}`,
+      `移除应用 ${pkg}`,
+      true,
+      redactedCliPreview(`app remove [package] ${target}`),
+    );
     if (commandFailed(text)) {
       state.output = text;
       state.appPolicy.proxy = previousProxy;
@@ -243,7 +253,12 @@ async function restoreBypass(pkg: string): Promise<void> {
     const previousBypass = [...state.appPolicy.bypass];
     moveLocalPackage(pkg, "bypass");
     state.output = `正在把 ${pkg} 加回 Bypass...`;
-    const text = await runCli(`app add ${shellQuote(pkg)} bypass`, `恢复 Bypass 应用 ${pkg}`, true);
+    const text = await runCli(
+      `app add ${shellQuote(pkg)} bypass`,
+      `恢复 Bypass 应用 ${pkg}`,
+      true,
+      redactedCliPreview("app add [package] bypass"),
+    );
     if (commandFailed(text)) {
       state.output = text;
       state.appPolicy.proxy = previousProxy;

--- a/webui/src/components/pages/BlocklistPage.vue
+++ b/webui/src/components/pages/BlocklistPage.vue
@@ -7,7 +7,7 @@ import Input from "@/components/ui/Input.vue";
 import PageHeader from "@/components/ui/PageHeader.vue";
 import { useActionLock } from "@/composables/useActionLock";
 import { useMagicNet } from "@/composables/useMagicNet";
-import { copyText } from "@/utils";
+import { copyText, redactedCliPreview } from "@/utils";
 import { buildBlocklistSummary, filterBlocklistEntries } from "./blocklistInsights";
 
 const { state, runCli, startBackgroundCli, refreshBlock, openExternal, shellQuote, REPO } = useMagicNet();
@@ -48,7 +48,12 @@ async function addDomain(domain: string): Promise<void> {
   await withAction(`add-domain-${domain}`, async () => {
     state.blocklist.manual.push(domain);
     state.blocklist.newDomain = "";
-    await runCli(`block add-domain ${shellQuote(domain)}`, `添加黑名单 ${domain}`, true);
+    await runCli(
+      `block add-domain ${shellQuote(domain)}`,
+      `添加黑名单 ${domain}`,
+      true,
+      redactedCliPreview("block add-domain [domain]"),
+    );
     await refreshBlock(true);
   });
 }
@@ -68,7 +73,12 @@ async function removeDomain(domain: string): Promise<void> {
   await withAction(`remove-domain-${domain}`, async () => {
     state.blocklist.manual = state.blocklist.manual.filter((item) => item !== domain);
     state.output = `正在移除阻断：${domain}`;
-    const text = await runCli(`block remove-domain ${shellQuote(domain)}`, `移除阻断 ${domain}`, true);
+    const text = await runCli(
+      `block remove-domain ${shellQuote(domain)}`,
+      `移除阻断 ${domain}`,
+      true,
+      redactedCliPreview("block remove-domain [domain]"),
+    );
     if (text.includes("[error]")) {
       state.output = text;
       state.blocklist.manual.unshift(domain);
@@ -94,7 +104,12 @@ async function allowRule(rule: string): Promise<void> {
     if (suffix !== rule) state.blocklist.communityDomains = state.blocklist.communityDomains.filter((item) => item !== suffix);
     if (!state.blocklist.allowRules.includes(rule)) state.blocklist.allowRules.push(rule);
     state.output = `正在加入广告放行白名单：${rule}`;
-    const text = await runCli(`block allow-rule ${shellQuote(rule)}`, `广告放行 ${rule}`, true);
+    const text = await runCli(
+      `block allow-rule ${shellQuote(rule)}`,
+      `广告放行 ${rule}`,
+      true,
+      redactedCliPreview("block allow-rule [rule]"),
+    );
     if (text.includes("[error]")) {
       state.output = text;
       state.blocklist.allowRules = state.blocklist.allowRules.filter((item) => item !== rule);
@@ -179,7 +194,12 @@ async function removeAllowRule(rule: string): Promise<void> {
   await withAction(`unallow-${rule}`, async () => {
     state.blocklist.allowRules = state.blocklist.allowRules.filter((item) => item !== rule);
     state.output = `正在从广告放行白名单删除：${rule}`;
-    const text = await runCli(`block unallow-rule ${shellQuote(rule)}`, `从广告放行白名单删除 ${rule}`, true);
+    const text = await runCli(
+      `block unallow-rule ${shellQuote(rule)}`,
+      `从广告放行白名单删除 ${rule}`,
+      true,
+      redactedCliPreview("block unallow-rule [rule]"),
+    );
     if (text.includes("[error]")) {
       state.output = text;
       if (!state.blocklist.allowRules.includes(rule)) state.blocklist.allowRules.push(rule);

--- a/webui/src/components/pages/DiagnosticsPage.vue
+++ b/webui/src/components/pages/DiagnosticsPage.vue
@@ -8,7 +8,7 @@ import PageHeader from "@/components/ui/PageHeader.vue";
 import { sanitizeDiagnosticText } from "@/composables/issueDrafts";
 import { useActionLock } from "@/composables/useActionLock";
 import { useMagicNet } from "@/composables/useMagicNet";
-import { copyText, probeFailed } from "@/utils";
+import { copyText, probeFailed, redactedCliPreview } from "@/utils";
 import { formatApiEndpointProbeReport, summarizeApiEndpointProbes, summarizeApiProbeOutput, validateApiProbeOutput, type ApiEndpointProbe, type ApiProbeKey } from "./apiEndpointProbe";
 import ConnectionsPanel from "./ConnectionsPanel.vue";
 import { formatHealthCheckReport, summarizeHealthChecks } from "./healthCheckSummary";
@@ -52,7 +52,12 @@ const assistants = [
 ];
 
 async function copyContextUnlocked(): Promise<void> {
-  const text = await runCli("support bundle", "生成诊断上下文", true);
+  const text = await runCli(
+    "support bundle",
+    "生成诊断上下文",
+    true,
+    redactedCliPreview("support bundle [private-output]"),
+  );
   const sanitized = sanitizeDiagnosticText(text);
   supportBundle.value = sanitized;
   supportCopied.value = false;
@@ -67,7 +72,12 @@ async function copyContext(): Promise<void> {
 
 async function refreshSupportBundle(): Promise<void> {
   await withAction("support-bundle", async () => {
-    const text = await runCli("support bundle", "生成支持包", true);
+    const text = await runCli(
+      "support bundle",
+      "生成支持包",
+      true,
+      redactedCliPreview("support bundle [private-output]"),
+    );
     supportBundle.value = sanitizeDiagnosticText(text);
     supportCopied.value = false;
     supportIssuesCopied.value = false;
@@ -111,7 +121,12 @@ async function runApiProbe(): Promise<void> {
     const next: ApiEndpointProbe[] = [];
     for (const target of targets) {
       const startedAt = performance.now();
-      const text = await runCli(target.command, `预检 ${target.label}`, true);
+      const text = await runCli(
+        target.command,
+        `预检 ${target.label}`,
+        true,
+        redactedCliPreview("api preflight [private-output]"),
+      );
       next.push({
         ...target,
         ok: !probeFailed(text) && validateApiProbeOutput(target.key, text),

--- a/webui/src/components/pages/DnsToolsCard.vue
+++ b/webui/src/components/pages/DnsToolsCard.vue
@@ -66,7 +66,6 @@ async function testDns(): Promise<void> {
       dnsTestOutput.value = await runCli(`dns test ${shellQuote(domain)}`, `DNS 测试 ${domain}`);
       testedDomain.value = domain;
       dnsCopied.value = false;
-      state.output = dnsTestOutput.value;
     } finally {
       runningDomain.value = "";
     }

--- a/webui/src/components/pages/DnsToolsCard.vue
+++ b/webui/src/components/pages/DnsToolsCard.vue
@@ -208,10 +208,12 @@ transport={{ state.dns.transport }}</pre>
         <p class="text-sm font-semibold">DNS 测试摘要</p>
         <p class="mt-1 text-sm leading-6 opacity-80">{{ dnsSummary.summary }}</p>
       </div>
-      <div class="grid gap-2 text-xs text-[var(--mn-ink-muted)] sm:grid-cols-5">
+      <div class="grid gap-2 text-xs text-[var(--mn-ink-muted)] sm:grid-cols-4 xl:grid-cols-7">
         <span>{{ dnsSummary.lineCount }} 行输出</span>
         <span>{{ dnsSummary.issueCount }} 条问题线索</span>
+        <span>probe_path={{ dnsSummary.probePath || "legacy-direct" }}</span>
         <span>http_code={{ dnsSummary.httpStatus ?? "none" }}</span>
+        <span>proxy_ip={{ dnsSummary.proxyIp || "none" }}</span>
         <span>remote_ip={{ dnsSummary.remoteIp || "none" }}</span>
         <span>time={{ dnsSummary.timeTotalMillis ?? "none" }}ms</span>
       </div>

--- a/webui/src/components/pages/OutputPage.vue
+++ b/webui/src/components/pages/OutputPage.vue
@@ -10,7 +10,7 @@ import { useMagicNet } from "@/composables/useMagicNet";
 import { copyText } from "@/utils";
 import RuntimeLogsPanel from "./RuntimeLogsPanel.vue";
 import { buildOutputDiagnostic, outputDiagnosticTone, sanitizeOutputText } from "./outputDiagnostics";
-import { analyzeRuntimeLogLines } from "./runtimeLogInsights";
+import { analyzeRuntimeLogLines, latestRuntimeLogIssueLines } from "./runtimeLogInsights";
 
 const { state, compactOutput, runShell } = useMagicNet();
 const outputQuery = ref("");
@@ -39,9 +39,9 @@ const outputDiagnostic = computed(() => buildOutputDiagnostic({
   issueLines: outputStats.value.issueLines,
   filtered: Boolean(outputQuery.value.trim())
 }));
-const issueSummary = computed(() => analyzeRuntimeLogLines(
+const issueSummary = computed(() => latestRuntimeLogIssueLines(
   outputLines.value.map((line) => line.trim()).filter(Boolean),
-).issueLines.slice(0, 60).join("\n"));
+).join("\n"));
 const visibleOutput = computed(() => compactOutput(filteredOutput.value || "没有匹配的输出行。", 7000));
 
 watch(outputQuery, () => {

--- a/webui/src/components/pages/OutputPage.vue
+++ b/webui/src/components/pages/OutputPage.vue
@@ -24,7 +24,7 @@ const outputStats = computed(() => {
   return {
     lines: outputLines.value.length,
     chars: state.output.length,
-    issueLines: analysis.issueLines.length
+    issueLines: analysis.issueCount
   };
 });
 const filteredOutput = computed(() => {

--- a/webui/src/components/pages/OutputPage.vue
+++ b/webui/src/components/pages/OutputPage.vue
@@ -7,7 +7,7 @@ import Input from "@/components/ui/Input.vue";
 import PageHeader from "@/components/ui/PageHeader.vue";
 import { backgroundLogCommand, formatBackgroundDuration, formatBackgroundTime } from "@/composables/backgroundTasks";
 import { useMagicNet } from "@/composables/useMagicNet";
-import { copyText } from "@/utils";
+import { copyText, redactedCliPreview } from "@/utils";
 import RuntimeLogsPanel from "./RuntimeLogsPanel.vue";
 import { buildOutputDiagnostic, outputDiagnosticTone, sanitizeOutputText } from "./outputDiagnostics";
 import { analyzeRuntimeLogLines, latestRuntimeLogIssueLines } from "./runtimeLogInsights";
@@ -72,7 +72,12 @@ async function copyBackgroundLogPath(): Promise<void> {
 async function refreshBackgroundLog(): Promise<void> {
   const { log, args, label } = state.backgroundTask;
   if (!log) return;
-  const text = await runShell(backgroundLogCommand(log, args), `刷新后台日志 ${label}`, true);
+  const text = await runShell(
+    backgroundLogCommand(log, args),
+    `刷新后台日志 ${label}`,
+    true,
+    redactedCliPreview("refresh background log [private-output]"),
+  );
   state.backgroundTask.updatedAt = Date.now();
   state.output = `后台日志已刷新：${label}\n\n${text || "日志为空。"}`;
   copied.value = false;

--- a/webui/src/components/pages/OutputPage.vue
+++ b/webui/src/components/pages/OutputPage.vue
@@ -10,21 +10,21 @@ import { useMagicNet } from "@/composables/useMagicNet";
 import { copyText } from "@/utils";
 import RuntimeLogsPanel from "./RuntimeLogsPanel.vue";
 import { buildOutputDiagnostic, outputDiagnosticTone, sanitizeOutputText } from "./outputDiagnostics";
+import { analyzeRuntimeLogLines } from "./runtimeLogInsights";
 
 const { state, compactOutput, runShell } = useMagicNet();
 const outputQuery = ref("");
 const copied = ref(false);
 const issueCopied = ref(false);
-const issuePattern = /\b(warn|warning|fail|failed|error|fatal|panic|denied|timeout|not found)\b/i;
 
 const outputLines = computed(() => state.output.split(/\r?\n/));
 const outputStats = computed(() => {
   const nonEmpty = outputLines.value.filter((line) => line.trim());
-  const issueLines = nonEmpty.filter((line) => issuePattern.test(line));
+  const analysis = analyzeRuntimeLogLines(nonEmpty);
   return {
     lines: outputLines.value.length,
     chars: state.output.length,
-    issueLines: issueLines.length
+    issueLines: analysis.issueLines.length
   };
 });
 const filteredOutput = computed(() => {
@@ -39,11 +39,9 @@ const outputDiagnostic = computed(() => buildOutputDiagnostic({
   issueLines: outputStats.value.issueLines,
   filtered: Boolean(outputQuery.value.trim())
 }));
-const issueSummary = computed(() => outputLines.value
-  .map((line) => line.trim())
-  .filter((line) => issuePattern.test(line))
-  .slice(0, 60)
-  .join("\n"));
+const issueSummary = computed(() => analyzeRuntimeLogLines(
+  outputLines.value.map((line) => line.trim()).filter(Boolean),
+).issueLines.slice(0, 60).join("\n"));
 const visibleOutput = computed(() => compactOutput(filteredOutput.value || "没有匹配的输出行。", 7000));
 
 watch(outputQuery, () => {

--- a/webui/src/components/pages/RuntimeLogsPanel.vue
+++ b/webui/src/components/pages/RuntimeLogsPanel.vue
@@ -8,7 +8,13 @@ import { useActionLock } from "@/composables/useActionLock";
 import { useMagicNet } from "@/composables/useMagicNet";
 import { copyText } from "@/utils";
 import { sanitizeOutputText } from "./outputDiagnostics";
-import { buildRuntimeLogInsight, formatRuntimeLogIssueReport, runtimeLogInsightTone } from "./runtimeLogInsights";
+import {
+  analyzeRuntimeLogLines,
+  buildRuntimeLogInsight,
+  formatRuntimeLogIssueReport,
+  runtimeLogInsightTone,
+  runtimeLogLevelMatches,
+} from "./runtimeLogInsights";
 
 const { runCli, state, compactOutput } = useMagicNet();
 const { isRunning, withAction } = useActionLock();
@@ -23,7 +29,6 @@ const lastLabel = ref("");
 const loadedTarget = ref<"sing-box" | "mcp">("sing-box");
 const autoRefresh = ref(false);
 let timer = 0;
-const issuePattern = /\b(warn|warning|fail|failed|error|fatal|panic|denied|timeout|not found)\b/i;
 
 const commandPreview = computed(() => {
   const count = normalizedLines();
@@ -34,17 +39,14 @@ const filteredLines = computed(() => logLines.value.filter((line) => {
   const lower = line.toLowerCase();
   const keyword = query.value.trim().toLowerCase();
   const matchesKeyword = !keyword || lower.includes(keyword);
-  const matchesLevel = level.value === "all"
-    || (level.value === "warn" && /\b(warn|warning)\b/i.test(line))
-    || (level.value === "error" && /\b(error|fail|failed|fatal|panic|denied|timeout|not found)\b/i.test(line));
+  const matchesLevel = runtimeLogLevelMatches(line, level.value);
   return matchesKeyword && matchesLevel;
 }));
-const warningCount = computed(() => logLines.value.filter((line) => /\b(warn|warning)\b/i.test(line)).length);
-const errorCount = computed(() => logLines.value.filter((line) => /\b(error|fail|failed|fatal|panic)\b/i.test(line)).length);
+const logAnalysis = computed(() => analyzeRuntimeLogLines(logLines.value));
+const warningCount = computed(() => logAnalysis.value.warningCount);
+const errorCount = computed(() => logAnalysis.value.errorCount);
 const visibleOutput = computed(() => filteredLines.value.join("\n"));
-const issueLines = computed(() => logLines.value
-  .filter((line) => issuePattern.test(line))
-  .slice(-80));
+const issueLines = computed(() => logAnalysis.value.issueLines);
 const logInsight = computed(() => buildRuntimeLogInsight(logLines.value, warningCount.value, errorCount.value, issueLines.value));
 const quickFilters = [
   { label: "错误", query: "", level: "error" },
@@ -95,7 +97,7 @@ async function copyIssueSummary(): Promise<void> {
     issueLines: issueLines.value,
     warningCount: warningCount.value,
     errorCount: errorCount.value,
-    otherIssueCount: Math.max(0, issueLines.value.length - warningCount.value - errorCount.value)
+    otherIssueCount: logAnalysis.value.otherIssueCount
   }));
   state.output = issueCopied.value ? "日志问题摘要已复制。" : "剪贴板不可用，日志问题摘要未复制。";
 }

--- a/webui/src/components/pages/RuntimeLogsPanel.vue
+++ b/webui/src/components/pages/RuntimeLogsPanel.vue
@@ -47,7 +47,7 @@ const warningCount = computed(() => logAnalysis.value.warningCount);
 const errorCount = computed(() => logAnalysis.value.errorCount);
 const visibleOutput = computed(() => filteredLines.value.join("\n"));
 const issueLines = computed(() => logAnalysis.value.issueLines);
-const logInsight = computed(() => buildRuntimeLogInsight(logLines.value, warningCount.value, errorCount.value, issueLines.value));
+const logInsight = computed(() => buildRuntimeLogInsight(logLines.value, warningCount.value, errorCount.value, issueLines.value, logAnalysis.value.issueCount));
 const quickFilters = [
   { label: "错误", query: "", level: "error" },
   { label: "警告", query: "", level: "warn" },
@@ -95,6 +95,7 @@ async function copyIssueSummary(): Promise<void> {
     target: loadedTarget.value,
     lines: logLines.value,
     issueLines: issueLines.value,
+    issueCount: logAnalysis.value.issueCount,
     warningCount: warningCount.value,
     errorCount: errorCount.value,
     otherIssueCount: logAnalysis.value.otherIssueCount

--- a/webui/src/components/pages/ToolsPage.vue
+++ b/webui/src/components/pages/ToolsPage.vue
@@ -47,7 +47,7 @@ async function refreshTools(): Promise<void> {
   toolsRefreshing.value = true;
   state.task = "刷新工具状态";
   try {
-    await refreshDns(true);
+    await refreshDns(true, redactedCliPreview("refresh tools [private-output]"));
     await refreshWarp(true);
     await refreshMcp(true);
     state.output = "工具状态已刷新。";

--- a/webui/src/components/pages/ToolsPage.vue
+++ b/webui/src/components/pages/ToolsPage.vue
@@ -82,7 +82,9 @@ async function exportBackup(): Promise<void> {
       preview,
     );
     const payload = outcome.ok ? outcome.stdout.trim().split(/\s+/).pop() || "" : "";
-    if (!payload) {
+    const exported = outcome.ok && Boolean(payload);
+    state.phase = exported ? "done" : "error";
+    if (!exported) {
       state.backup.status = "导出失败，请检查设备状态后重试。";
       state.output = state.backup.status;
       return;
@@ -141,7 +143,9 @@ async function runRestoreBackup(payload: string): Promise<void> {
         "导入配置备份",
         redactedCliPreview("backup restore-file [安全码和备份内容已隐藏]"),
       );
-      state.backup.status = outcome.ok && outcome.stdout.includes("[info] Backup restored")
+      const restored = outcome.ok && outcome.stdout.includes("[info] Backup restored");
+      state.phase = restored ? "done" : "error";
+      state.backup.status = restored
         ? "导入成功，运行配置已应用"
         : "导入失败，请检查安全码和备份内容后重试。";
       state.output = state.backup.status;
@@ -149,6 +153,7 @@ async function runRestoreBackup(payload: string): Promise<void> {
       const cleaned = await removePrivatePayload("tmp", staged.basename, "备份导入载荷");
       if (!cleaned) {
         state.backup.status = `${state.backup.status} 私有临时数据清理未确认。`;
+        state.phase = "error";
         state.output = state.backup.status;
       }
     }
@@ -225,6 +230,7 @@ async function runImportWarp(payload: string): Promise<void> {
     } finally {
       const cleaned = await removePrivatePayload("tmp", staged.basename, "WARP 导入载荷");
       if (!cleaned) {
+        state.phase = "error";
         state.output = state.output + "\n\nWARP 私有临时数据清理未确认。";
       }
     }

--- a/webui/src/components/pages/WarpRouteRulesPanel.vue
+++ b/webui/src/components/pages/WarpRouteRulesPanel.vue
@@ -6,7 +6,7 @@ import Input from "@/components/ui/Input.vue";
 import { parseRouteRuleSummary } from "@/composables/parsers";
 import { useActionLock } from "@/composables/useActionLock";
 import { useMagicNet } from "@/composables/useMagicNet";
-import { copyText, execFailed } from "@/utils";
+import { copyText, execFailed, redactedCliPreview } from "@/utils";
 import { buildRouteRuleChangePlan, formatRouteRuleChangePlanReport, type RouteRuleChangePlan } from "./routeRuleChangePlan";
 import type { PendingToolAction } from "./toolActions";
 
@@ -26,8 +26,13 @@ const visibleWarpDomains = computed(() => {
   return summary.value.warp.filter((item) => item.toLowerCase().includes(query));
 });
 
-async function refreshRoutes(): Promise<void> {
-  routeOutput.value = await runCli("route list", "读取路由规则", true);
+async function refreshRoutes(trackUserAction = false): Promise<void> {
+  routeOutput.value = await runCli(
+    "route list",
+    "读取路由规则",
+    true,
+    trackUserAction ? redactedCliPreview("route list [private-output]") : "",
+  );
   pendingAction.value = null;
   pendingPlan.value = null;
   planCopied.value = false;
@@ -212,7 +217,7 @@ onMounted(() => {
       <p v-if="!visibleWarpDomains.length" class="rounded bg-[var(--mn-carrier-deep)]/30 px-2 py-2 text-[var(--mn-ink-muted)]">没有匹配的 WARP 域名。</p>
     </div>
     <div class="grid gap-2 sm:grid-cols-2">
-      <Button variant="outline" :loading="isRunning('warp-route-refresh')" @click="withAction('warp-route-refresh', () => refreshRoutes())">
+      <Button variant="outline" :loading="isRunning('warp-route-refresh')" @click="withAction('warp-route-refresh', () => refreshRoutes(true))">
         <RefreshCw :size="16" />刷新路由规则
       </Button>
       <Button variant="outline" @click="copyRouteSnapshot">

--- a/webui/src/components/pages/WebuiPage.vue
+++ b/webui/src/components/pages/WebuiPage.vue
@@ -9,7 +9,7 @@ import PageHeader from "@/components/ui/PageHeader.vue";
 import Textarea from "@/components/ui/Textarea.vue";
 import { useActionLock } from "@/composables/useActionLock";
 import { useMagicNet } from "@/composables/useMagicNet";
-import { copyText, redactSensitiveText } from "@/utils";
+import { copyText, redactSensitiveText, redactedCliPreview } from "@/utils";
 import ToolActionConfirmCard from "./ToolActionConfirmCard.vue";
 import type { PendingToolAction } from "./toolActions";
 import { buildWebuiInstallPlan, formatWebuiInstallPlanReport, webuiInstallPlanTone, type WebuiInstallPlan } from "./webuiInstallPlan";
@@ -64,7 +64,12 @@ const panelWarnings = computed(() => buildPanelWarnings(panel.value.url, panel.v
 
 async function refreshWebui(): Promise<void> {
   await withAction("webui-status", async () => {
-    const rawStatus = await runCli("webui status", "读取 WebUI 配置", true);
+    const rawStatus = await runCli(
+      "webui status",
+      "读取 WebUI 配置",
+      true,
+      redactedCliPreview("webui status [private-output]"),
+    );
     status.value = redactSensitiveText(rawStatus);
     state.output = status.value;
   });
@@ -72,7 +77,12 @@ async function refreshWebui(): Promise<void> {
 
 async function verifyWebui(): Promise<void> {
   await withAction("webui-verify", async () => {
-    const rawVerifyOutput = await runCli("webui verify", "校验 WebUI 面板", true);
+    const rawVerifyOutput = await runCli(
+      "webui verify",
+      "校验 WebUI 面板",
+      true,
+      redactedCliPreview("webui verify [private-output]"),
+    );
     const safeVerifyOutput = redactSensitiveText(rawVerifyOutput);
     verifyOutput.value = safeVerifyOutput;
     state.output = safeVerifyOutput;

--- a/webui/src/components/pages/dnsTestSummary.ts
+++ b/webui/src/components/pages/dnsTestSummary.ts
@@ -3,7 +3,9 @@ export type DnsTestSummary = {
   lineCount: number;
   issueCount: number;
   domain: string;
+  probePath: string;
   httpStatus: number | null;
+  proxyIp: string;
   remoteIp: string;
   timeTotalMillis: number | null;
   status: "ok" | "warn" | "fail" | "idle";
@@ -18,19 +20,23 @@ export function parseDnsTestSummary(text: string, fallbackDomain = ""): DnsTestS
   const fields = parseFields(lines);
   const issueLines = lines.filter((line) => ISSUE_PATTERN.test(line));
   const httpStatus = parseHttpStatus(fields.http_code || "");
+  const probePath = fields.probe_path || "";
+  const proxyIp = fields.proxy_ip || "";
   const remoteIp = fields.remote_ip || "";
   const timeTotalMillis = parseSecondsToMillis(fields.time_total || "");
   const domain = cleanDomain(fields.domain || fallbackDomain);
-  const status = dnsStatus(lines.length, issueLines.length, httpStatus, remoteIp, timeTotalMillis);
+  const status = dnsStatus(lines.length, issueLines.length, probePath, httpStatus, proxyIp, remoteIp, timeTotalMillis);
   return {
     lineCount: lines.length,
     issueCount: issueLines.length,
     domain,
+    probePath,
     httpStatus,
+    proxyIp,
     remoteIp,
     timeTotalMillis,
     status,
-    summary: dnsSummary(status, domain, httpStatus, remoteIp, timeTotalMillis, issueLines.length),
+    summary: dnsSummary(status, domain, probePath, httpStatus, proxyIp, remoteIp, timeTotalMillis, issueLines.length),
     issueLines
   };
 }
@@ -43,7 +49,9 @@ export function formatDnsTestReport(summary: DnsTestSummary, profile: string, pr
     `secondary=${secondary || "-"}`,
     `transport=${transport}`,
     `domain=${summary.domain || "unknown"}`,
+    `probe_path=${summary.probePath || "legacy-direct"}`,
     `http_code=${summary.httpStatus ?? "none"}`,
+    `proxy_ip=${summary.proxyIp || "none"}`,
     `remote_ip=${summary.remoteIp || "none"}`,
     `time_total_ms=${summary.timeTotalMillis ?? "none"}`,
     `status=${summary.status}`,
@@ -81,17 +89,36 @@ function cleanDomain(value: string): string {
   return value.replace(/^https?:\/\//i, "").replace(/\/.*$/, "");
 }
 
-function dnsStatus(lineCount: number, issueCount: number, httpStatus: number | null, remoteIp: string, timeTotalMillis: number | null): DnsTestSummary["status"] {
+function dnsStatus(lineCount: number, issueCount: number, probePath: string, httpStatus: number | null, proxyIp: string, remoteIp: string, timeTotalMillis: number | null): DnsTestSummary["status"] {
   if (!lineCount) return "idle";
-  if (!remoteIp || issueCount) return "fail";
+  if (issueCount) return "fail";
+  if (probePath === "magicnet-mixed") {
+    if (!proxyIp || httpStatus === null) return "fail";
+  } else if (probePath || !remoteIp) {
+    return "fail";
+  }
   if (httpStatus !== null && httpStatus >= 400) return "warn";
   if (timeTotalMillis !== null && timeTotalMillis > 2500) return "warn";
   return "ok";
 }
 
-function dnsSummary(status: DnsTestSummary["status"], domain: string, httpStatus: number | null, remoteIp: string, timeTotalMillis: number | null, issueCount: number): string {
+function dnsSummary(status: DnsTestSummary["status"], domain: string, probePath: string, httpStatus: number | null, proxyIp: string, remoteIp: string, timeTotalMillis: number | null, issueCount: number): string {
   if (status === "idle") return "尚未运行 DNS 测试。";
-  if (status === "fail") return issueCount ? `发现 ${issueCount} 条 DNS/连接问题线索。` : "未解析到 remote_ip，DNS 或 HTTPS 连通性需要检查。";
+  if (status === "fail") {
+    if (issueCount) return `发现 ${issueCount} 条 DNS/连接问题线索。`;
+    return probePath === "magicnet-mixed"
+      ? "未取得有效的 MagicNet 混合入口与 HTTP 结果，DNS 或 HTTPS 连通性需要检查。"
+      : "未解析到 remote_ip，DNS 或 HTTPS 连通性需要检查。";
+  }
+  if (probePath === "magicnet-mixed") {
+    if (httpStatus !== null && httpStatus >= 400) {
+      return `${domain || "目标域名"} 已通过 MagicNet 混合入口（${proxyIp}）完成 DNS/HTTPS 连接，但目标返回 HTTP ${httpStatus}；链路可达。`;
+    }
+    if (status === "warn") {
+      return `${domain || "目标域名"} 已通过 MagicNet 混合入口（${proxyIp}）完成 DNS/HTTPS 探测，但总耗时 ${timeTotalMillis}ms 偏高。`;
+    }
+    return `${domain || "目标域名"} 已通过 MagicNet 混合入口（${proxyIp}）完成 DNS/HTTPS 探测，总耗时 ${timeTotalMillis ?? "未知"}ms。`;
+  }
   if (httpStatus !== null && httpStatus >= 400) {
     return `${domain || "目标域名"} 已解析到 ${remoteIp}，但 HTTPS 返回 HTTP ${httpStatus}；DNS/网络链路可达。`;
   }

--- a/webui/src/components/pages/dnsTestSummary.ts
+++ b/webui/src/components/pages/dnsTestSummary.ts
@@ -73,7 +73,8 @@ function parseSecondsToMillis(value: string): number | null {
 
 function parseHttpStatus(value: string): number | null {
   if (!/^\d{3}$/.test(value)) return null;
-  return Number(value);
+  const status = Number(value);
+  return status >= 100 && status <= 599 ? status : null;
 }
 
 function cleanDomain(value: string): string {

--- a/webui/src/components/pages/runtimeLogInsights.ts
+++ b/webui/src/components/pages/runtimeLogInsights.ts
@@ -43,6 +43,10 @@ export function analyzeRuntimeLogLines(lines: string[]): RuntimeLogAnalysis {
   };
 }
 
+export function latestRuntimeLogIssueLines(lines: string[]): string[] {
+  return analyzeRuntimeLogLines(lines).issueLines.slice(-60);
+}
+
 export function runtimeLogLevelMatches(line: string, level: "all" | "warn" | "error"): boolean {
   if (level === "all") return true;
   const normalized = stripTerminalControlSequences(line);

--- a/webui/src/components/pages/runtimeLogInsights.ts
+++ b/webui/src/components/pages/runtimeLogInsights.ts
@@ -16,13 +16,14 @@ export type RuntimeLogIssueReportInput = {
   target: string;
   lines: string[];
   issueLines: string[];
+  issueCount: number;
   warningCount: number;
   errorCount: number;
   otherIssueCount: number;
 };
 
 export type RuntimeLogAnalysis = Pick<RuntimeLogIssueReportInput,
-  "issueLines" | "warningCount" | "errorCount" | "otherIssueCount"
+  "issueLines" | "issueCount" | "warningCount" | "errorCount" | "otherIssueCount"
 >;
 
 export function analyzeRuntimeLogLines(lines: string[]): RuntimeLogAnalysis {
@@ -33,6 +34,7 @@ export function analyzeRuntimeLogLines(lines: string[]): RuntimeLogAnalysis {
   const issues = classified.filter(({ normalized }) => ISSUE_PATTERN.test(normalized));
   return {
     issueLines: issues.map(({ line }) => line).slice(-80),
+    issueCount: issues.length,
     warningCount: classified.filter(({ normalized }) => WARNING_PATTERN.test(normalized)).length,
     errorCount: classified.filter(({ normalized }) => ERROR_PATTERN.test(normalized)).length,
     otherIssueCount: issues.filter(({ normalized }) => (
@@ -47,7 +49,7 @@ export function runtimeLogLevelMatches(line: string, level: "all" | "warn" | "er
   return level === "warn" ? WARNING_PATTERN.test(normalized) : ERROR_PATTERN.test(normalized);
 }
 
-export function buildRuntimeLogInsight(lines: string[], warningCount: number, errorCount: number, issueLines: string[]): RuntimeLogInsight {
+export function buildRuntimeLogInsight(lines: string[], warningCount: number, errorCount: number, issueLines: string[], issueCount = issueLines.length): RuntimeLogInsight {
   if (!lines.length) {
     return {
       status: "idle",
@@ -73,11 +75,11 @@ export function buildRuntimeLogInsight(lines: string[], warningCount: number, er
       lastIssue
     };
   }
-  if (issueLines.length) {
+  if (issueCount) {
     return {
       status: "warning",
       label: "发现异常线索",
-      detail: `${issueLines.length} 行匹配 timeout/denied/not found 等异常关键词。`,
+      detail: `${issueCount} 行匹配 timeout/denied/not found 等异常关键词。`,
       lastIssue
     };
   }
@@ -97,6 +99,8 @@ export function formatRuntimeLogIssueReport(input: RuntimeLogIssueReportInput): 
     `warnings=${input.warningCount}`,
     `errors=${input.errorCount}`,
     `other_issues=${input.otherIssueCount}`,
+    `issues=${input.issueCount}`,
+    `excerpt_lines=${input.issueLines.length}`,
     "",
     ...input.issueLines.map((line) => sanitizeDiagnosticText(line))
   ].join("\n").trim();

--- a/webui/src/components/pages/runtimeLogInsights.ts
+++ b/webui/src/components/pages/runtimeLogInsights.ts
@@ -2,8 +2,8 @@ import { sanitizeDiagnosticText, stripTerminalControlSequences } from "@/composa
 import { statusToneClasses } from "@/lib/statusTone";
 
 const WARNING_PATTERN = /\b(warn|warning)\b/i;
-const ERROR_PATTERN = /\b(error|fail|failed|fatal|panic)\b/i;
-const ISSUE_PATTERN = /\b(warn|warning|fail|failed|error|fatal|panic|denied|timeout|not found)\b/i;
+const ERROR_PATTERN = /\b(error|fail|failed|fatal|panic|denied|timeout|timed out|not found)\b/i;
+const ISSUE_PATTERN = /\b(warn|warning|fail|failed|error|fatal|panic|denied|timeout|timed out|not found)\b/i;
 
 export type RuntimeLogInsight = {
   status: "idle" | "ok" | "warning" | "error";

--- a/webui/src/components/pages/runtimeLogInsights.ts
+++ b/webui/src/components/pages/runtimeLogInsights.ts
@@ -1,5 +1,9 @@
-import { sanitizeDiagnosticText } from "@/composables/issueDrafts";
+import { sanitizeDiagnosticText, stripTerminalControlSequences } from "@/composables/issueDrafts";
 import { statusToneClasses } from "@/lib/statusTone";
+
+const WARNING_PATTERN = /\b(warn|warning)\b/i;
+const ERROR_PATTERN = /\b(error|fail|failed|fatal|panic)\b/i;
+const ISSUE_PATTERN = /\b(warn|warning|fail|failed|error|fatal|panic|denied|timeout|not found)\b/i;
 
 export type RuntimeLogInsight = {
   status: "idle" | "ok" | "warning" | "error";
@@ -16,6 +20,32 @@ export type RuntimeLogIssueReportInput = {
   errorCount: number;
   otherIssueCount: number;
 };
+
+export type RuntimeLogAnalysis = Pick<RuntimeLogIssueReportInput,
+  "issueLines" | "warningCount" | "errorCount" | "otherIssueCount"
+>;
+
+export function analyzeRuntimeLogLines(lines: string[]): RuntimeLogAnalysis {
+  const classified = lines.map((line) => ({
+    line,
+    normalized: stripTerminalControlSequences(line),
+  }));
+  const issues = classified.filter(({ normalized }) => ISSUE_PATTERN.test(normalized));
+  return {
+    issueLines: issues.map(({ line }) => line).slice(-80),
+    warningCount: classified.filter(({ normalized }) => WARNING_PATTERN.test(normalized)).length,
+    errorCount: classified.filter(({ normalized }) => ERROR_PATTERN.test(normalized)).length,
+    otherIssueCount: issues.filter(({ normalized }) => (
+      !WARNING_PATTERN.test(normalized) && !ERROR_PATTERN.test(normalized)
+    )).length,
+  };
+}
+
+export function runtimeLogLevelMatches(line: string, level: "all" | "warn" | "error"): boolean {
+  if (level === "all") return true;
+  const normalized = stripTerminalControlSequences(line);
+  return level === "warn" ? WARNING_PATTERN.test(normalized) : ERROR_PATTERN.test(normalized);
+}
 
 export function buildRuntimeLogInsight(lines: string[], warningCount: number, errorCount: number, issueLines: string[]): RuntimeLogInsight {
   if (!lines.length) {

--- a/webui/src/components/ui/Button.vue
+++ b/webui/src/components/ui/Button.vue
@@ -38,7 +38,7 @@ const buttonVariants = cva(
         ghost:
           "bg-transparent text-[var(--mn-ink-soft)] hover:bg-[color-mix(in_srgb,var(--mn-ink)_8%,transparent)] hover:text-[var(--mn-ink)]",
         destructive:
-          "bg-[var(--mn-clay)] text-white shadow-[inset_0_1px_0_color-mix(in_srgb,#fff_28%,transparent),inset_0_0_0_1px_color-mix(in_srgb,var(--mn-ink)_12%,transparent),0_4px_12px_color-mix(in_srgb,var(--mn-clay)_20%,transparent)] hover:brightness-105",
+          "bg-[var(--mn-clay)] text-[var(--mn-on-accent)] shadow-[inset_0_1px_0_color-mix(in_srgb,#fff_28%,transparent),inset_0_0_0_1px_color-mix(in_srgb,var(--mn-ink)_12%,transparent),0_4px_12px_color-mix(in_srgb,var(--mn-clay)_20%,transparent)] hover:brightness-105",
       },
       size: {
         sm: "min-h-11 px-4",

--- a/webui/src/composables/issueDrafts.ts
+++ b/webui/src/composables/issueDrafts.ts
@@ -103,9 +103,10 @@ export type IssueOperationContext = {
 };
 
 const SAFE_COMMANDS: Record<string, readonly string[]> = {
+  api: ["preflight", "groups", "conns", "proxies"],
   app: ["list", "packages", "add", "add-many", "remove"],
-  backup: ["create", "restore", "restore-file"],
-  block: ["list", "add", "remove", "update"],
+  backup: ["create", "export", "restore", "restore-file"],
+  block: ["list", "add", "add-domain", "allow-rule", "remove", "remove-domain", "unallow-rule", "update"],
   config: ["apply", "show"],
   "config-editor": ["get", "save-file", "sync-template"],
   core: ["status", "logs"],
@@ -113,15 +114,20 @@ const SAFE_COMMANDS: Record<string, readonly string[]> = {
   dns: ["status", "set", "test"],
   health: [],
   mcp: ["status", "start", "stop"],
+  open: ["external"],
   repair: [],
+  refresh: ["background", "tools"],
+  route: ["list"],
   service: ["status", "logs", "start", "stop", "restart", "ensure"],
   setup: [],
   sub: ["apply-file", "get", "list", "schedule", "set", "set-file", "status", "update", "update-all"],
   supervisor: ["status", "start", "stop", "restart"],
+  support: ["bundle"],
   sysroute: ["snapshot", "list", "add-rule", "del-rule", "add-route", "del-route"],
   topology: [],
   transparent: ["get", "set"],
-  warp: ["status", "import", "route"],
+  warp: ["status", "import", "import-file", "route"],
+  webui: ["status", "verify", "payload", "install-local"],
 };
 
 export function classifyOperationCommand(raw: string): string {

--- a/webui/src/composables/issueDrafts.ts
+++ b/webui/src/composables/issueDrafts.ts
@@ -75,8 +75,12 @@ export function propValue(text: string, key: string): string {
     .trim() || "";
 }
 
+export function stripTerminalControlSequences(text: string): string {
+  return text.replace(/(?:\u001b\[|\u009b|\^\[\[)[0-?]*[ -/]*[@-~]/g, "");
+}
+
 export function sanitizeDiagnosticText(text: string): string {
-  return text
+  return stripTerminalControlSequences(text)
     .replace(/\b(?:https?|socks?|ss|ssr|vmess|vless|trojan|hysteria2?|tuic):\/\/[^\s"'<>]+/gi, "[filtered-url]")
     .replace(/\b(?:token|secret|password|passwd|node|query|path)[=:._-][A-Za-z0-9._~+/-]{4,}\b/gi, "[filtered-value]")
     .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, "[filtered-email]")

--- a/webui/src/composables/issueReporter.ts
+++ b/webui/src/composables/issueReporter.ts
@@ -13,6 +13,7 @@ import {
 import { copyText, intentDataQuote, shellQuote } from "@/utils";
 import type { RuntimeState } from "@/types";
 import type { BackgroundTaskState } from "@/composables/backgroundTasks";
+import type { OperationCapture } from "@/composables/operationCapture";
 
 type IssueReporterState = {
   task: string;
@@ -23,6 +24,7 @@ type IssueReporterState = {
   hasKsu: boolean;
   runtime: RuntimeState;
   lastCommand: string;
+  operationCapture: OperationCapture;
   backgroundTask: BackgroundTaskState;
 };
 
@@ -108,10 +110,13 @@ export async function createMagicNetIssue(
   { state, runShell, runCli }: IssueReporterDeps,
   kind: IssueKind,
 ): Promise<void> {
+  const captured = state.operationCapture.command
+    ? state.operationCapture
+    : { phase: state.phase, command: state.lastCommand, output: state.output };
   const operation: IssueOperationContext = {
-    phase: state.phase,
-    lastCommand: state.lastCommand,
-    lastOutput: state.output,
+    phase: captured.phase,
+    lastCommand: captured.command,
+    lastOutput: captured.output,
     backgroundLabel: state.backgroundTask.label,
     backgroundArgs: state.backgroundTask.args,
     backgroundStatus: state.backgroundTask.status,

--- a/webui/src/composables/operationCapture.ts
+++ b/webui/src/composables/operationCapture.ts
@@ -1,0 +1,41 @@
+export type OperationCapture = {
+  sequence: number;
+  phase: "idle" | "accepted" | "queued" | "running" | "done" | "error";
+  command: string;
+  output: string;
+};
+
+type OperationCaptureUpdate = Partial<Pick<OperationCapture, "phase" | "output">>;
+
+export function emptyOperationCapture(output = ""): OperationCapture {
+  return {
+    sequence: 0,
+    phase: "idle",
+    command: "",
+    output,
+  };
+}
+
+export function beginOperationCapture(
+  state: OperationCapture,
+  command: string,
+  output: string,
+): number {
+  const sequence = state.sequence + 1;
+  state.sequence = sequence;
+  state.phase = "accepted";
+  state.command = command;
+  state.output = output;
+  return sequence;
+}
+
+export function updateOperationCapture(
+  state: OperationCapture,
+  sequence: number,
+  update: OperationCaptureUpdate,
+): boolean {
+  if (sequence !== state.sequence) return false;
+  if (update.phase) state.phase = update.phase;
+  if (update.output !== undefined) state.output = update.output;
+  return true;
+}

--- a/webui/src/composables/operationCapture.ts
+++ b/webui/src/composables/operationCapture.ts
@@ -39,3 +39,11 @@ export function updateOperationCapture(
   if (update.output !== undefined) state.output = update.output;
   return true;
 }
+
+export function invalidateOperationCapture(state: OperationCapture): number {
+  state.sequence += 1;
+  state.phase = "idle";
+  state.command = "";
+  state.output = "";
+  return state.sequence;
+}

--- a/webui/src/composables/useMagicNet.ts
+++ b/webui/src/composables/useMagicNet.ts
@@ -138,10 +138,11 @@ const state = reactive({
   },
 });
 
-function trackRedactedOperation(commandPreview: string): void {
-  invalidateOperationCapture(state.operationCapture);
+function trackRedactedOperation(commandPreview: string): number {
+  const sequence = invalidateOperationCapture(state.operationCapture);
   state.lastCommand = commandPreview;
   state.phase = "accepted";
+  return sequence;
 }
 
 async function queued<T>(task: () => Promise<T>): Promise<T> {
@@ -268,8 +269,12 @@ async function runPrivateCli(
   label: string,
   redactedPreview: string,
 ): Promise<ExecOutcome> {
-  trackRedactedOperation(redactedPreview);
-  return runShellOutcome(`${CLI} ${args}`, label, true, redactedPreview);
+  const operationSequence = trackRedactedOperation(redactedPreview);
+  const outcome = await runShellOutcome(`${CLI} ${args}`, label, true, redactedPreview);
+  if (state.operationCapture.sequence === operationSequence) {
+    state.phase = outcome.ok ? "done" : "error";
+  }
+  return outcome;
 }
 
 async function runPrivatePayloadCli(
@@ -289,8 +294,10 @@ async function stagePrivatePayload(
   label: string,
   chunkSize?: number,
 ) {
-  trackRedactedOperation(redactedCliPreview(`webui payload stage ${namespace} [private-payload]`));
-  return stagePrivatePayloadWithCli(
+  const operationSequence = trackRedactedOperation(
+    redactedCliPreview(`webui payload stage ${namespace} [private-payload]`),
+  );
+  const staged = await stagePrivatePayloadWithCli(
     runPrivatePayloadCli,
     MODULE_DIR,
     namespace,
@@ -299,6 +306,10 @@ async function stagePrivatePayload(
     label,
     chunkSize,
   );
+  if (state.operationCapture.sequence === operationSequence) {
+    state.phase = staged ? "done" : "error";
+  }
+  return staged;
 }
 
 async function removePrivatePayload(

--- a/webui/src/composables/useMagicNet.ts
+++ b/webui/src/composables/useMagicNet.ts
@@ -51,7 +51,6 @@ import type { IssueKind } from "@/composables/issueDrafts";
 import {
   beginOperationCapture,
   emptyOperationCapture,
-  invalidateOperationCapture,
   updateOperationCapture,
 } from "@/composables/operationCapture";
 import { useExternalLinks } from "@/composables/useExternalLinks";
@@ -146,12 +145,26 @@ function releaseForegroundTask(sequence: number): void {
 }
 
 function trackRedactedOperation(commandPreview: string, label = ""): number {
-  const sequence = invalidateOperationCapture(state.operationCapture);
+  const output = `$ ${commandPreview}\n执行中；私密输出已隐藏。`;
+  const sequence = beginOperationCapture(state.operationCapture, commandPreview, output);
   state.lastCommand = commandPreview;
   state.phase = "accepted";
-  state.output = `$ ${commandPreview}\n执行中；私密输出已隐藏。`;
+  state.output = output;
   if (label) state.notice = `已接收：${label}`;
   return sequence;
+}
+
+function publishTrackedOperation(
+  sequence: number,
+  phase: Phase,
+  notice: string,
+  output: string,
+): boolean {
+  if (!updateOperationCapture(state.operationCapture, sequence, { phase, output })) return false;
+  state.phase = phase;
+  state.notice = notice;
+  state.output = output;
+  return true;
 }
 
 async function queued<T>(task: () => Promise<T>): Promise<T> {
@@ -288,16 +301,18 @@ async function runTrackedQuietShellOutcome(
 ): Promise<ExecOutcome> {
   const operationSequence = trackRedactedOperation(redactedPreview, label);
   const outcome = await runShellOutcome(commandBody, label, true, redactedPreview);
-  if (state.operationCapture.sequence === operationSequence) {
-    state.phase = outcome.ok ? "done" : "error";
-    state.notice = outcome.ok ? `完成：${label}` : `失败：${label}`;
-    const result = outcome.ok
-      ? "[info] completed; private output hidden"
-      : outcome.timedOut
-        ? "[exec-timeout] private output hidden"
-        : `[error] errno=${outcome.errno}; private output hidden`;
-    state.output = `$ ${redactedPreview}\n${result}`;
-  }
+  const phase = outcome.ok ? "done" : "error";
+  const result = outcome.ok
+    ? "[info] completed; private output hidden"
+    : outcome.timedOut
+      ? "[exec-timeout] private output hidden"
+      : `[error] errno=${outcome.errno}; private output hidden`;
+  publishTrackedOperation(
+    operationSequence,
+    phase,
+    outcome.ok ? `完成：${label}` : `失败：${label}`,
+    `$ ${redactedPreview}\n${result}`,
+  );
   return outcome;
 }
 
@@ -331,13 +346,14 @@ async function stagePrivatePayload(
     label,
     chunkSize,
   );
-  if (state.operationCapture.sequence === operationSequence) {
-    state.phase = staged ? "done" : "error";
-    state.notice = staged ? `完成：${label}` : `失败：${label}`;
-    state.output = staged
+  publishTrackedOperation(
+    operationSequence,
+    staged ? "done" : "error",
+    staged ? `完成：${label}` : `失败：${label}`,
+    staged
       ? `$ ${state.lastCommand}\n[info] completed; private output hidden`
-      : `$ ${state.lastCommand}\n[error] private payload staging failed; private output hidden`;
-  }
+      : `$ ${state.lastCommand}\n[error] private payload staging failed; private output hidden`,
+  );
   return staged;
 }
 
@@ -358,9 +374,12 @@ async function startBackgroundCli(
   lifecycleArgs = displayArgs,
 ): Promise<string> {
   const redactOutput = Boolean(previewOverride);
-  if (redactOutput) trackRedactedOperation(previewOverride);
+  const operationSequence = trackRedactedOperation(
+    previewOverride || redactedCliPreview(displayArgs),
+    label,
+  );
   const subscriptionTask = isSubscriptionBackgroundArgs(lifecycleArgs);
-  const subscriptionBaselineKnown = subscriptionTask ? await refreshSubs(true) : false;
+  const subscriptionBaselineKnown = subscriptionTask ? await refreshSubs(true, false) : false;
   const operationId = createBackgroundOperationId();
   const log = backgroundLogPath(label, operationId);
   stopBackgroundLogFollow();
@@ -379,11 +398,11 @@ async function startBackgroundCli(
     subscriptionBaselineGenerationId: state.subscriptions.lastGenerationId,
     subscriptionBaselineResult: state.subscriptions.lastResult,
   };
-  state.phase = "accepted";
-  state.notice = `已投递后台任务：${label}`;
-  state.output = redactOutput
+  const launchNotice = `已投递后台任务：${label}`;
+  const launchOutput = redactOutput
     ? `${label} 已在后台执行；私有命令和日志不会显示。正在跟踪安全状态...`
     : `${label} 已在后台执行。\n日志：${log}\n正在跟踪启动日志...`;
+  publishTrackedOperation(operationSequence, "accepted", launchNotice, launchOutput);
   await nextTick();
   await nextFrame();
   const command = backgroundLaunchCommand(args, label, log, operationId, cleanupCommand);
@@ -396,21 +415,22 @@ async function startBackgroundCli(
   const accepted = outcome.ok && backgroundAccepted(outcome.stdout, operationId);
   if (accepted || outcome.timedOut) {
     if (outcome.timedOut) {
-      state.notice = `投递确认超时，继续对账：${label}`;
-      state.output = redactOutput
+      const notice = `投递确认超时，继续对账：${label}`;
+      const output = redactOutput
         ? `${label} 的投递确认超时；这不代表设备侧任务失败。正在继续跟踪安全状态。`
         : `${label} 的投递确认超时；这不代表设备侧任务失败。正在继续跟踪后台日志。`;
+      publishTrackedOperation(operationSequence, "running", notice, output);
     }
-    followBackgroundLogs(log, label, lifecycleArgs, operationId, 0, redactOutput);
+    followBackgroundLogs(log, label, lifecycleArgs, operationId, operationSequence, 0, redactOutput);
   } else {
     state.backgroundTask.status = "error";
     state.backgroundTask.updatedAt = Date.now();
     state.backgroundTask.finishedAt = state.backgroundTask.updatedAt;
-    state.phase = "error";
-    state.notice = `投递失败：${label}`;
-    state.output = redactOutput
+    const notice = `投递失败：${label}`;
+    const output = redactOutput
       ? `${label} 未投递到后台；私有命令详情已隐藏。请检查设备状态后重试。`
       : `${label} 未投递到后台。\n\n${outcome.text || "[error] accepted marker missing"}`;
+    publishTrackedOperation(operationSequence, "error", notice, output);
   }
   if (outcome.timedOut) {
     return `[warning] background launch confirmation timed out; reconciliation continues in ${log}`;
@@ -446,6 +466,7 @@ function followBackgroundLogs(
   label: string,
   args: string,
   operationId: string,
+  operationSequence: number,
   attempt = 0,
   redactOutput = false,
 ): void {
@@ -453,7 +474,7 @@ function followBackgroundLogs(
   backgroundLogTimer = window.setTimeout(
     async () => {
       const subscriptionTask = isSubscriptionBackgroundArgs(args)
-        ? refreshSubs(true)
+        ? refreshSubs(true, false)
         : Promise.resolve(true);
       const [logs, status] = await Promise.all([
         runShell(backgroundLogCommand(log, args, operationId), `跟踪 ${label}`, true),
@@ -483,8 +504,8 @@ function followBackgroundLogs(
           : "running";
       state.backgroundTask.updatedAt = now;
       state.backgroundTask.finishedAt = done || failed ? now : 0;
-      state.phase = done ? "done" : failed ? "error" : "running";
-      state.notice = done
+      const phase = done ? "done" : failed ? "error" : "running";
+      const notice = done
         ? `完成：${label}`
         : failed
           ? `失败：${label}`
@@ -492,20 +513,21 @@ function followBackgroundLogs(
       const visibleLogs = redactOutput
         ? "私有后台日志已隐藏。"
         : logs || "等待日志输出...";
-      state.output = `${done ? "后台任务完成" : failed ? "后台任务失败" : "后台任务运行中"}：${label}\n\n${visibleLogs}`;
+      const output = `${done ? "后台任务完成" : failed ? "后台任务失败" : "后台任务运行中"}：${label}\n\n${visibleLogs}`;
+      publishTrackedOperation(operationSequence, phase, notice, output);
       if (!done && !failed && attempt + 1 < maxAttempts) {
-        followBackgroundLogs(log, label, args, operationId, attempt + 1, redactOutput);
+        followBackgroundLogs(log, label, args, operationId, operationSequence, attempt + 1, redactOutput);
       } else {
         backgroundLogTimer = 0;
         if (!done && !failed) {
           state.backgroundTask.status = "timeout";
           state.backgroundTask.updatedAt = Date.now();
           state.backgroundTask.finishedAt = 0;
-          state.phase = "running";
-          state.notice = `${label} 仍在后台运行或等待对账`;
-          state.output += redactOutput
+          const timeoutNotice = `${label} 仍在后台运行或等待对账`;
+          const timeoutOutput = output + (redactOutput
             ? "\n\n[warn] 安全状态跟踪已超时，但这不代表任务失败。请刷新订阅状态完成对账。"
-            : "\n\n[warn] 日志跟踪已超时，但这不代表任务失败。请刷新订阅状态或查看完整日志以完成对账。";
+            : "\n\n[warn] 日志跟踪已超时，但这不代表任务失败。请刷新订阅状态或查看完整日志以完成对账。");
+          publishTrackedOperation(operationSequence, "running", timeoutNotice, timeoutOutput);
         }
       }
     },
@@ -601,7 +623,7 @@ async function refreshBlock(quiet = false): Promise<boolean> {
   return true;
 }
 
-async function refreshSubs(quiet = false): Promise<boolean> {
+async function refreshSubs(quiet = false, reportFailure = true): Promise<boolean> {
   const [listText, statusText] = await Promise.all([
     runCli("sub list", "读取订阅列表", quiet),
     runCli("sub status", "读取订阅状态", quiet),
@@ -611,9 +633,11 @@ async function refreshSubs(quiet = false): Promise<boolean> {
     execFailed(statusText) ? "订阅状态" : "",
   ].filter(Boolean);
   if (failed.length) {
-    state.phase = "error";
-    state.notice = "订阅刷新不完整";
-    state.output = `读取${failed.join("和")}失败，旧数据已保留。\n\n${[listText, statusText].filter(execFailed).join("\n")}`;
+    if (reportFailure) {
+      state.phase = "error";
+      state.notice = "订阅刷新不完整";
+      state.output = `读取${failed.join("和")}失败，旧数据已保留。\n\n${[listText, statusText].filter(execFailed).join("\n")}`;
+    }
     return false;
   }
   state.subscriptions = parseSubs(listText, statusText, state.subscriptions);

--- a/webui/src/composables/useMagicNet.ts
+++ b/webui/src/composables/useMagicNet.ts
@@ -379,7 +379,6 @@ async function startBackgroundCli(
     label,
   );
   const subscriptionTask = isSubscriptionBackgroundArgs(lifecycleArgs);
-  const subscriptionBaselineKnown = subscriptionTask ? await refreshSubs(true, false) : false;
   const operationId = createBackgroundOperationId();
   const log = backgroundLogPath(label, operationId);
   stopBackgroundLogFollow();
@@ -393,7 +392,7 @@ async function startBackgroundCli(
     updatedAt: startedAt,
     finishedAt: 0,
     status: "running",
-    subscriptionBaselineKnown,
+    subscriptionBaselineKnown: false,
     subscriptionBaselineAttemptEpoch: state.subscriptions.lastAttemptEpoch,
     subscriptionBaselineGenerationId: state.subscriptions.lastGenerationId,
     subscriptionBaselineResult: state.subscriptions.lastResult,
@@ -403,6 +402,13 @@ async function startBackgroundCli(
     ? `${label} 已在后台执行；私有命令和日志不会显示。正在跟踪安全状态...`
     : `${label} 已在后台执行。\n日志：${log}\n正在跟踪启动日志...`;
   publishTrackedOperation(operationSequence, "accepted", launchNotice, launchOutput);
+  const subscriptionBaselineKnown = subscriptionTask ? await refreshSubs(true, false) : false;
+  if (state.backgroundTask.id === operationId) {
+    state.backgroundTask.subscriptionBaselineKnown = subscriptionBaselineKnown;
+    state.backgroundTask.subscriptionBaselineAttemptEpoch = state.subscriptions.lastAttemptEpoch;
+    state.backgroundTask.subscriptionBaselineGenerationId = state.subscriptions.lastGenerationId;
+    state.backgroundTask.subscriptionBaselineResult = state.subscriptions.lastResult;
+  }
   await nextTick();
   await nextFrame();
   const command = backgroundLaunchCommand(args, label, log, operationId, cleanupCommand);
@@ -413,6 +419,7 @@ async function startBackgroundCli(
     previewOverride,
   );
   const accepted = outcome.ok && backgroundAccepted(outcome.stdout, operationId);
+  const ownsBackgroundTask = state.backgroundTask.id === operationId;
   if (accepted || outcome.timedOut) {
     if (outcome.timedOut) {
       const notice = `投递确认超时，继续对账：${label}`;
@@ -421,11 +428,15 @@ async function startBackgroundCli(
         : `${label} 的投递确认超时；这不代表设备侧任务失败。正在继续跟踪后台日志。`;
       publishTrackedOperation(operationSequence, "running", notice, output);
     }
-    followBackgroundLogs(log, label, lifecycleArgs, operationId, operationSequence, 0, redactOutput);
+    if (ownsBackgroundTask) {
+      followBackgroundLogs(log, label, lifecycleArgs, operationId, operationSequence, 0, redactOutput);
+    }
   } else {
-    state.backgroundTask.status = "error";
-    state.backgroundTask.updatedAt = Date.now();
-    state.backgroundTask.finishedAt = state.backgroundTask.updatedAt;
+    if (ownsBackgroundTask) {
+      state.backgroundTask.status = "error";
+      state.backgroundTask.updatedAt = Date.now();
+      state.backgroundTask.finishedAt = state.backgroundTask.updatedAt;
+    }
     const notice = `投递失败：${label}`;
     const output = redactOutput
       ? `${label} 未投递到后台；私有命令详情已隐藏。请检查设备状态后重试。`
@@ -433,7 +444,9 @@ async function startBackgroundCli(
     publishTrackedOperation(operationSequence, "error", notice, output);
   }
   if (outcome.timedOut) {
-    return `[warning] background launch confirmation timed out; reconciliation continues in ${log}`;
+    return ownsBackgroundTask
+      ? `[warning] background launch confirmation timed out; reconciliation continues in ${log}`
+      : "[warning] background launch confirmation timed out after a newer task took over tracking";
   }
   return accepted ? outcome.text : `[error] errno=-1 background accepted marker missing`;
 }

--- a/webui/src/composables/useMagicNet.ts
+++ b/webui/src/composables/useMagicNet.ts
@@ -51,6 +51,7 @@ import type { IssueKind } from "@/composables/issueDrafts";
 import {
   beginOperationCapture,
   emptyOperationCapture,
+  invalidateOperationCapture,
   updateOperationCapture,
 } from "@/composables/operationCapture";
 import { useExternalLinks } from "@/composables/useExternalLinks";
@@ -137,6 +138,12 @@ const state = reactive({
   },
 });
 
+function trackRedactedOperation(commandPreview: string): void {
+  invalidateOperationCapture(state.operationCapture);
+  state.lastCommand = commandPreview;
+  state.phase = "accepted";
+}
+
 async function queued<T>(task: () => Promise<T>): Promise<T> {
   state.queueDepth += 1;
   const run = writeQueue.then(task, task).finally(() => {
@@ -151,10 +158,11 @@ async function runShellOutcome(
   label: string,
   quiet = false,
   previewOverride = "",
+  trackCommand = true,
 ): Promise<ExecOutcome> {
   const command = `su -M -c ${shellQuote(commandBody)}`;
   const commandPreview = previewOverride || compactCommand(command);
-  if (!quiet || previewOverride) state.lastCommand = commandPreview;
+  if (trackCommand && (!quiet || previewOverride)) state.lastCommand = commandPreview;
   const pendingOutput = `$ ${commandPreview}\n执行中...`;
   const captureSequence = quiet
     ? 0
@@ -260,7 +268,18 @@ async function runPrivateCli(
   label: string,
   redactedPreview: string,
 ): Promise<ExecOutcome> {
+  trackRedactedOperation(redactedPreview);
   return runShellOutcome(`${CLI} ${args}`, label, true, redactedPreview);
+}
+
+async function runPrivatePayloadCli(
+  args: string,
+  label: string,
+  redactedPreview: string,
+): Promise<ExecOutcome> {
+  // Payload staging and cleanup are implementation details. Keep the user's
+  // redacted parent-operation preview as the diagnostic fallback.
+  return runShellOutcome(`${CLI} ${args}`, label, true, redactedPreview, false);
 }
 
 async function stagePrivatePayload(
@@ -270,8 +289,9 @@ async function stagePrivatePayload(
   label: string,
   chunkSize?: number,
 ) {
+  trackRedactedOperation(redactedCliPreview(`webui payload stage ${namespace} [private-payload]`));
   return stagePrivatePayloadWithCli(
-    runPrivateCli,
+    runPrivatePayloadCli,
     MODULE_DIR,
     namespace,
     basename,
@@ -286,7 +306,7 @@ async function removePrivatePayload(
   basename: string,
   label: string,
 ): Promise<boolean> {
-  return removePrivatePayloadWithCli(runPrivateCli, namespace, basename, label);
+  return removePrivatePayloadWithCli(runPrivatePayloadCli, namespace, basename, label);
 }
 
 async function startBackgroundCli(
@@ -298,6 +318,7 @@ async function startBackgroundCli(
   lifecycleArgs = displayArgs,
 ): Promise<string> {
   const redactOutput = Boolean(previewOverride);
+  if (redactOutput) trackRedactedOperation(previewOverride);
   const subscriptionTask = isSubscriptionBackgroundArgs(lifecycleArgs);
   const subscriptionBaselineKnown = subscriptionTask ? await refreshSubs(true) : false;
   const operationId = createBackgroundOperationId();

--- a/webui/src/composables/useMagicNet.ts
+++ b/webui/src/composables/useMagicNet.ts
@@ -48,6 +48,11 @@ import {
 } from "@/composables/parsers";
 import { createMagicNetIssue } from "@/composables/issueReporter";
 import type { IssueKind } from "@/composables/issueDrafts";
+import {
+  beginOperationCapture,
+  emptyOperationCapture,
+  updateOperationCapture,
+} from "@/composables/operationCapture";
 import { useExternalLinks } from "@/composables/useExternalLinks";
 import {
   compactCommand,
@@ -75,6 +80,9 @@ function hasKsuExec(): boolean {
 }
 
 const hasKsu = hasKsuExec();
+const initialOutput = hasKsu
+  ? "正在读取 MagicNet 状态..."
+  : "本地预览模式：真机 WebUI 才会执行 root 命令。";
 let writeQueue: Promise<unknown> = Promise.resolve();
 let backgroundLogTimer = 0;
 
@@ -86,9 +94,8 @@ const state = reactive({
   notice: "面板已加载，所有耗时命令都会异步执行。",
   queueDepth: 0,
   lastCommand: "",
-  output: hasKsu
-    ? "正在读取 MagicNet 状态..."
-    : "本地预览模式：真机 WebUI 才会执行 root 命令。",
+  output: initialOutput,
+  operationCapture: emptyOperationCapture(initialOutput),
   backgroundTask: { ...backgroundTaskDefaults },
   issueReporter: {
     open: false,
@@ -148,13 +155,18 @@ async function runShellOutcome(
   const command = `su -M -c ${shellQuote(commandBody)}`;
   const commandPreview = previewOverride || compactCommand(command);
   if (!quiet || previewOverride) state.lastCommand = commandPreview;
+  const pendingOutput = `$ ${commandPreview}\n执行中...`;
+  const captureSequence = quiet
+    ? 0
+    : beginOperationCapture(state.operationCapture, commandPreview, pendingOutput);
   if (!quiet) {
     state.task = label;
     state.notice = `已接收：${label}`;
     const wasBusy = state.busy;
     state.busy = true;
     state.phase = wasBusy ? "queued" : "accepted";
-    state.output = `$ ${commandPreview}\n执行中...`;
+    updateOperationCapture(state.operationCapture, captureSequence, { phase: state.phase });
+    state.output = pendingOutput;
   }
   await nextTick();
   await nextFrame();
@@ -162,8 +174,9 @@ async function runShellOutcome(
   state.hasKsu = hasKsuExec();
   if (!state.hasKsu) {
     const outcome = unavailableExecOutcome(commandPreview);
-    if (!quiet) {
-      state.output = `当前没有 KernelSU 执行通道，命令未执行。\n\n${outcome.text}`;
+    const output = `当前没有 KernelSU 执行通道，命令未执行。\n\n${outcome.text}`;
+    if (!quiet && updateOperationCapture(state.operationCapture, captureSequence, { phase: "error", output })) {
+      state.output = output;
       state.phase = "error";
       state.notice = `未执行：${label}`;
       state.busy = false;
@@ -179,8 +192,10 @@ async function runShellOutcome(
         await nextFrame();
         return withTimeout(kernelsu.exec(command), CLI_TIMEOUT_MS, label);
       }
-      state.phase = "running";
-      state.notice = `正在执行：${label}`;
+      if (updateOperationCapture(state.operationCapture, captureSequence, { phase: "running" })) {
+        state.phase = "running";
+        state.notice = `正在执行：${label}`;
+      }
       await nextTick();
       await nextFrame();
       await nextFrame();
@@ -188,24 +203,29 @@ async function runShellOutcome(
     });
     const outcome = normalizeExecOutcome(result);
     const text = outcome.text;
-    if (!quiet) {
+    const output = `$ ${commandPreview}\n${text || "完成"}`;
+    if (!quiet && updateOperationCapture(state.operationCapture, captureSequence, {
+      phase: outcome.ok ? "done" : "error",
+      output,
+    })) {
       state.phase = outcome.ok ? "done" : "error";
       state.notice = outcome.ok ? `完成：${label}` : `失败：${label}`;
-      state.output = `$ ${commandPreview}\n${text || "完成"}`;
+      state.output = output;
     }
     return outcome;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const timedOut = error instanceof ExecTimeoutError;
     const text = `${timedOut ? "[exec-timeout]" : "[error] errno=-1"} ${message}`;
-    if (!quiet) {
+    const output = `$ ${commandPreview}\n${text}`;
+    if (!quiet && updateOperationCapture(state.operationCapture, captureSequence, { phase: "error", output })) {
       state.phase = "error";
       state.notice = timedOut ? `等待超时：${label}` : `失败：${label}`;
-      state.output = `$ ${commandPreview}\n${text}`;
+      state.output = output;
     }
     return { ok: false, timedOut, errno: -1, stdout: "", stderr: message, text };
   } finally {
-    if (!quiet) {
+    if (!quiet && state.operationCapture.sequence === captureSequence) {
       state.busy = false;
       state.task = "";
     }

--- a/webui/src/composables/useMagicNet.ts
+++ b/webui/src/composables/useMagicNet.ts
@@ -142,6 +142,7 @@ function trackRedactedOperation(commandPreview: string): number {
   const sequence = invalidateOperationCapture(state.operationCapture);
   state.lastCommand = commandPreview;
   state.phase = "accepted";
+  state.output = `$ ${commandPreview}\n执行中；私密输出已隐藏。`;
   return sequence;
 }
 
@@ -247,7 +248,10 @@ async function runShell(
   quiet = false,
   previewOverride = "",
 ): Promise<string> {
-  return (await runShellOutcome(commandBody, label, quiet, previewOverride)).text;
+  const outcome = quiet && previewOverride
+    ? await runTrackedQuietShellOutcome(commandBody, label, previewOverride)
+    : await runShellOutcome(commandBody, label, quiet, previewOverride);
+  return outcome.text;
 }
 
 async function runCli(
@@ -269,10 +273,24 @@ async function runPrivateCli(
   label: string,
   redactedPreview: string,
 ): Promise<ExecOutcome> {
+  return runTrackedQuietShellOutcome(`${CLI} ${args}`, label, redactedPreview);
+}
+
+async function runTrackedQuietShellOutcome(
+  commandBody: string,
+  label: string,
+  redactedPreview: string,
+): Promise<ExecOutcome> {
   const operationSequence = trackRedactedOperation(redactedPreview);
-  const outcome = await runShellOutcome(`${CLI} ${args}`, label, true, redactedPreview);
+  const outcome = await runShellOutcome(commandBody, label, true, redactedPreview);
   if (state.operationCapture.sequence === operationSequence) {
     state.phase = outcome.ok ? "done" : "error";
+    const result = outcome.ok
+      ? "[info] completed; private output hidden"
+      : outcome.timedOut
+        ? "[exec-timeout] private output hidden"
+        : `[error] errno=${outcome.errno}; private output hidden`;
+    state.output = `$ ${redactedPreview}\n${result}`;
   }
   return outcome;
 }
@@ -308,6 +326,9 @@ async function stagePrivatePayload(
   );
   if (state.operationCapture.sequence === operationSequence) {
     state.phase = staged ? "done" : "error";
+    state.output = staged
+      ? `$ ${state.lastCommand}\n[info] completed; private output hidden`
+      : `$ ${state.lastCommand}\n[error] private payload staging failed; private output hidden`;
   }
   return staged;
 }
@@ -598,8 +619,8 @@ async function refreshMcp(quiet = false): Promise<boolean> {
   return true;
 }
 
-async function refreshDns(quiet = false): Promise<boolean> {
-  const text = await runCli("dns status", "读取 DNS", quiet);
+async function refreshDns(quiet = false, previewOverride = ""): Promise<boolean> {
+  const text = await runCli("dns status", "读取 DNS", quiet, previewOverride);
   if (quiet && markQuietFailure("读取 DNS", text)) return false;
   state.dns = parseDns(text, state.dns);
   return true;
@@ -633,7 +654,12 @@ async function submitIssue(kind: IssueKind): Promise<void> {
 }
 
 async function refreshTopology(): Promise<void> {
-  const text = await runCli("topology", "刷新网络拓扑", true);
+  const text = await runCli(
+    "topology",
+    "刷新网络拓扑",
+    true,
+    redactedCliPreview("topology [private-output]"),
+  );
   state.topology = execFailed(text)
     ? await runCli("sysroute snapshot", "刷新路由快照")
     : text;
@@ -651,11 +677,12 @@ async function loadConfig(): Promise<void> {
     `config-editor get ${target}`,
     `加载 ${target} 配置`,
     true,
+    redactedCliPreview(`config-editor get ${target} [private-output]`),
   );
   if (execFailed(text)) {
     state.config.status = "加载失败";
     state.notice = `${target} 配置加载失败`;
-    state.output = text || "加载失败：没有返回内容。";
+    state.output = "加载失败：配置读取命令未成功，私密输出未显示。";
     state.phase = "error";
     return;
   }

--- a/webui/src/composables/useMagicNet.ts
+++ b/webui/src/composables/useMagicNet.ts
@@ -86,6 +86,7 @@ const initialOutput = hasKsu
   : "本地预览模式：真机 WebUI 才会执行 root 命令。";
 let writeQueue: Promise<unknown> = Promise.resolve();
 let backgroundLogTimer = 0;
+let foregroundTaskSequence = 0;
 
 const state = reactive({
   hasKsu,
@@ -138,11 +139,18 @@ const state = reactive({
   },
 });
 
-function trackRedactedOperation(commandPreview: string): number {
+function releaseForegroundTask(sequence: number): void {
+  if (!sequence || sequence !== foregroundTaskSequence) return;
+  state.busy = false;
+  state.task = "";
+}
+
+function trackRedactedOperation(commandPreview: string, label = ""): number {
   const sequence = invalidateOperationCapture(state.operationCapture);
   state.lastCommand = commandPreview;
   state.phase = "accepted";
   state.output = `$ ${commandPreview}\n执行中；私密输出已隐藏。`;
+  if (label) state.notice = `已接收：${label}`;
   return sequence;
 }
 
@@ -166,6 +174,7 @@ async function runShellOutcome(
   const commandPreview = previewOverride || compactCommand(command);
   if (trackCommand && (!quiet || previewOverride)) state.lastCommand = commandPreview;
   const pendingOutput = `$ ${commandPreview}\n执行中...`;
+  const foregroundSequence = quiet ? 0 : ++foregroundTaskSequence;
   const captureSequence = quiet
     ? 0
     : beginOperationCapture(state.operationCapture, commandPreview, pendingOutput);
@@ -189,9 +198,8 @@ async function runShellOutcome(
       state.output = output;
       state.phase = "error";
       state.notice = `未执行：${label}`;
-      state.busy = false;
-      state.task = "";
     }
+    releaseForegroundTask(foregroundSequence);
     return outcome;
   }
 
@@ -235,10 +243,7 @@ async function runShellOutcome(
     }
     return { ok: false, timedOut, errno: -1, stdout: "", stderr: message, text };
   } finally {
-    if (!quiet && state.operationCapture.sequence === captureSequence) {
-      state.busy = false;
-      state.task = "";
-    }
+    releaseForegroundTask(foregroundSequence);
   }
 }
 
@@ -281,10 +286,11 @@ async function runTrackedQuietShellOutcome(
   label: string,
   redactedPreview: string,
 ): Promise<ExecOutcome> {
-  const operationSequence = trackRedactedOperation(redactedPreview);
+  const operationSequence = trackRedactedOperation(redactedPreview, label);
   const outcome = await runShellOutcome(commandBody, label, true, redactedPreview);
   if (state.operationCapture.sequence === operationSequence) {
     state.phase = outcome.ok ? "done" : "error";
+    state.notice = outcome.ok ? `完成：${label}` : `失败：${label}`;
     const result = outcome.ok
       ? "[info] completed; private output hidden"
       : outcome.timedOut
@@ -314,6 +320,7 @@ async function stagePrivatePayload(
 ) {
   const operationSequence = trackRedactedOperation(
     redactedCliPreview(`webui payload stage ${namespace} [private-payload]`),
+    label,
   );
   const staged = await stagePrivatePayloadWithCli(
     runPrivatePayloadCli,
@@ -326,6 +333,7 @@ async function stagePrivatePayload(
   );
   if (state.operationCapture.sequence === operationSequence) {
     state.phase = staged ? "done" : "error";
+    state.notice = staged ? `完成：${label}` : `失败：${label}`;
     state.output = staged
       ? `$ ${state.lastCommand}\n[info] completed; private output hidden`
       : `$ ${state.lastCommand}\n[error] private payload staging failed; private output hidden`;

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -2,9 +2,9 @@
 
 /*
   MagicNet WebUI design tokens.
-  The brand palette stays warm and quiet while functional layers use a restrained,
-  Apple-inspired material system: platform typography, translucent chrome, clear
-  depth, immediate press feedback, and accessibility fallbacks.
+  Verified editorial colors provide the flat field/carrier/ink hierarchy. Functional
+  layers retain restrained platform typography, translucent chrome, immediate press
+  feedback, and accessibility fallbacks.
 */
 
 @theme {
@@ -19,10 +19,10 @@
   --color-mn-cactus-deep: #8fafa4;
   --color-mn-heather: #cbcadb;
   --color-mn-oat: #e3dacc;
-  --color-mn-clay: #c45f3f;
-  --color-mn-olive: #5f7549;
-  --color-mn-sky: #4f84b5;
-  --color-mn-coral: #d9a8a8;
+  --color-mn-clay: #d97757;
+  --color-mn-olive: #788c5d;
+  --color-mn-sky: #6a9bcc;
+  --color-mn-coral: #ebcece;
   --color-mn-success: #1f4a32;
   --color-mn-warning: #7a5410;
   --color-mn-danger: #9a342a;
@@ -44,10 +44,12 @@ html[data-theme="light"] {
   --mn-cactus-deep: #8fafa4;
   --mn-heather: #cbcadb;
   --mn-oat: #e3dacc;
-  --mn-clay: #c45f3f;
-  --mn-olive: #5f7549;
-  --mn-sky: #4f84b5;
-  --mn-coral: #d4a0a0;
+  --mn-clay: #d97757;
+  --mn-clay-ink: #8a341f;
+  --mn-olive: #788c5d;
+  --mn-sky: #6a9bcc;
+  --mn-sky-ink: #275b83;
+  --mn-coral: #ebcece;
   --mn-surface: var(--mn-ivory);
   --mn-surface-raised: var(--mn-carrier);
   --mn-surface-sunken: #e8e5db;
@@ -110,8 +112,10 @@ html[data-theme="dark"] {
   --mn-heather: #9a98b0;
   --mn-oat: #b8a888;
   --mn-clay: #d97757;
+  --mn-clay-ink: #f0a58f;
   --mn-olive: #8fad72;
   --mn-sky: #6a9bcc;
+  --mn-sky-ink: #a7c8e3;
   --mn-coral: #c48a8a;
   --mn-surface: var(--mn-ivory);
   --mn-surface-raised: var(--mn-carrier);
@@ -182,13 +186,6 @@ button {
   touch-action: manipulation;
 }
 
-button,
-input,
-select,
-textarea {
-  font: inherit;
-}
-
 .rounded-md {
   border-radius: var(--mn-radius-md);
 }
@@ -240,6 +237,24 @@ textarea {
   backdrop-filter: blur(28px) saturate(160%);
 }
 
+/*
+  Editorial status hierarchy: one flat cactus field, one irregular ivory
+  carrier, then near-black information. This is the shell's single expressive
+  surface; functional cards elsewhere stay quiet.
+*/
+.mn-editorial-field {
+  overflow: hidden;
+  background: var(--mn-cactus);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--mn-ink) 18%, transparent),
+    var(--mn-shadow-card);
+}
+
+.mn-editorial-carrier {
+  background: var(--mn-ivory);
+  border-radius: 1rem 1.65rem 1.1rem 1.45rem;
+}
+
 .mn-brand-mark {
   background: var(--mn-cactus);
   color: var(--mn-on-accent);
@@ -278,32 +293,6 @@ textarea {
 .mn-topbar {
   position: relative;
   isolation: isolate;
-}
-
-.mn-topbar::after,
-.runtime-cockpit::after,
-.mobile-nav::before,
-.mn-page-actions::after {
-  position: absolute;
-  pointer-events: none;
-  content: "";
-  opacity: 0.7;
-}
-
-.mn-topbar::after,
-.runtime-cockpit::after,
-.mn-page-actions::after {
-  right: 1rem;
-  bottom: -1px;
-  left: 1rem;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--mn-border-strong), transparent);
-}
-
-.mobile-nav::before {
-  inset: 0.18rem 1rem auto;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--mn-material-edge), transparent);
 }
 
 .runtime-cockpit {

--- a/webui/src/utils.ts
+++ b/webui/src/utils.ts
@@ -82,11 +82,11 @@ export function* chunkSurrogateSafe(text: string, size: number): Generator<strin
 
 /**
  * Redacted `lastCommand` preview for a CLI invocation whose real arguments
- * carry a secret. Owns the `su -M -c '…'` framing in one place so previews
- * can't drift from the wrapper actually built by `runShellOutcome`.
+ * carry a secret. Preserve a safe `cli` token so issue diagnostics can classify
+ * the operation without retaining the executable path or private arguments.
  */
 export function redactedCliPreview(displayArgs: string): string {
-  return `su -M -c '… ${displayArgs}'`;
+  return `su -M -c '… cli ${displayArgs}'`;
 }
 
 export function compactOutput(value: string, limit = OUTPUT_RENDER_LIMIT): string {

--- a/webui/ui-layout-regression.test.mjs
+++ b/webui/ui-layout-regression.test.mjs
@@ -3,10 +3,16 @@ import { readFileSync } from "node:fs";
 
 const app = readFileSync(new URL("./src/App.vue", import.meta.url), "utf8");
 const apps = readFileSync(new URL("./src/components/pages/AppsPage.vue", import.meta.url), "utf8");
+const styles = readFileSync(new URL("./src/styles.css", import.meta.url), "utf8");
 
 assert.match(app, /desktop-rail[\s\S]*whitespace-nowrap/, "desktop navigation labels must stay on one line");
 assert.match(app, /mobile-nav[\s\S]*whitespace-nowrap/, "mobile navigation labels must stay on one line");
 assert.match(apps, /min-h-12 whitespace-nowrap[\s\S]*全局接管/);
 assert.match(apps, /min-h-12 whitespace-nowrap[\s\S]*仅名单接管/);
+assert.doesNotMatch(
+  styles,
+  /button,\s*input,\s*select,\s*textarea\s*\{\s*font:\s*inherit;/,
+  "an unlayered font shorthand must not override responsive button text sizes",
+);
 
 console.log("UI layout regression tests passed");


### PR DESCRIPTION
## Summary

- preserve ChatGPT/X domain ownership for IP-only Android flows with sing-box DNS reverse mapping
- route only OpenAI’s published ChatGPT Voice prefixes on UDP/3478 and refresh them atomically at build time
- run root DNS probes through MagicNet’s managed mixed inbound
- bind issue reports to the actual active command, correctly classify ANSI-colored errors, and reject non-HTTP curl status `000`
- fix responsive navigation typography and upgrade the shell using the verified anthropic-art palette/layer hierarchy

## Issue mapping

- #99: IP-only connections no longer fall through to CN direct; ChatGPT Voice gets a narrow official endpoint rule
- #100: the unlayered font shorthand no longer overrides Tailwind responsive sizing; `黑名单` stays on one line
- #101: DNS probes use the managed route and generated issue context cannot be overwritten by an earlier async command

## Validation

- `scripts/pre-commit.sh`
- `cargo test -p magicnet-cli` (304 passed)
- `npm run check` (28 tests, typecheck, production build)
- `sing-box check` with sing-box 1.13.16
- real Chrome/Playwright at 320, 360, 412, and 1280 px; light/dark design audit; no console/page errors or horizontal overflow
- MagicSingBox PR #9 merged before updating the submodule pointer

## Device boundary

No adb device was connected during implementation, so the PR does not claim on-device validation. The automated route model, real sing-box parser, browser runtime, and fake-Magisk smoke are green.

Related to #99, #100, and #101.

## Summary by Sourcery

加强 ChatGPT/X 应用的路由保证，收紧 ChatGPT Voice IP 前缀处理，并优化 WebUI 诊断与布局样式。

New Features:
- 引入自动化预构建钩子，从 OpenAI 刷新 ChatGPT Voice UDP/3478 IP 前缀并在应用前进行校验。
- 添加操作捕获跟踪，使问题报告绑定到当前活动命令及其输出，而不是被后续异步工作覆盖。

Bug Fixes:
- 确保需要并验证 DNS 反向映射，使 ChatGPT 和 X 在仅 IP 的 Android 流程中仍能保持正确的域名归属，避免落入 CN 直连路由。
- 将 ChatGPT Voice 路由约束为一个单一的规范化 UDP/3478 规则，并使用官方 IP 前缀且优先于 CN IP 归属规则。
- 通过本地代理，将 CLI DNS 测试路由到 MagicNet 管理的混合入站路径，使探测使用与被代理应用相同的 DNS 和出站路径。
- 拒绝非 HTTP 的 dns 测试状态码，并将 100–599 之外的值视为无效 HTTP 状态码。
- 修正运行时日志级别过滤和问题行提取逻辑，包括对带 ANSI 颜色和插入符编码的终端序列的处理，以便准确分类警告和错误。
- 防止 DNS 测试 CLI 输出覆盖 WebUI 主命令输出状态。
- 移除表单控件上的全局字体缩写设置，避免其覆盖 Tailwind 的响应式按钮排版。
- 修复 UI 标签颜色和链接样式，改用专用的高对比度墨水色彩 token，以保持导航和引导文案的一致性。

Enhancements:
- 为 ChatGPT Voice 规则生成、操作捕获语义、Anthropic 样式契约以及 UI 布局回归添加针对性测试，以保护路由与设计约束。
- 精细化运行时 cockpit shell 样式，引入编辑字段/承载层级结构，并调整明/暗主题的强调色彩 token。
- 更新运行时日志与输出面板，使用共享的日志分析辅助工具，将问题检测与级别过滤逻辑集中化。

Build:
- 扩展 pre-commit 脚本，运行新的 ChatGPT Voice 路由测试及相关钩子校验。

Tests:
- 添加单元与集成测试，覆盖 DNS curl 代理使用、运行时日志分析与净化、操作捕获顺序、ChatGPT Voice 规则更新、Anthropic 样式约束，以及 UI 布局回归。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen ChatGPT/X app routing guarantees, tighten ChatGPT Voice IP prefix handling, and refine WebUI diagnostics and layout styling.

New Features:
- Introduce automated pre-build hook to refresh ChatGPT Voice UDP/3478 IP prefixes from OpenAI and validate them before applying.
- Add operation capture tracking so issue reports are bound to the currently active command and its output instead of overwritten by later async work.

Bug Fixes:
- Ensure DNS reverse mapping is required and validated so IP-only Android flows for ChatGPT and X preserve correct domain ownership and avoid falling through to CN-direct routes.
- Constrain ChatGPT Voice routing to a single canonical UDP/3478 rule with official IP prefixes that precedes CN IP ownership rules.
- Route CLI DNS tests through MagicNet’s managed mixed inbound via a local proxy so probes exercise the same DNS and outbound path as proxied apps.
- Reject non-HTTP dns test status codes and treat values outside 100–599 as invalid HTTP statuses.
- Correct runtime log level filtering and issue line extraction, including ANSI-colored and caret-encoded terminal sequences, so warnings and errors are classified accurately.
- Prevent DNS test CLI output from overwriting the main WebUI command output state.
- Remove global font shorthand on form controls that was overriding Tailwind’s responsive button typography.
- Fix UI label colors and link styling to use dedicated high-contrast ink tokens, keeping navigation and onboarding text consistent.

Enhancements:
- Add targeted tests for ChatGPT Voice rule generation, operation capture semantics, Anthropic style contract, and UI layout regressions to guard routing and design constraints.
- Refine runtime cockpit shell styling with an editorial field/carrier hierarchy and adjust accent palette tokens for light/dark themes.
- Update runtime log and output panels to use shared log analysis helpers, centralizing issue detection and level filtering logic.

Build:
- Extend pre-commit script to run the new ChatGPT Voice routing test and associated hook validation.

Tests:
- Add unit and integration tests covering DNS curl proxy usage, runtime log analysis and sanitization, operation capture ordering, ChatGPT Voice rule updates, Anthropic styling constraints, and UI layout regressions.

</details>