### PR TITLE
release: v1.2.11 hotspot and security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   policy when Android creates, removes, or renumbers the hotspot interface.
 - Restore the X/Twitter DNS ownership rule and harden packaged subscription and
   route configuration updates against partial writes.
+- Keep repeated runtime configuration application idempotent while preserving
+  selector connection-interruption semantics.
 - Pin transitive WebUI `nanoid` to `3.3.17` to remediate Dependabot alert #3
   (GHSA-2v37-7h3g-55p8 / CVE-2026-67213).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Unreleased
 
+## v1.2.11 (2026-08-11)
+
+- Add a configurable sing-box two-hop proxy chain with manual or automatic
+  exit selection, CLI controls, persisted policy, and Zashboard selector
+  integration.
+- Fix hotspot proxy sharing by dynamically discovering tether interfaces and
+  subnets, routing tethered IPv4 traffic into `magicnet0`, and reconciling the
+  policy when Android creates, removes, or renumbers the hotspot interface.
+- Restore the X/Twitter DNS ownership rule and harden packaged subscription and
+  route configuration updates against partial writes.
+- Pin transitive WebUI `nanoid` to `3.3.17` to remediate Dependabot alert #3
+  (GHSA-2v37-7h3g-55p8 / CVE-2026-67213).
+
 - Import `socks://` and `socks5://` nodes natively with validated optional
   authentication, and preserve independent VMess WebSocket path, Host, server,
   and SNI fields through sing-box outbound generation.
@@ -10,6 +23,9 @@
 - Disable Android tether offload while hotspot Proxy is enabled, then restore
   the previous system value when disabled or uninstalled so tethered traffic
   cannot bypass the TUN through vendor hardware/BPF forwarding.
+- Discover Android tether interfaces dynamically and install reversible
+  `ip rule` entries ahead of the OEM tethering rule so hotspot clients reach
+  the `magicnet0` TUN even when the OEM changes the SoftAP subnet.
 - Fix #93 by accepting validated standalone sing-box JSON configs and imported
   Clash YAML, base64, share-link, JSON, or text subscription files as local
   startup sources without requiring a subscription URL, with atomic URL/local

--- a/crates/magicnet-cli/src/chain.rs
+++ b/crates/magicnet-cli/src/chain.rs
@@ -1,0 +1,365 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+
+use crate::selector_store;
+use crate::service::apply_config;
+use crate::webui_api::{curl_get_json, select_proxy};
+use crate::{write_text_file, App};
+
+const POLICY_PATH: &str = ".config/magicnet/proxy-chain.json";
+const CHAIN_PREFIX: &str = "magicnet-chain-";
+
+pub(crate) fn chain_cmd(app: &App, args: &[String]) -> Result<(), String> {
+    match args.first().map(String::as_str).unwrap_or("status") {
+        "status" => chain_status(app),
+        "enable" => set_enabled(app, true),
+        "disable" => set_enabled(app, false),
+        "set-upstream" => set_role(app, "upstream", &args[1..].join(" ")),
+        "set-exit" => set_role(app, "exit", &args[1..].join(" ")),
+        "clear-upstream" => clear_role(app, "upstream"),
+        "clear-exit" => clear_role(app, "exit"),
+        "mode" => set_mode(app, args.get(1).map(String::as_str).unwrap_or_default()),
+        "select-upstream" => select_upstream(app, &args[1..].join(" ")),
+        "select-exit" => select_exit(app, &args[1..].join(" ")),
+        _ => Err(chain_usage()),
+    }
+}
+
+fn chain_usage() -> String {
+    "Usage: cli chain {status|enable|disable|set-upstream <tag>|set-exit <tag>|clear-upstream|clear-exit|mode <manual|auto>|select-upstream <tag>|select-exit <tag>}"
+        .to_string()
+}
+
+fn policy_path(app: &App) -> PathBuf {
+    app.moddir.join(POLICY_PATH)
+}
+
+fn default_policy() -> Value {
+    json!({
+        "enabled": false,
+        "mode": "manual",
+        "upstream": [],
+        "exit": []
+    })
+}
+
+fn load_policy(app: &App) -> Result<(Value, Option<Vec<u8>>), String> {
+    let path = policy_path(app);
+    let previous = match fs::read(&path) {
+        Ok(bytes) => Some(bytes),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(format!("read proxy chain policy: {error}")),
+    };
+    let policy = match previous.as_deref() {
+        Some(bytes) => serde_json::from_slice(bytes)
+            .map_err(|error| format!("parse proxy chain policy: {error}"))?,
+        None => default_policy(),
+    };
+    if !policy.is_object() {
+        return Err("proxy chain policy must be a JSON object".to_string());
+    }
+    Ok((policy, previous))
+}
+
+fn write_policy(app: &App, policy: &Value) -> Result<(), String> {
+    let text = serde_json::to_string_pretty(policy)
+        .map_err(|error| format!("encode proxy chain policy: {error}"))?;
+    write_text_file(app, Path::new(POLICY_PATH), &format!("{text}\n"))
+}
+
+fn restore_policy(app: &App, previous: Option<&[u8]>) -> Result<(), String> {
+    let path = policy_path(app);
+    match previous {
+        Some(bytes) => {
+            write_text_file(app, Path::new(POLICY_PATH), &String::from_utf8_lossy(bytes))
+        }
+        None => match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(format!("remove new proxy chain policy: {error}")),
+        },
+    }
+}
+
+fn commit_policy(
+    app: &App,
+    policy: &Value,
+    previous: Option<&[u8]>,
+    apply: bool,
+) -> Result<(), String> {
+    write_policy(app, policy)?;
+    if !apply {
+        return Ok(());
+    }
+    if let Err(error) = apply_config(app) {
+        let restore_error = restore_policy(app, previous).err();
+        let detail = restore_error
+            .map(|restore| format!("; policy restore failed: {restore}"))
+            .unwrap_or_default();
+        return Err(format!("apply proxy chain policy failed: {error}{detail}"));
+    }
+    Ok(())
+}
+
+fn policy_enabled(policy: &Value) -> bool {
+    policy
+        .get("enabled")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn policy_mode(policy: &Value) -> &str {
+    policy
+        .get("mode")
+        .and_then(Value::as_str)
+        .filter(|mode| matches!(*mode, "manual" | "auto"))
+        .unwrap_or("manual")
+}
+
+fn role_tags<'a>(policy: &'a Value, role: &str) -> Vec<&'a str> {
+    policy
+        .get(role)
+        .and_then(Value::as_array)
+        .map(|items| items.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default()
+}
+
+fn set_enabled(app: &App, enabled: bool) -> Result<(), String> {
+    let (mut policy, previous) = load_policy(app)?;
+    if enabled
+        && (role_tags(&policy, "upstream").is_empty() || role_tags(&policy, "exit").is_empty())
+    {
+        return Err("set upstream and exit nodes before enabling the proxy chain".to_string());
+    }
+    policy["enabled"] = Value::Bool(enabled);
+    commit_policy(app, &policy, previous.as_deref(), true)?;
+    let runtime_member = if enabled {
+        "chain".to_string()
+    } else {
+        proxy_default_member(app)?
+    };
+    select_runtime_member(app, "proxy", &runtime_member)?;
+    println!(
+        "[info] proxy chain {}",
+        if enabled { "enabled" } else { "disabled" }
+    );
+    Ok(())
+}
+
+fn set_role(app: &App, role: &str, tag: &str) -> Result<(), String> {
+    let tag = clean_tag(tag)?;
+    if !base_node_exists(app, &tag)? {
+        return Err(format!("proxy node is not available: {tag}"));
+    }
+    let (mut policy, previous) = load_policy(app)?;
+    policy[role] = json!([tag]);
+    let apply = policy_enabled(&policy);
+    commit_policy(app, &policy, previous.as_deref(), apply)?;
+    println!("[info] proxy chain {role} node set to {tag}");
+    Ok(())
+}
+
+fn clear_role(app: &App, role: &str) -> Result<(), String> {
+    let (mut policy, previous) = load_policy(app)?;
+    policy[role] = json!([]);
+    if policy_enabled(&policy) {
+        return Err("disable the proxy chain before clearing a chain role".to_string());
+    }
+    commit_policy(app, &policy, previous.as_deref(), false)?;
+    println!("[info] proxy chain {role} node cleared");
+    Ok(())
+}
+
+fn set_mode(app: &App, mode: &str) -> Result<(), String> {
+    if !matches!(mode.trim(), "manual" | "auto") {
+        return Err("proxy chain mode must be manual or auto".to_string());
+    }
+    let (mut policy, previous) = load_policy(app)?;
+    policy["mode"] = Value::String(mode.trim().to_string());
+    let apply = policy_enabled(&policy);
+    commit_policy(app, &policy, previous.as_deref(), apply)?;
+    println!("[info] proxy chain mode set to {}", mode.trim());
+    Ok(())
+}
+
+fn clean_tag(tag: &str) -> Result<String, String> {
+    let tag = tag.trim();
+    if tag.is_empty() {
+        return Err(chain_usage());
+    }
+    if tag.chars().any(char::is_control) {
+        return Err("proxy node tag contains a control character".to_string());
+    }
+    if tag.starts_with(CHAIN_PREFIX) {
+        return Err("generated proxy chain tags cannot be used as base nodes".to_string());
+    }
+    Ok(tag.to_string())
+}
+
+fn base_node_exists(app: &App, tag: &str) -> Result<bool, String> {
+    let config = fs::read_to_string(app.moddir.join(".config/sing-box/config.json"))
+        .map_err(|error| format!("read sing-box config: {error}"))?;
+    let value: Value =
+        serde_json::from_str(&config).map_err(|error| format!("parse sing-box config: {error}"))?;
+    Ok(value
+        .get("outbounds")
+        .and_then(Value::as_array)
+        .is_some_and(|outbounds| {
+            outbounds.iter().any(|outbound| {
+                outbound.get("tag").and_then(Value::as_str) == Some(tag)
+                    && outbound
+                        .get("tag")
+                        .and_then(Value::as_str)
+                        .is_some_and(|name| !name.starts_with(CHAIN_PREFIX))
+                    && matches!(
+                        outbound.get("type").and_then(Value::as_str),
+                        Some(
+                            "shadowsocks"
+                                | "vmess"
+                                | "vless"
+                                | "trojan"
+                                | "hysteria2"
+                                | "anytls"
+                                | "tuic"
+                                | "socks"
+                        )
+                    )
+            })
+        }))
+}
+
+fn proxy_default_member(app: &App) -> Result<String, String> {
+    let config = fs::read_to_string(app.moddir.join(".config/sing-box/config.json"))
+        .map_err(|error| format!("read sing-box config: {error}"))?;
+    let value: Value =
+        serde_json::from_str(&config).map_err(|error| format!("parse sing-box config: {error}"))?;
+    let default = value
+        .get("outbounds")
+        .and_then(Value::as_array)
+        .and_then(|outbounds| {
+            outbounds.iter().find(|outbound| {
+                outbound.get("tag").and_then(Value::as_str) == Some("proxy")
+                    && outbound.get("type").and_then(Value::as_str) == Some("selector")
+            })
+        })
+        .and_then(|proxy| proxy.get("default"))
+        .and_then(Value::as_str)
+        .filter(|member| {
+            !member.is_empty() && *member != "chain" && !member.starts_with(CHAIN_PREFIX)
+        })
+        .unwrap_or("block");
+    Ok(default.to_string())
+}
+
+fn select_upstream(app: &App, tag: &str) -> Result<(), String> {
+    let tag = clean_tag(tag)?;
+    let (policy, _) = load_policy(app)?;
+    if !role_tags(&policy, "upstream").contains(&tag.as_str()) {
+        return Err("upstream tag is not in the configured chain role".to_string());
+    }
+    select_runtime_member(app, "chain-hop1", &tag)
+}
+
+fn select_exit(app: &App, tag: &str) -> Result<(), String> {
+    let requested = tag.trim();
+    if requested.is_empty() {
+        return Err(chain_usage());
+    }
+    let member = if requested.starts_with("magicnet-chain-exit::") {
+        if requested.chars().any(char::is_control) || !generated_exit_exists(app, requested)? {
+            return Err("generated chain exit is not available".to_string());
+        }
+        requested.to_string()
+    } else {
+        let base = clean_tag(requested)?;
+        let generated = format!("magicnet-chain-exit::{base}");
+        if !generated_exit_exists(app, &generated)? {
+            return Err(format!("generated chain exit is not available: {base}"));
+        }
+        generated
+    };
+    select_runtime_member(app, "chain-exit", &member)
+}
+
+fn generated_exit_exists(app: &App, tag: &str) -> Result<bool, String> {
+    let config = fs::read_to_string(app.moddir.join(".config/sing-box/config.json"))
+        .map_err(|error| format!("read sing-box config: {error}"))?;
+    let value: Value =
+        serde_json::from_str(&config).map_err(|error| format!("parse sing-box config: {error}"))?;
+    Ok(value
+        .get("outbounds")
+        .and_then(Value::as_array)
+        .is_some_and(|outbounds| {
+            outbounds.iter().any(|outbound| {
+                outbound.get("tag").and_then(Value::as_str) == Some(tag)
+                    && outbound.get("detour").and_then(Value::as_str) == Some("chain-hop1")
+            })
+        }))
+}
+
+fn select_runtime_member(app: &App, group: &str, member: &str) -> Result<(), String> {
+    if curl_get_json(app, "/proxies").is_ok() {
+        select_proxy(app, group, member)
+    } else {
+        selector_store::save(app, group, member)
+            .map_err(|error| format!("persist proxy chain selector: {error}"))
+    }
+}
+
+fn chain_status(app: &App) -> Result<(), String> {
+    let (policy, _) = load_policy(app)?;
+    println!("enabled={}", policy_enabled(&policy));
+    println!("mode={}", policy_mode(&policy));
+    print_role_status("upstream", &policy);
+    print_role_status("exit", &policy);
+    match curl_get_json(app, "/proxies") {
+        Ok(runtime) => {
+            println!("runtime=available");
+            for group in ["proxy", "chain", "chain-hop1", "chain-exit"] {
+                if let Some(now) = runtime
+                    .get("proxies")
+                    .and_then(|proxies| proxies.get(group))
+                    .and_then(|value| value.get("now"))
+                    .and_then(Value::as_str)
+                {
+                    println!("runtime.{group}={now}");
+                }
+            }
+        }
+        Err(_) => println!("runtime=unavailable"),
+    }
+    Ok(())
+}
+
+fn print_role_status(role: &str, policy: &Value) {
+    let tags = role_tags(policy, role);
+    if tags.is_empty() {
+        println!("{role}=none");
+    } else {
+        println!("{role}={}", tags.join(","));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{clean_tag, default_policy, policy_mode};
+
+    #[test]
+    fn default_policy_starts_disabled_and_manual() {
+        let policy = default_policy();
+        assert!(!policy["enabled"].as_bool().unwrap_or(true));
+        assert_eq!(policy_mode(&policy), "manual");
+    }
+
+    #[test]
+    fn clean_tag_rejects_generated_chain_tags() {
+        assert!(clean_tag("magicnet-chain-exit::node-a").is_err());
+    }
+
+    #[test]
+    fn clean_tag_preserves_node_names_with_spaces() {
+        assert_eq!(clean_tag("  node a  ").unwrap(), "node a");
+    }
+}

--- a/crates/magicnet-cli/src/diagnostics.rs
+++ b/crates/magicnet-cli/src/diagnostics.rs
@@ -295,6 +295,10 @@ fn support_bundle(app: &App) -> String {
 
 const SUPPORT_CHAIN_TAGS: &[&str] = &[
     "proxy",
+    "chain",
+    "chain-hop1",
+    "chain-exit",
+    "chain-auto",
     "select",
     "final",
     "proxy-rule",
@@ -436,6 +440,8 @@ fn safe_proxy_kind(value: &str) -> &str {
         "anytls" => "anytls",
         "tuic" => "tuic",
         "wireguard" => "wireguard",
+        "socks" => "socks",
+        "http" => "http",
         "selector" => "selector",
         "urltest" => "urltest",
         "direct" => "direct",

--- a/crates/magicnet-cli/src/main.rs
+++ b/crates/magicnet-cli/src/main.rs
@@ -165,7 +165,7 @@ const COMMAND_HELP: &[CommandHelp] = &[
     },
     CommandHelp {
         command: "hotspot",
-        usage: "cli hotspot {status|enable|disable}",
+        usage: "cli hotspot {status|enable|disable|reconcile}",
     },
     CommandHelp {
         command: "route",

--- a/crates/magicnet-cli/src/main.rs
+++ b/crates/magicnet-cli/src/main.rs
@@ -1,6 +1,7 @@
 mod base64;
 #[cfg(test)]
 mod base64_tests;
+mod chain;
 mod config_editor;
 mod connection_control;
 mod diagnostics;
@@ -37,6 +38,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 pub(crate) use base64::{decode_base64, encode_base64};
+use chain::chain_cmd;
 use config_editor::config_editor;
 use diagnostics::{health, support, sysroute, topology};
 use dns::dns_cmd;
@@ -148,6 +150,10 @@ const COMMAND_HELP: &[CommandHelp] = &[
     CommandHelp {
         command: "node",
         usage: "cli node {list|current|use|test <name>|test-all [name ...]}",
+    },
+    CommandHelp {
+        command: "chain",
+        usage: "cli chain {status|enable|disable|set-upstream <tag>|set-exit <tag>|clear-upstream|clear-exit|mode <manual|auto>|select-upstream <tag>|select-exit <tag>}",
     },
     CommandHelp {
         command: "mode",
@@ -347,6 +353,7 @@ fn dispatch(app: &App, args: &[String]) -> Result<(), String> {
         "wifi" => wifi_cmd(app, &args[1..]),
         "hotspot" => hotspot_cmd(app, &args[1..]),
         "node" => node_cmd(app, &args[1..]),
+        "chain" => chain_cmd(app, &args[1..]),
         "sub" if args.get(1).map(String::as_str) == Some("list") => {
             sub_list(app);
             Ok(())

--- a/crates/magicnet-cli/src/nodes.rs
+++ b/crates/magicnet-cli/src/nodes.rs
@@ -278,6 +278,10 @@ fn is_obvious_group(name: &str) -> bool {
             | "Global"
             | "global"
             | "proxy"
+            | "chain"
+            | "chain-hop1"
+            | "chain-exit"
+            | "chain-auto"
             | "select"
             | "lan"
             | "ad-block"
@@ -299,6 +303,7 @@ fn is_obvious_group(name: &str) -> bool {
             | "final"
     ) || name.contains("选择")
         || name.contains("策略")
+        || name.starts_with("magicnet-chain-")
         || name.contains("Selector")
         || name.contains("selector")
         || name.contains("URLTest")

--- a/crates/magicnet-cli/src/service.rs
+++ b/crates/magicnet-cli/src/service.rs
@@ -11,7 +11,7 @@ use crate::{
 
 const START_SUPERVISORS_COMMAND: &str = "\"${MODDIR}/cli\" supervisor start all >/dev/null 2>&1";
 const STOP_RUNTIME_CLEANUP_COMMAND: &str =
-    "magicnet_disable_dns_capture || true; magicnet_disable_dns_leak_guard || true";
+    "magicnet_hotspot_watchdog_stop >/dev/null 2>&1 || true; magicnet_hotspot_route_cleanup >/dev/null 2>&1 || true; magicnet_disable_dns_capture || true; magicnet_disable_dns_leak_guard || true";
 const SELECTED_CORE_CONF: &str = ".config/magicnet/current-core.conf";
 const TRANSPARENT_MODE_CONF: &str = ".config/magicnet/transparent-mode.conf";
 const CONFIG_APPLY_LOCK: &str = ".state/config-apply.lock";
@@ -196,11 +196,8 @@ pub(crate) fn apply_config(app: &App) -> Result<(), String> {
     // current.  A missing or unreadable fingerprint remains fail-safe and
     // takes the restart path.
     if singbox_pid_summary(app) != "stopped" {
-        let runtime_unchanged = run_magicnet_function(
-            app,
-            "magicnet_singbox_runtime_fingerprint_matches",
-        )
-        .is_ok();
+        let runtime_unchanged =
+            run_magicnet_function(app, "magicnet_singbox_runtime_fingerprint_matches").is_ok();
         if !runtime_unchanged {
             restart_current_core_preserving_config_apply(app)?;
         }
@@ -638,7 +635,7 @@ mod tests {
     fn stop_runtime_cleanup_disables_dns_capture_before_leak_guard() {
         assert_eq!(
             stop_runtime_cleanup_command(),
-            "magicnet_disable_dns_capture || true; magicnet_disable_dns_leak_guard || true"
+            "magicnet_hotspot_watchdog_stop >/dev/null 2>&1 || true; magicnet_hotspot_route_cleanup >/dev/null 2>&1 || true; magicnet_disable_dns_capture || true; magicnet_disable_dns_leak_guard || true"
         );
     }
 

--- a/crates/magicnet-cli/src/webui_api.rs
+++ b/crates/magicnet-cli/src/webui_api.rs
@@ -11,7 +11,7 @@ use crate::connection_control::{
     print_close_all_summary,
 };
 use crate::selector_store;
-use crate::service::singbox_webui;
+use crate::service::{apply_config, singbox_webui};
 use crate::subscriptions::validate_subscription_url;
 use crate::{run_magicnet_function, write_text_file, App};
 
@@ -57,6 +57,17 @@ fn sync_persisted_hotspot_offload(app: &App) {
     if let Err(err) = run_magicnet_function(app, function) {
         eprintln!("[warning] persisted hotspot offload state could not be synchronized: {err}");
     }
+    if member == "proxy" {
+        if let Err(err) = run_magicnet_function(app, "magicnet_hotspot_reconcile") {
+            eprintln!("[warning] persisted hotspot TUN route could not be reconciled: {err}");
+        }
+        if let Err(err) = run_magicnet_function(app, "magicnet_hotspot_watchdog_start") {
+            eprintln!("[warning] hotspot route watcher could not be started: {err}");
+        }
+    } else {
+        let _ = run_magicnet_function(app, "magicnet_hotspot_watchdog_stop");
+        let _ = run_magicnet_function(app, "magicnet_hotspot_route_cleanup");
+    }
 }
 
 pub(crate) fn hotspot_cmd(app: &App, args: &[String]) -> Result<(), String> {
@@ -67,8 +78,10 @@ pub(crate) fn hotspot_cmd(app: &App, args: &[String]) -> Result<(), String> {
             println!("enabled={}", usize::from(member == "proxy"));
             println!("outbound={member}");
             run_magicnet_function(app, "magicnet_hotspot_offload_status")?;
+            run_magicnet_function(app, "magicnet_hotspot_route_status")?;
             Ok(())
         }
+        "reconcile" => run_magicnet_function(app, "magicnet_hotspot_reconcile"),
         "enable" | "disable" => {
             let member = if action == "enable" {
                 "proxy"
@@ -93,12 +106,39 @@ pub(crate) fn hotspot_cmd(app: &App, args: &[String]) -> Result<(), String> {
                 }
                 return Err(error);
             }
+            if action == "enable" {
+                // The hotspot source rule is consumed at sing-box startup.
+                // Apply the canonical RFC1918 rule and restart only when the
+                // effective runtime fingerprint changed; this upgrades an
+                // already-running process from the legacy fixed subnets.
+                if let Err(error) = apply_config(app) {
+                    let _ = select_proxy(app, "hotspot", "direct");
+                    let _ = run_magicnet_function(app, "magicnet_hotspot_offload_restore");
+                    return Err(format!("apply hotspot TUN policy: {error}"));
+                }
+                if let Err(error) = run_magicnet_function(app, "magicnet_hotspot_reconcile") {
+                    let _ = select_proxy(app, "hotspot", "direct");
+                    let _ = run_magicnet_function(app, "magicnet_hotspot_offload_restore");
+                    let _ = run_magicnet_function(app, "magicnet_hotspot_route_cleanup");
+                    return Err(format!("apply hotspot TUN route: {error}"));
+                }
+                if let Err(error) = run_magicnet_function(app, "magicnet_hotspot_watchdog_start") {
+                    let _ = select_proxy(app, "hotspot", "direct");
+                    let _ = run_magicnet_function(app, "magicnet_hotspot_offload_restore");
+                    let _ = run_magicnet_function(app, "magicnet_hotspot_route_cleanup");
+                    return Err(format!("start hotspot route watcher: {error}"));
+                }
+            }
             if action == "disable" {
                 run_magicnet_function(app, "magicnet_hotspot_offload_restore")?;
+                let stop_result = run_magicnet_function(app, "magicnet_hotspot_watchdog_stop");
+                let cleanup_result = run_magicnet_function(app, "magicnet_hotspot_route_cleanup");
+                stop_result?;
+                cleanup_result?;
             }
             Ok(())
         }
-        _ => Err("Usage: cli hotspot {status|enable|disable}".to_string()),
+        _ => Err("Usage: cli hotspot {status|enable|disable|reconcile}".to_string()),
     }
 }
 

--- a/docs/next-gen-architecture.md
+++ b/docs/next-gen-architecture.md
@@ -24,7 +24,7 @@ Android 应用 / 已进入内核转发的热点流量
 
 设备应用包由 root 管理的 TUN 自动路由进入 sing-box。MagicNet 不调用 Android 应用的 `VpnService.establish()`，因此不会占用系统 VPN slot。`Bypass TUN` UID 是明确例外：它们同时绕过 TUN 和 MagicNet DNS 捕获，回到原生网络或外部 VPN 的路径。
 
-热点仍由 Android/OEM tethering 完成 DHCP、NAT 与转发。选择热点 Proxy 时，MagicNet 暂时关闭 tether 硬件卸载，使转发包有机会进入 `magicnet0`，再由 `hotspot` selector 决定 Direct 或 Proxy；退出 Proxy 或卸载会恢复原值。
+热点仍由 Android/OEM tethering 完成 DHCP 与 NAT。选择热点 Proxy 时，MagicNet 发现真实 tether 接口，在 Android tethering 规则之前添加指向 sing-box `table 2022` 的临时 `ip rule`，并关闭 tether 硬件卸载，让转发包进入 `magicnet0`，再由 `hotspot` selector 决定 Direct 或 Proxy；接口变化由 watcher 重算，退出 Proxy、停止服务或卸载会清理策略规则并恢复原值。
 
 ## 控制面
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -102,7 +102,7 @@ su -c /data/adb/modules/MagicNet/cli wifi status
 
 ## 热点
 
-MagicNet 不创建热点，也不替代 Android 的 tethering/NAT。热点客户端流量已经进入 `magicnet0` 后，可通过 `hotspot` selector 选择 Direct 或 Proxy：
+MagicNet 不创建热点，也不替代 Android 的 DHCP/NAT。启用热点 Proxy 后，MagicNet 会把当前 tether 接口的 IPv4 入站策略路由到 `magicnet0`，再通过 `hotspot` selector 选择 Direct 或 Proxy：
 
 ```bash
 su -c /data/adb/modules/MagicNet/cli hotspot status
@@ -152,7 +152,7 @@ su -c /data/adb/modules/MagicNet/cli support bundle
 - 域名失败但 IP 可达：检查 Private DNS、`cli dns status` 和 DNS 相关诊断。
 - TCP 正常、UDP/QUIC 异常：检查网络策略、MTU、节点 UDP 能力和 `ipv4_only` 对照结果。
 - 某应用策略无效：检查包名、Android 用户、`cli app list`，再执行 `cli app apply`。
-- 热点设备异常而手机正常：检查 `cli hotspot status`、tether offload 状态和热点客户端是否真正进入 `magicnet0`。
+- 热点设备异常而手机正常：检查 `cli hotspot status`，确认 `route_status=ready`、`downstream_interfaces` 和 `policy_rule`，再确认 tether offload 已关闭且客户端流量进入 `magicnet0`。
 - 更新订阅失败：保留原配置，查看 `cli sub status` 和支持包中的失败阶段，不要删除回滚现场。
 
 支持包和 WebUI Issue 草稿会做脱敏，但提交前仍应人工检查。不要公开订阅 URL、token、MCP secret、password、完整节点地址、设备序列号或未经检查的完整日志。

--- a/kam.toml
+++ b/kam.toml
@@ -1,8 +1,8 @@
 [prop]
 id = "MagicNet"
 name = "MagicNet"
-version = "v1.2.10"
-versionCode = 1786360750770
+version = "v1.2.11"
+versionCode = 1786454155461
 author = "LIghtJUNction"
 description = "[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM."
 updateJson = "https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json"

--- a/scripts/fake-magisk-smoke.sh
+++ b/scripts/fake-magisk-smoke.sh
@@ -758,7 +758,7 @@ hotspot_policy_ready() {
     )
     and ([.route.rules[] | select(
       .inbound == ["tun-in"]
-      and .source_ip_cidr == ["192.168.0.0/16", "10.42.0.0/16", "172.20.10.0/28"]
+      and .source_ip_cidr == ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
       and .outbound == "hotspot"
     )] | length == 1)
     ' "$MODDIR/.config/sing-box/config.json" >/dev/null
@@ -1274,16 +1274,20 @@ run env MODDIR="$MODDIR" MODPATH="$MODDIR" PATH="$MOCK_BIN:$TOYBOX_APPLET_BIN:$M
     "$MODDIR/cli" config apply
 test ! -d "$MODDIR/.state/sing-box/subscription-update.lock"
 cp "$MODDIR/.config/sing-box/config.json" "$TMP/config-apply-first.json"
+# shellcheck disable=SC2016
 if ! env MODDIR="$MODDIR" MODPATH="$MODDIR" PATH="$MOCK_BIN:$TOYBOX_APPLET_BIN:$MODDIR/bin:$ORIGINAL_PATH" \
     sh -c '. "$MODDIR/lib/kamfw/.kamfwrc"; import magicnet; magicnet_singbox_runtime_fingerprint_matches'; then
     echo "first config apply left a stale sing-box runtime fingerprint" >&2
     echo "stored: $(cat "$MODDIR/.state/sing-box/runtime-fingerprint" 2>/dev/null || echo missing)" >&2
+    # shellcheck disable=SC2016
     env MODDIR="$MODDIR" MODPATH="$MODDIR" PATH="$MOCK_BIN:$TOYBOX_APPLET_BIN:$MODDIR/bin:$ORIGINAL_PATH" \
         sh -c '. "$MODDIR/lib/kamfw/.kamfwrc"; import magicnet; printf "current: "; magicnet_singbox_runtime_fingerprint' >&2 || true
     exit 1
 fi
+# shellcheck disable=SC2016
 run env MODDIR="$MODDIR" MODPATH="$MODDIR" PATH="$MOCK_BIN:$TOYBOX_APPLET_BIN:$MODDIR/bin:$ORIGINAL_PATH" \
     sh -c '. "$MODDIR/lib/kamfw/.kamfwrc"; import magicnet; magicnet_apply_runtime_config'
+# shellcheck disable=SC2016
 if ! env MODDIR="$MODDIR" MODPATH="$MODDIR" PATH="$MOCK_BIN:$TOYBOX_APPLET_BIN:$MODDIR/bin:$ORIGINAL_PATH" \
     sh -c '. "$MODDIR/lib/kamfw/.kamfwrc"; import magicnet; magicnet_singbox_runtime_fingerprint_matches'; then
     echo "runtime materialization changed the running sing-box inputs:" >&2
@@ -1383,3 +1387,97 @@ unset _diag_name
 assert_transparent_mode() {
     local mode="$1"
     local before_marker after_marker
+
+    before_marker="$(wc -l <"$MOCK_LOG")"
+    # shellcheck disable=SC2016
+    run env MAGICNET_TEST_MODE="$mode" sh -c '
+        . "$MODDIR/lib/kamfw/.kamfwrc"
+        import __runtime__
+        . "$MODDIR/lib/magicnet.sh"
+        mkdir -p "$MODDIR/.config/magicnet"
+        magicnet_transparent_set_mode "$MAGICNET_TEST_MODE"
+        magicnet_transparent_apply
+    '
+    after_marker="$(wc -l <"$MOCK_LOG")"
+    sed -n "$((before_marker + 1)),${after_marker}p" "$MOCK_LOG" >"$TMP/${mode}-commands.log"
+
+    "$MODDIR/cli" transparent status | tee "$TMP/${mode}-transparent-status.log"
+    rg -qx "mode=${mode}" "$TMP/${mode}-transparent-status.log"
+
+    python3 - "$MODDIR/.config/sing-box/config.json" "$mode" <<'PY'
+import json
+import pathlib
+import sys
+
+singbox_path = sys.argv[1]
+mode = sys.argv[2]
+singbox = json.loads(pathlib.Path(singbox_path).read_text())
+
+inbound_types = [inbound.get("type") for inbound in singbox.get("inbounds", [])]
+inbound_tags = [inbound.get("tag") for inbound in singbox.get("inbounds", [])]
+sniff_rule = next((rule for rule in singbox.get("route", {}).get("rules", []) if rule.get("action") == "sniff"), None)
+legacy_inbound_fields = {"sniff", "sniff_timeout", "domain_strategy"}
+
+if inbound_tags.count("mixed-in") != 1:
+    raise SystemExit(f"mixed-in inbound should appear exactly once in {mode} mode: {inbound_tags!r}")
+dns_inbound = next((inbound for inbound in singbox.get("inbounds", []) if inbound.get("tag") == "magicnet-dns-in"), None)
+if not dns_inbound:
+    raise SystemExit(f"magicnet DNS inbound missing in {mode} mode")
+if dns_inbound.get("type") != "direct" or dns_inbound.get("listen") != "127.0.0.1" or dns_inbound.get("listen_port") != 1053:
+    raise SystemExit(f"magicnet DNS inbound mismatch in {mode} mode: {dns_inbound!r}")
+dns_hijack = next(
+    (
+        rule for rule in singbox.get("route", {}).get("rules", [])
+        if rule.get("action") == "hijack-dns"
+        and rule.get("inbound") == ["magicnet-dns-in"]
+        and "protocol" not in rule
+    ),
+    None,
+)
+if not dns_hijack:
+    raise SystemExit(f"magicnet DNS hijack rule missing in {mode} mode")
+for inbound in singbox.get("inbounds", []):
+    present = sorted(legacy_inbound_fields.intersection(inbound))
+    if present:
+        raise SystemExit(f"legacy inbound fields present in {mode} mode: tag={inbound.get('tag')!r} fields={present!r}")
+if "tun" not in inbound_types:
+    raise SystemExit(f"sing-box tun inbound missing in {mode} mode")
+tun_inbound = next((inbound for inbound in singbox.get("inbounds", []) if inbound.get("type") == "tun"), {})
+if tun_inbound.get("tag") != "tun-in":
+    raise SystemExit(f"sing-box tun tag mismatch in {mode} mode: {tun_inbound.get('tag')!r}")
+if tun_inbound.get("address") != ["172.19.0.1/30", "fdfe:dcba:9876::1/126"]:
+    raise SystemExit(f"sing-box tun address is not dual-stack in {mode} mode: {tun_inbound.get('address')!r}")
+expected_sniff_inbounds = ["mixed-in", "tun-in"]
+if any(kind in inbound_types for kind in ("tproxy", "redirect")):
+    raise SystemExit(f"legacy transparent inbound still present in {mode} mode: {inbound_types!r}")
+if any((inbound.get("tag") or "").startswith("magicnet-") and inbound.get("tag") != "magicnet-dns-in" for inbound in singbox.get("inbounds", [])):
+    raise SystemExit(f"managed transparent inbound still present in {mode} mode")
+if not sniff_rule:
+    raise SystemExit(f"sing-box sniff rule missing in {mode} mode")
+if sniff_rule.get("inbound") != expected_sniff_inbounds:
+    raise SystemExit(f"sing-box sniff inbound list mismatch in {mode} mode: {sniff_rule.get('inbound')!r}")
+PY
+
+    if rg -q -- '-j TPROXY|REDIRECT --to-ports' "$TMP/${mode}-commands.log"; then
+        exit 1
+    fi
+}
+
+assert_transparent_mode tun
+
+for legacy_mode in proxy external external-tun hybrid; do
+    # shellcheck disable=SC2016
+    if run env MAGICNET_TEST_MODE="$legacy_mode" sh -c '
+        . "$MODDIR/lib/kamfw/.kamfwrc"
+        import __runtime__
+        . "$MODDIR/lib/magicnet.sh"
+        magicnet_transparent_set_mode "$MAGICNET_TEST_MODE"
+    '; then
+        echo "legacy transparent mode was still accepted: $legacy_mode" >&2
+        exit 1
+    fi
+done
+
+"$HOST_JQ" empty "$MODDIR/.config/sing-box/config.json"
+
+echo "fake Magisk smoke passed: $MODDIR"

--- a/scripts/fake-magisk-smoke.sh
+++ b/scripts/fake-magisk-smoke.sh
@@ -1276,20 +1276,20 @@ test ! -d "$MODDIR/.state/sing-box/subscription-update.lock"
 cp "$MODDIR/.config/sing-box/config.json" "$TMP/config-apply-first.json"
 # shellcheck disable=SC2016
 if ! env MODDIR="$MODDIR" MODPATH="$MODDIR" PATH="$MOCK_BIN:$TOYBOX_APPLET_BIN:$MODDIR/bin:$ORIGINAL_PATH" \
-    sh -c '. "$MODDIR/lib/kamfw/.kamfwrc"; import magicnet; magicnet_singbox_runtime_fingerprint_matches'; then
+    sh -c '. "$MODDIR/lib/kamfw/.kamfwrc"; import __runtime__; . "$MODDIR/lib/magicnet.sh"; magicnet_singbox_runtime_fingerprint_matches'; then
     echo "first config apply left a stale sing-box runtime fingerprint" >&2
     echo "stored: $(cat "$MODDIR/.state/sing-box/runtime-fingerprint" 2>/dev/null || echo missing)" >&2
     # shellcheck disable=SC2016
     env MODDIR="$MODDIR" MODPATH="$MODDIR" PATH="$MOCK_BIN:$TOYBOX_APPLET_BIN:$MODDIR/bin:$ORIGINAL_PATH" \
-        sh -c '. "$MODDIR/lib/kamfw/.kamfwrc"; import magicnet; printf "current: "; magicnet_singbox_runtime_fingerprint' >&2 || true
+        sh -c '. "$MODDIR/lib/kamfw/.kamfwrc"; import __runtime__; . "$MODDIR/lib/magicnet.sh"; printf "current: "; magicnet_singbox_runtime_fingerprint' >&2 || true
     exit 1
 fi
 # shellcheck disable=SC2016
 run env MODDIR="$MODDIR" MODPATH="$MODDIR" PATH="$MOCK_BIN:$TOYBOX_APPLET_BIN:$MODDIR/bin:$ORIGINAL_PATH" \
-    sh -c '. "$MODDIR/lib/kamfw/.kamfwrc"; import magicnet; magicnet_apply_runtime_config'
+    sh -c '. "$MODDIR/lib/kamfw/.kamfwrc"; import __runtime__; . "$MODDIR/lib/magicnet.sh"; magicnet_apply_runtime_config'
 # shellcheck disable=SC2016
 if ! env MODDIR="$MODDIR" MODPATH="$MODDIR" PATH="$MOCK_BIN:$TOYBOX_APPLET_BIN:$MODDIR/bin:$ORIGINAL_PATH" \
-    sh -c '. "$MODDIR/lib/kamfw/.kamfwrc"; import magicnet; magicnet_singbox_runtime_fingerprint_matches'; then
+    sh -c '. "$MODDIR/lib/kamfw/.kamfwrc"; import __runtime__; . "$MODDIR/lib/magicnet.sh"; magicnet_singbox_runtime_fingerprint_matches'; then
     echo "runtime materialization changed the running sing-box inputs:" >&2
     diff -u \
         <("$HOST_JQ" -S . "$TMP/config-apply-first.json") \

--- a/scripts/package-smoke.sh
+++ b/scripts/package-smoke.sh
@@ -52,6 +52,7 @@ require_entry lib/kamfw/watchdog.sh
 require_entry lib/kamfw/fswatch.sh
 require_entry lib/kamfw/__singbox__.sh
 require_entry lib/magicnet_singbox_subscribe.sh
+require_entry lib/magicnet/chain.sh
 require_entry lib/magicnet/transparent.sh
 require_entry .config/sing-box/config.json
 for entry in common fetch parse config proxylink update; do
@@ -141,6 +142,7 @@ subscription_module_root="$elf_tmp/subscription-module"
 mkdir -p "$subscription_module_root"
 unzip -oq "$ZIP_PATH" \
     'lib/magicnet_singbox_subscribe.sh' \
+    'lib/magicnet/chain.sh' \
     'lib/magicnet/singbox_subscribe/*.sh' \
     -d "$subscription_module_root"
 bash "$ROOT/scripts/singbox-subscription-protocol-smoke.sh" "$subscription_module_root"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -45,6 +45,7 @@ bash scripts/test-block-apply-safety.sh
 bash scripts/test-wechat-routing.sh
 bash scripts/test-action-routing.sh
 bash scripts/test-route-apply-safety.sh
+bash scripts/test-hotspot-routing.sh
 bash scripts/test-singbox-route-apply-safety.sh
 bash scripts/test-anthropic-routing.sh
 bash scripts/test-mcp-phase-config.sh

--- a/scripts/test-app-routing-policy.sh
+++ b/scripts/test-app-routing-policy.sh
@@ -14,6 +14,10 @@ fi
 
 . "$ROOT/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh"
 . "$ROOT/src/MagicNet/lib/magicnet/apps.sh"
+# network.sh reconciles the hotspot policy provided by routes.sh.
+. "$ROOT/src/MagicNet/lib/magicnet/routes.sh"
+# core.sh materializes the optional proxy chain during config startup.
+. "$ROOT/src/MagicNet/lib/magicnet/chain.sh"
 . "$ROOT/src/MagicNet/lib/magicnet/core.sh"
 . "$ROOT/src/MagicNet/lib/magicnet/network.sh"
 . "$ROOT/src/MagicNet/lib/magicnet/runtime_config.sh"

--- a/scripts/test-default-routing-policy.sh
+++ b/scripts/test-default-routing-policy.sh
@@ -2146,7 +2146,13 @@ ln -s "$(command -v awk)" "$selector_no_jq_bin/awk"
 ln -s "$(command -v chmod)" "$selector_no_jq_bin/chmod"
 ln -s "$CONFIG_DIR/rules" "$selector_fixture_dir/rules"
 trap 'rm -rf "$selector_fixture_dir"' EXIT
+export MODDIR="$selector_fixture_dir"
 
+# config.sh materializes the optional proxy chain during subscription updates;
+# load the shared helper explicitly so this standalone policy test matches the
+# module entrypoint and package smoke environment.
+# shellcheck disable=SC1091
+. "$ROOT/src/MagicNet/lib/magicnet/chain.sh"
 # shellcheck disable=SC1091
 . "$ROOT/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh"
 # shellcheck disable=SC1091

--- a/scripts/test-hotspot-routing.sh
+++ b/scripts/test-hotspot-routing.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT HUP INT TERM
+
+MODDIR="$WORK/module"
+RULES="$WORK/ip-rules"
+mkdir -p "$MODDIR/.state/hotspot" "$MODDIR/.config/sing-box"
+printf '%s\n' '21000: from all iif wlan2 lookup wlan0' >"$RULES"
+printf '%s\n' 'value=0' >"$MODDIR/.state/hotspot/tether-offload.previous"
+
+magicnet_cmd_exists() {
+  case "$1" in
+    dumpsys | ip) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+magicnet_iface_exists() {
+  [ "$1" = magicnet0 ] || [ "$1" = wlan2 ]
+}
+
+magicnet_warn() {
+  printf 'warning: %s\n' "$1" >&2
+}
+
+dumpsys() {
+  [ "${1:-}" = tethering ] || return 1
+  printf '%s\n' 'wlan2 - TetheredState - lastError = 0'
+}
+
+settings() {
+  case "${1:-} ${2:-} ${3:-}" in
+    'put global tether_offload_disabled') printf '%s\n' "${4:-}" >"$WORK/offload" ;;
+    'delete global tether_offload_disabled') rm -f "$WORK/offload" ;;
+    *) return 0 ;;
+  esac
+}
+
+ip() {
+  if [ "${1:-}" = route ] && [ "${2:-}" = show ] &&
+    [ "${3:-}" = table ] && [ "${4:-}" = 2022 ]; then
+    printf '%s\n' '0.0.0.0/5 dev magicnet0'
+    return 0
+  fi
+  if [ "${1:-}" = route ] && [ "${2:-}" = show ] &&
+    [ "${3:-}" = dev ] && [ "${4:-}" = wlan2 ] &&
+    [ "${5:-}" = scope ] && [ "${6:-}" = link ]; then
+    printf '%s\n' '10.199.43.0/24 proto kernel scope link src 10.199.43.11'
+    return 0
+  fi
+  if [ "${1:-}" = rule ] && [ "${2:-}" = show ]; then
+    cat "$RULES"
+    return 0
+  fi
+  if [ "${1:-}" = rule ] && [ "${2:-}" = add ]; then
+    priority="${4:-}"
+    iface="${6:-}"
+    printf '%s: from all iif %s lookup 2022\n' "$priority" "$iface" >>"$RULES"
+    return 0
+  fi
+  if [ "${1:-}" = rule ] && [ "${2:-}" = del ]; then
+    priority="${4:-}"
+    iface="${6:-}"
+    pattern="${priority}: from all iif ${iface} lookup 2022"
+    grep -F -v -x "$pattern" "$RULES" >"$WORK/ip-rules.new" || true
+    mv -f "$WORK/ip-rules.new" "$RULES"
+    return 0
+  fi
+  return 1
+}
+
+. "$ROOT/src/MagicNet/lib/magicnet/routes.sh"
+
+magicnet_hotspot_reconcile
+grep -Fqx '20999|wlan2' "$MODDIR/.state/hotspot/tun-rules.list"
+grep -Fqx '20999: from all iif wlan2 lookup 2022' "$RULES"
+
+magicnet_hotspot_reconcile
+[ "$(grep -c '^20999:' "$RULES")" -eq 1 ]
+
+magicnet_hotspot_route_status >"$WORK/status"
+grep -Fqx 'route_table_ready=1' "$WORK/status"
+grep -Fqx 'downstream_interfaces=wlan2' "$WORK/status"
+grep -Fqx 'downstream_networks=10.199.43.0/24' "$WORK/status"
+grep -Fqx 'route_status=ready' "$WORK/status"
+
+magicnet_hotspot_offload_restore
+[ ! -e "$MODDIR/.state/hotspot/tun-rules.list" ]
+if grep -q '^20999:' "$RULES"; then
+  exit 1
+fi
+
+printf '%s\n' 'hotspot routing test passed'

--- a/scripts/test-singbox-chain.sh
+++ b/scripts/test-singbox-chain.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+command -v jq >/dev/null 2>&1 || {
+  printf '%s\n' 'jq is required for the sing-box chain test' >&2
+  exit 1
+}
+
+export MODDIR="$tmp/module"
+mkdir -p "$MODDIR/.config/sing-box" "$MODDIR/.config/magicnet"
+
+magicnet_warn() {
+  printf '[warn] %s\n' "$1" >&2
+}
+
+. "$ROOT/src/MagicNet/lib/magicnet/chain.sh"
+
+config="$MODDIR/.config/sing-box/config.json"
+policy="$MODDIR/.config/magicnet/proxy-chain.json"
+
+cat >"$config" <<'EOF'
+{
+  "outbounds": [
+    {"type":"socks","tag":"node-us","server":"127.0.0.1","server_port":1080,"version":"5"},
+    {"type":"socks","tag":"node-jp","server":"127.0.0.1","server_port":1081,"version":"5"},
+    {"type":"urltest","tag":"proxy-auto","outbounds":["node-us","node-jp"],"url":"https://www.gstatic.com/generate_204","interval":"3m","tolerance":30,"idle_timeout":"10m","interrupt_exist_connections":false},
+    {"type":"selector","tag":"proxy","outbounds":["node-us","node-jp","proxy-auto","direct","block"],"default":"node-us"},
+    {"type":"selector","tag":"ai-proxy","outbounds":["node-us","node-jp"],"default":"node-us"},
+    {"type":"urltest","tag":"ai-chatgpt-auto","outbounds":["node-us","node-jp"],"url":"https://chatgpt.com/","interval":"10m","tolerance":30,"idle_timeout":"10m","interrupt_exist_connections":false},
+    {"type":"selector","tag":"ai-chatgpt","outbounds":["node-us","node-jp","block","ai-chatgpt-auto"],"default":"node-us"},
+    {"type":"urltest","tag":"ai-gemini-auto","outbounds":["node-us","node-jp"],"url":"https://gemini.google.com/","interval":"10m","tolerance":30,"idle_timeout":"10m","interrupt_exist_connections":false},
+    {"type":"selector","tag":"ai-gemini","outbounds":["node-us","node-jp","block","ai-gemini-auto"],"default":"node-us"},
+    {"type":"urltest","tag":"ai-grok-auto","outbounds":["node-us","node-jp"],"url":"https://grok.com/","interval":"10m","tolerance":30,"idle_timeout":"10m","interrupt_exist_connections":false},
+    {"type":"selector","tag":"ai-grok","outbounds":["node-us","node-jp","block","ai-grok-auto"],"default":"node-us"},
+    {"type":"urltest","tag":"ai-claude-auto","outbounds":["node-us","node-jp"],"url":"https://claude.ai/","interval":"10m","tolerance":30,"idle_timeout":"10m","interrupt_exist_connections":false},
+    {"type":"selector","tag":"ai-claude","outbounds":["node-us","node-jp","block","ai-claude-auto"],"default":"node-us"},
+    {"type":"direct","tag":"direct"},
+    {"type":"block","tag":"block"}
+  ]
+}
+EOF
+
+cat >"$policy" <<'EOF'
+{
+  "enabled": true,
+  "mode": "manual",
+  "upstream": ["node-jp"],
+  "exit": ["node-us"]
+}
+EOF
+
+magicnet_singbox_chain_apply "$config"
+jq -e '
+  ([.outbounds[].tag] | index("chain")) != null
+  and ([.outbounds[].tag] | index("chain-hop1")) != null
+  and ([.outbounds[].tag] | index("chain-exit")) != null
+  and ([.outbounds[].tag] | index("chain-auto")) != null
+  and ([.outbounds[].tag] | index("magicnet-chain-exit::node-us")) != null
+  and (any(.outbounds[]; .tag == "proxy" and .default == "chain"))
+  and (any(.outbounds[]; .tag == "ai-proxy" and .outbounds == ["chain","block"]))
+  and (any(.outbounds[]; .tag == "ai-chatgpt-auto" and .outbounds == ["chain"]))
+  and (any(.outbounds[]; .tag == "magicnet-chain-exit::node-us"
+      and .detour == "chain-hop1" and .network == "tcp"))
+' "$config" >/dev/null
+
+if command -v sing-box >/dev/null 2>&1; then
+  sing-box check -c "$config" -D "$(dirname "$config")" >/dev/null
+fi
+
+sha256sum "$config" | cut -d' ' -f1 >"$tmp/enabled.sha256"
+
+cat >"$policy" <<'EOF'
+{
+  "enabled": false,
+  "mode": "manual",
+  "upstream": ["node-jp"],
+  "exit": ["node-us"]
+}
+EOF
+
+magicnet_singbox_chain_apply "$config"
+jq -e '
+  (all(.outbounds[]; ((.tag // "") | startswith("magicnet-chain-") | not)))
+  and (all(.outbounds[]; (((.outbounds // []) | index("chain")) == null)))
+  and (any(.outbounds[]; .tag == "proxy"
+      and .outbounds == ["node-us","node-jp","proxy-auto","direct","block"]
+      and .default == "node-us"))
+  and (any(.outbounds[]; .tag == "ai-proxy"
+      and .outbounds == ["node-us","node-jp"] and .default == "node-us"))
+  and (any(.outbounds[]; .tag == "ai-chatgpt-auto" and .outbounds == ["node-us","node-jp"]))
+  and (any(.outbounds[]; .tag == "ai-chatgpt"
+      and .outbounds == ["node-us","node-jp","block","ai-chatgpt-auto"]
+      and .default == "node-us"))
+' "$config" >/dev/null
+
+if command -v sing-box >/dev/null 2>&1; then
+  sing-box check -c "$config" -D "$(dirname "$config")" >/dev/null
+fi
+
+sha256sum "$config" | cut -d' ' -f1 >"$tmp/disabled-before.sha256"
+magicnet_singbox_chain_apply "$config"
+sha256sum "$config" | cut -d' ' -f1 >"$tmp/disabled-after.sha256"
+cmp "$tmp/disabled-before.sha256" "$tmp/disabled-after.sha256"
+
+printf '%s\n' 'sing-box chain materialization and rollback test passed'

--- a/src/MagicNet/README.md
+++ b/src/MagicNet/README.md
@@ -120,6 +120,25 @@ MagicNet 会抓取常见 Clash-style 节点 payload，并重新生成 `.config/s
 
 MagicNet 新安装默认按节点名过滤 `免费`、`free`、`HK`、`香港`、`TW`、`台湾`，可在 WebUI 的订阅页删除部分关键词，或清空并保存以关闭过滤。过滤规则会同时作用于新下载、缓存回放与配置修复后的节点列表。导入后的其余节点统一放进 `proxy` 选择器；AI 选择器固定排除中国大陆、香港和台湾标签，并按美国、日本、其他地区的顺序排列候选节点。规则选择器只在 `proxy`、`direct`、`block` 之间切换，不再生成固定的地区桶。如果节点数量明显少于订阅内容，也可能是订阅里包含当前 shell 导入器不支持的协议或字段；安装了 proxylink 时会优先用它生成 sing-box outbounds，以覆盖更多协议。
 
+## 两跳链式代理
+
+MagicNet 支持基于 sing-box detour 的本地两跳链路。它保持单进程、单 magicnet0 TUN，默认关闭；第一版按 TCP 链路设计，链路失败时不会静默回落到直连。
+
+先从当前订阅节点中指定中转和落地节点：
+
+    su -c '/data/adb/modules/MagicNet/cli chain set-upstream "中转节点名"'
+    su -c '/data/adb/modules/MagicNet/cli chain set-exit "落地节点名"'
+    su -c /data/adb/modules/MagicNet/cli chain enable
+    su -c /data/adb/modules/MagicNet/cli chain status
+
+链路策略只保存节点 tag，保存在 .config/magicnet/proxy-chain.json；节点凭据仍只存在 sing-box 配置中。启用后会生成 chain、chain-hop1、chain-exit 和 chain-auto 标准代理组，并把 proxy 的默认出口切换到 chain。
+
+Zashboard 可以直接连接 MagicNet 的 Clash API 或 sing-box 原生 API，选择这些代理组并展开查看嵌套链路。Zashboard 负责选择和观察，链路创建、detour 生成、节点角色校验由 MagicNet 完成。
+
+切换回普通代理：
+
+    su -c /data/adb/modules/MagicNet/cli chain disable
+
 ## 透明代理边界
 
 MagicNet 目前只支持 `tun` 透明模式，使用 `sing-box` `magicnet0` TUN 接管透明流量。旧配置中的 `proxy`、`external-tun`、`hybrid` 会安全归一为 `tun`，CLI 不再接受这些模式。

--- a/src/MagicNet/README.md
+++ b/src/MagicNet/README.md
@@ -59,7 +59,7 @@ su -c /data/adb/modules/MagicNet/cli hotspot status
 
 应用策略按 Android 多用户解析 UID。Bypass UID 同时绕过 TUN 与 DNS 捕获，主要用于外部 VPN 共存；普通“不走代理”优先选择 Direct。
 
-热点由 Android/OEM 创建和 NAT。MagicNet 只管理已经进入 TUN 的转发流量；Proxy 期间临时关闭 tether 硬件卸载，disable 或卸载时恢复原值。
+热点由 Android/OEM 创建 DHCP 和 NAT。启用 Proxy 后，MagicNet 会发现当前 tether 接口和私网网段，写入指向 `table 2022` 的临时 `ip rule`，把下游 IPv4 流量置于 Android tethering 规则之前送入 `magicnet0`；同时临时关闭 tether 硬件卸载，disable、停止或卸载时清理规则并恢复原值。接口变化由 watcher 自动重算。
 
 ## 网络与恢复
 

--- a/src/MagicNet/lib/magicnet.sh
+++ b/src/MagicNet/lib/magicnet.sh
@@ -20,6 +20,7 @@ for _magicnet_lib in \
     blocklist \
     routes \
     warp \
+    chain \
     runtime_config \
     supervisors \
     core \

--- a/src/MagicNet/lib/magicnet/blocklist.sh
+++ b/src/MagicNet/lib/magicnet/blocklist.sh
@@ -296,6 +296,7 @@ magicnet_block_ensure_ad_selectors() {
             print "    {"
             print "      \"type\": \"selector\","
             print "      \"tag\": \"ad-block\","
+            print "      \"interrupt_exist_connections\": true,"
             print "      \"outbounds\": [\"block\", \"direct\", \"proxy\"],"
             print "      \"default\": \"block\""
             print "    }" comma
@@ -304,6 +305,7 @@ magicnet_block_ensure_ad_selectors() {
             print "    {"
             print "      \"type\": \"selector\","
             print "      \"tag\": \"ad-allow\","
+            print "      \"interrupt_exist_connections\": true,"
             print "      \"outbounds\": [\"final\", \"direct\", \"proxy\"],"
             print "      \"default\": \"final\""
             print "    }" comma

--- a/src/MagicNet/lib/magicnet/chain.sh
+++ b/src/MagicNet/lib/magicnet/chain.sh
@@ -1,0 +1,222 @@
+# shellcheck shell=ash
+#
+# Materialize the local two-hop sing-box proxy chain.
+#
+# The policy file contains node tags only.  The subscription pipeline owns the
+# real node credentials; this module only creates deterministic child
+# outbounds with a detour to the selected upstream group.
+
+magicnet_singbox_chain_policy_file() {
+    printf '%s\n' "${MODDIR}/.config/magicnet/proxy-chain.json"
+}
+
+magicnet_singbox_chain_config_file() {
+    if [ -n "${MAGICNET_SUB_CONFIG_FILE:-}" ]; then
+        printf '%s\n' "$MAGICNET_SUB_CONFIG_FILE"
+    else
+        printf '%s\n' "${MODDIR}/.config/sing-box/config.json"
+    fi
+}
+
+magicnet_singbox_chain_jq() {
+    if [ -x "${MODDIR}/bin/jq" ]; then
+        printf '%s\n' "${MODDIR}/bin/jq"
+    else
+        command -v jq 2>/dev/null || true
+    fi
+}
+
+magicnet_singbox_chain_apply() {
+    _chain_config="${1:-$(magicnet_singbox_chain_config_file)}"
+    _chain_policy_file="$(magicnet_singbox_chain_policy_file)"
+    _chain_jq="$(magicnet_singbox_chain_jq)"
+    [ -s "$_chain_config" ] || {
+        unset _chain_config _chain_policy_file _chain_jq _chain_policy _chain_tmp _chain_rc
+        return 1
+    }
+    [ -s "$_chain_policy_file" ] || {
+        # A missing policy is the backwards-compatible disabled state. Keep
+        # the existing subscription path usable on minimal systems without
+        # jq; the CLI creates the policy before enabling chain mode.
+        unset _chain_config _chain_policy_file _chain_jq _chain_policy _chain_tmp _chain_rc
+        return 0
+    }
+    [ -n "$_chain_jq" ] || {
+        magicnet_warn "jq not found; refusing to materialize the proxy chain"
+        unset _chain_config _chain_policy_file _chain_jq _chain_policy _chain_tmp _chain_rc
+        return 1
+    }
+
+    _chain_policy="$($_chain_jq -c -e . "$_chain_policy_file" 2>/dev/null)" || {
+        magicnet_warn "proxy chain policy is not valid JSON"
+        unset _chain_config _chain_policy_file _chain_jq _chain_policy _chain_tmp _chain_rc
+        return 1
+    }
+
+    _chain_tmp="${_chain_config}.chain.$$"
+    # shellcheck disable=SC2016
+    if ! (umask 077; "$_chain_jq" \
+        --argjson policy "$_chain_policy" \
+        --arg prefix "magicnet-chain-" '
+      def managed_tag($tag):
+        (($tag | type) == "string" and ($tag | startswith($prefix)))
+        or (["chain", "chain-hop1", "chain-exit", "chain-auto"] | index($tag) != null);
+      def valid_tag:
+        type == "string" and length > 0 and (test("[[:cntrl:]]") | not);
+      def unique_strings:
+        reduce .[] as $item ([]; if index($item) == null then . + [$item] else . end);
+      def blocked_ai_node_tag:
+        test("中国|大陆|内地|香港|台湾|臺灣|台北|臺北|台中|臺中|台南|臺南|高雄|新竹|🇭🇰|🇹🇼|北京|上海|广州|深圳|天津|重庆|江苏|浙江|福建|山东|河南|河北|湖北|湖南|四川|陕西|安徽|辽宁|吉林|黑龙江|海南|广西|贵州|云南|山西|江西|(^|[^A-Za-z0-9])(?:Hong[ _-]?Kong(?:[ _-]?[0-9]+)?|HKG?[ _-]?[0-9]+|Taiwan|Taipei|Taichung|Tainan|Kaohsiung|Hsinchu|TW|TWN|China|Mainland|HK|HKG|CN|Beijing|Shanghai|Guangzhou|Shenzhen|Chongqing|Tianjin|Hebei|Shanxi|Liaoning|Jilin|Heilongjiang|Jiangsu|Zhejiang|Anhui|Fujian|Jiangxi|Shandong|Henan|Hubei|Hunan|Guangdong|Hainan|Sichuan|Guizhou|Yunnan|Shaanxi|Gansu|Qinghai|Inner[ _-]?Mongolia|Guangxi|Tibet|Ningxia|Xinjiang)([^A-Za-z0-9]|$)"; "i");
+      def us_node_tag:
+        test("美国|美國|美西|美东|美東|洛杉矶|洛杉磯|圣何塞|聖何塞|西雅图|西雅圖|达拉斯|達拉斯|纽约|紐約|芝加哥|迈阿密|邁阿密|凤凰城|鳳凰城|亚特兰大|亞特蘭大|波特兰|波特蘭|丹佛|拉斯维加斯|拉斯維加斯|硅谷|🇺🇸|(^|[^A-Za-z0-9])(?:US|USA|United[ _-]?States|America|Los[ _-]?Angeles|San[ _-]?Jose|Seattle|Dallas|New[ _-]?York|Chicago|Washington|Miami|Phoenix|Atlanta|Portland|Denver|Las[ _-]?Vegas|Silicon[ _-]?Valley)([^A-Za-z0-9]|$)"; "i");
+      def japan_node_tag:
+        test("日本|东京|東京|大阪|埼玉|名古屋|🇯🇵|(^|[^A-Za-z0-9])(?:JP|JPN|Japan|Tokyo|Osaka|Saitama|Nagoya)([^A-Za-z0-9]|$)"; "i");
+      def prioritize_ai_tags:
+        . as $tags
+        | ([$tags[]? | select(blocked_ai_node_tag | not)]) as $eligible
+        | ([$eligible[] | select(us_node_tag)])
+          + ([$eligible[] | select((us_node_tag | not) and japan_node_tag)])
+          + ([$eligible[] | select((us_node_tag | not) and (japan_node_tag | not))]);
+      def proxy_node:
+        (.tag | valid_tag and (managed_tag(.) | not))
+          and (.server | type == "string" and length > 0)
+          and (.server_port | type == "number" and . == floor and . >= 1 and . <= 65535)
+          and (.type == "shadowsocks" or .type == "vmess" or .type == "vless"
+            or .type == "trojan" or .type == "hysteria2" or .type == "anytls"
+            or .type == "tuic" or .type == "socks");
+      def policy_tags($key):
+        if (($policy[$key] // []) | type) == "array"
+        then ($policy[$key] | map(select(valid_tag)) | unique_strings)
+        else error("proxy chain policy field must be an array: " + $key)
+        end;
+      (.outbounds // []) as $all
+      | ($all | map(select((.tag // "") as $tag | (managed_tag($tag) | not)))) as $clean
+      | ($clean | map(select(proxy_node) | .tag) | unique_strings) as $node_tags
+      | ($clean
+          | map(select(proxy_node and ((.detour // "") == "")) | .tag)
+          | unique_strings) as $chain_safe_tags
+      | ($node_tags | prioritize_ai_tags) as $ai_tags
+      | (policy_tags("upstream")) as $requested_upstream
+      | (policy_tags("exit")) as $requested_exit
+      | ($requested_upstream
+          | map(. as $tag | select(($chain_safe_tags | index($tag)) != null))) as $upstream
+      | ($requested_exit
+          | map(. as $tag | select(($chain_safe_tags | index($tag)) != null))) as $exit
+      | (($policy.enabled // false) == true) as $enabled
+      | ($policy.mode // "manual") as $mode
+      | if ($mode != "manual" and $mode != "auto")
+        then error("proxy chain mode must be manual or auto")
+        elif $enabled and (($upstream | length) == 0 or ($exit | length) == 0)
+        then error("enabled proxy chain requires at least one valid upstream and exit node")
+        else
+          ($enabled and ($upstream | length) > 0 and ($exit | length) > 0) as $chain_valid
+          | ($exit
+              | map(. as $source
+                  | $clean[]
+                  | select(.tag == $source)
+                  | del(.detour)
+                  | .tag = ("magicnet-chain-exit::" + $source)
+                  | .detour = "chain-hop1"
+                  | .network = "tcp")) as $chain_nodes
+          | ($chain_nodes | map(.tag)) as $chain_exit_tags
+          | ($clean | map(select(.tag == "proxy" and .type == "selector")) | .[0]) as $old_proxy
+          | ($old_proxy.default // "") as $old_default
+          | (if $chain_valid then "chain"
+             elif (($node_tags | index($old_default)) != null
+                or $old_default == "proxy-auto"
+                or $old_default == "direct"
+                or $old_default == "block") then $old_default
+             elif ($node_tags | length) > 0 then $node_tags[0]
+             else "block"
+             end) as $proxy_default
+          | (if ($node_tags | length) > 0
+             then (($node_tags + ["proxy-auto"]
+               + (if $chain_valid then ["chain"] else [] end)
+               + ["direct", "block"]) | unique_strings)
+             else ["block"]
+             end) as $proxy_members
+          | {"type":"selector", "tag":"proxy", "outbounds":$proxy_members,
+             "default":$proxy_default} as $proxy
+          | ($clean
+              | map(if $chain_valid and .tag == "ai-proxy"
+                   then .outbounds = ["chain", "block"] | .default = "chain"
+                   elif $chain_valid
+                     and (.tag == "ai-chatgpt" or .tag == "ai-gemini"
+                       or .tag == "ai-grok" or .tag == "ai-claude")
+                   then .outbounds = ["chain", "block", (.tag + "-auto")]
+                     | .default = "chain"
+                   elif $chain_valid
+                     and (.tag == "ai-chatgpt-auto" or .tag == "ai-gemini-auto"
+                       or .tag == "ai-grok-auto" or .tag == "ai-claude-auto")
+                   then .outbounds = ["chain"]
+                   elif ($chain_valid | not) and .tag == "ai-proxy"
+                   then if ($ai_tags | length) > 0
+                        then .outbounds = $ai_tags | .default = $ai_tags[0]
+                        else .outbounds = ["block"] | .default = "block"
+                        end
+                   elif ($chain_valid | not)
+                     and (.tag == "ai-chatgpt" or .tag == "ai-gemini"
+                       or .tag == "ai-grok" or .tag == "ai-claude")
+                   then if ($ai_tags | length) > 0
+                        then .outbounds = ($ai_tags + ["block", (.tag + "-auto")])
+                          | .default = $ai_tags[0]
+                        else .outbounds = ["block"] | .default = "block"
+                        end
+                   elif ($chain_valid | not)
+                     and (.tag == "ai-chatgpt-auto" or .tag == "ai-gemini-auto"
+                       or .tag == "ai-grok-auto" or .tag == "ai-claude-auto")
+                   then if ($ai_tags | length) > 0
+                        then .outbounds = $ai_tags
+                        else empty
+                        end
+                   else .
+                   end)) as $policy_clean
+          | (if $chain_valid
+             then [
+               {"type":"selector", "tag":"chain-hop1",
+                "outbounds":($upstream + ["block"]), "default":$upstream[0]},
+               $chain_nodes[],
+               {"type":"selector", "tag":"chain-exit",
+                "outbounds":($chain_exit_tags + ["block"]), "default":$chain_exit_tags[0]},
+               {"type":"urltest", "tag":"chain-auto", "outbounds":$chain_exit_tags,
+                "url":"https://www.gstatic.com/generate_204", "interval":"3m",
+                "tolerance":30, "idle_timeout":"10m",
+                "interrupt_exist_connections":false},
+               {"type":"selector", "tag":"chain",
+                "outbounds":(["chain-exit", "chain-auto", "block"]),
+                "default":(if $mode == "auto" then "chain-auto" else "chain-exit" end)}
+             ]
+             else []
+             end) as $chain_outbounds
+          | .outbounds = ($chain_outbounds + [$proxy]
+              + ($policy_clean | map(select((.tag // "") != "proxy"))))
+        end
+    ' "$_chain_config" >"$_chain_tmp"); then
+        rm -f "$_chain_tmp" 2>/dev/null || true
+        unset _chain_config _chain_policy_file _chain_jq _chain_policy _chain_tmp _chain_rc
+        return 1
+    fi
+
+    chmod 600 "$_chain_tmp" || {
+        rm -f "$_chain_tmp" 2>/dev/null || true
+        unset _chain_config _chain_policy_file _chain_jq _chain_policy _chain_tmp _chain_rc
+        return 1
+    }
+    if command -v sing-box >/dev/null 2>&1; then
+        sing-box check -c "$_chain_tmp" -D "${_chain_config%/*}" >/dev/null 2>&1 || {
+            magicnet_warn "generated sing-box proxy chain failed validation"
+            rm -f "$_chain_tmp" 2>/dev/null || true
+            unset _chain_config _chain_policy_file _chain_jq _chain_policy _chain_tmp _chain_rc
+            return 1
+        }
+    fi
+    mv -f "$_chain_tmp" "$_chain_config" || {
+        rm -f "$_chain_tmp" 2>/dev/null || true
+        unset _chain_config _chain_policy_file _chain_jq _chain_policy _chain_tmp _chain_rc
+        return 1
+    }
+    chmod 600 "$_chain_config"
+    _chain_rc=$?
+    unset _chain_config _chain_policy_file _chain_jq _chain_policy _chain_tmp
+    return "$_chain_rc"
+}

--- a/src/MagicNet/lib/magicnet/core.sh
+++ b/src/MagicNet/lib/magicnet/core.sh
@@ -22,6 +22,7 @@ magicnet_start_singbox_unlocked() {
     import __singbox__
     is_singbox_running >/dev/null 2>&1 && return 0
     magicnet_prepare_singbox_nodes_unlocked || return 1
+    magicnet_singbox_chain_apply || return 1
     magicnet_singbox_apply_transparent_mode || return 1
     magicnet_singbox_apply_hotspot_policy || return 1
     # sing-box snapshots DNS servers and WARP endpoints when the process

--- a/src/MagicNet/lib/magicnet/network.sh
+++ b/src/MagicNet/lib/magicnet/network.sh
@@ -446,6 +446,11 @@ magicnet_after_kernel_start_deferred_unlocked() {
     # These rewrites run asynchronously after the core starts and may otherwise
     # publish a snapshot that predates the startup-time hotspot normalization.
     magicnet_singbox_apply_hotspot_policy || _deferred_mark_failed hotspot
+    # Android inserts a higher-priority tethering rule after the hotspot
+    # interface appears. Install MagicNet's per-interface rule after the TUN
+    # table exists so forwarded clients reach magicnet0 before that rule.
+    magicnet_hotspot_reconcile ||
+        magicnet_warn "Hotspot TUN policy is not ready; the interface watcher will retry it."
 
     if [ -n "$_deferred_failures" ]; then
         # A partially applied configuration must not leave stale interception

--- a/src/MagicNet/lib/magicnet/routes.sh
+++ b/src/MagicNet/lib/magicnet/routes.sh
@@ -27,6 +27,336 @@ magicnet_hotspot_offload_state_file() {
     printf '%s\n' "${MODDIR}/.state/hotspot/tether-offload.previous"
 }
 
+magicnet_hotspot_route_state_file() {
+    printf '%s\n' "${MODDIR}/.state/hotspot/tun-rules.list"
+}
+
+magicnet_hotspot_proxy_enabled() {
+    [ -f "$(magicnet_hotspot_offload_state_file)" ]
+}
+
+magicnet_hotspot_interface_allowed() {
+    _hotspot_allowed_iface="$1"
+    case "$_hotspot_allowed_iface" in
+        "" | *[!A-Za-z0-9_.-]*)
+            unset _hotspot_allowed_iface
+            return 1
+            ;;
+    esac
+    case "$_hotspot_allowed_iface" in
+        wlan[0-9]* | softap[0-9]* | ap_br_wlan[0-9]* | ap_br_softap[0-9]* | \
+        swlan[0-9]* | rndis[0-9]* | usb[0-9]* | bt-pan | bt-pan[0-9]* | \
+        p2p[0-9]* | p2p-*)
+            unset _hotspot_allowed_iface
+            return 0
+            ;;
+        *)
+            unset _hotspot_allowed_iface
+            return 1
+            ;;
+    esac
+}
+
+# Android exposes the active tethering interfaces through dumpsys, but OEMs
+# differ in which command output is available to a root shell. Prefer the
+# authoritative tethering state and fall back to the standard SoftAP/USB/Bt
+# interface names only when dumpsys returns no active interface.
+magicnet_hotspot_discover_interfaces() {
+    _hotspot_tethered=
+    if magicnet_cmd_exists dumpsys; then
+        _hotspot_tethered="$(dumpsys tethering 2>/dev/null | awk '
+            $2 == "-" && $3 == "TetheredState" && $1 !~ /[^A-Za-z0-9_.-]/ {
+                print $1
+            }
+        ' | awk '!seen[$0]++' || true)"
+    fi
+    if [ -n "$_hotspot_tethered" ]; then
+        printf '%s\n' "$_hotspot_tethered" | while IFS= read -r _hotspot_iface; do
+            magicnet_hotspot_interface_allowed "$_hotspot_iface" &&
+                printf '%s\n' "$_hotspot_iface"
+        done
+        unset _hotspot_tethered _hotspot_iface
+        return 0
+    fi
+    if magicnet_cmd_exists ip; then
+        ip -o link show 2>/dev/null | awk -F': ' '
+            {
+                name = $2
+                sub(/@.*/, "", name)
+                if (name ~ /^(wlan[1-9][0-9]*|softap[0-9]+|ap_br_(wlan|softap)[0-9]+|swlan[0-9]+|rndis[0-9]+|usb[0-9]+|bt-pan[0-9]*|p2p[0-9]+|p2p-.+)$/ && !seen[name]++) {
+                    print name
+                }
+            }
+        '
+    fi
+    unset _hotspot_tethered _hotspot_iface
+}
+
+magicnet_hotspot_active_networks() {
+    _hotspot_iface=
+    _hotspot_routes=
+    for _hotspot_iface in $(magicnet_hotspot_discover_interfaces); do
+        magicnet_hotspot_interface_allowed "$_hotspot_iface" || continue
+        magicnet_iface_exists "$_hotspot_iface" || continue
+        _hotspot_routes="$(ip route show dev "$_hotspot_iface" scope link 2>/dev/null | awk '
+            function valid_octet(value) {
+                return value ~ /^[0-9]+$/ && length(value) <= 3 &&
+                    (length(value) == 1 || substr(value, 1, 1) != "0") &&
+                    value + 0 <= 255
+            }
+            {
+                count = split($1, cidr, "/")
+                if (count != 2 || cidr[2] !~ /^[0-9]+$/ || cidr[2] + 0 > 32) next
+                octets = split(cidr[1], address, ".")
+                if (octets != 4) next
+                for (octet_index = 1; octet_index <= octets; octet_index++) {
+                    if (!valid_octet(address[octet_index])) next
+                }
+                print $1
+            }
+        ' | awk '!seen[$0]++')"
+        for _hotspot_cidr in $_hotspot_routes; do
+            printf '%s|%s\n' "$_hotspot_iface" "$_hotspot_cidr"
+        done
+    done
+    unset _hotspot_iface _hotspot_routes _hotspot_cidr
+}
+
+magicnet_hotspot_rule_present() {
+    _hotspot_rule_check_priority="$1"
+    _hotspot_rule_check_iface="$2"
+    ip rule show 2>/dev/null | awk \
+        -v expected_priority="${_hotspot_rule_check_priority}:" \
+        -v expected_iface="$_hotspot_rule_check_iface" '
+        $1 == expected_priority && index($0, "iif " expected_iface " ") > 0 &&
+            index($0, "lookup 2022") > 0 { found = 1 }
+        END { exit found ? 0 : 1 }
+    '
+    _hotspot_rule_rc=$?
+    unset _hotspot_rule_check_priority _hotspot_rule_check_iface
+    return "$_hotspot_rule_rc"
+}
+
+magicnet_hotspot_delete_rule() {
+    _hotspot_priority="$1"
+    _hotspot_iface="$2"
+    magicnet_hotspot_rule_present "$_hotspot_priority" "$_hotspot_iface" || {
+        unset _hotspot_priority _hotspot_iface
+        return 0
+    }
+    _hotspot_delete_attempt=0
+    while [ "$_hotspot_delete_attempt" -lt 8 ]; do
+        if ip rule del priority "$_hotspot_priority" iif "$_hotspot_iface" lookup 2022 \
+            >/dev/null 2>&1; then
+            _hotspot_delete_attempt=$((_hotspot_delete_attempt + 1))
+        else
+            break
+        fi
+    done
+    if magicnet_hotspot_rule_present "$_hotspot_priority" "$_hotspot_iface"; then
+        _hotspot_rule_rc=1
+    else
+        _hotspot_rule_rc=0
+    fi
+    unset _hotspot_priority _hotspot_iface _hotspot_delete_attempt
+    return "$_hotspot_rule_rc"
+}
+
+magicnet_hotspot_route_cleanup() {
+    _hotspot_state_file="$(magicnet_hotspot_route_state_file)"
+    _hotspot_cleanup_rc=0
+    if [ -f "$_hotspot_state_file" ]; then
+        while IFS='|' read -r _hotspot_priority _hotspot_iface; do
+            case "$_hotspot_priority" in
+                "" | *[!0-9]*)
+                    _hotspot_cleanup_rc=1
+                    continue
+                    ;;
+            esac
+            magicnet_hotspot_interface_allowed "$_hotspot_iface" || {
+                _hotspot_cleanup_rc=1
+                continue
+            }
+            magicnet_hotspot_delete_rule "$_hotspot_priority" "$_hotspot_iface" ||
+                _hotspot_cleanup_rc=1
+        done <"$_hotspot_state_file"
+    fi
+    if [ "$_hotspot_cleanup_rc" -eq 0 ]; then
+        rm -f "$_hotspot_state_file" 2>/dev/null || true
+    fi
+    _hotspot_cleanup_result="$_hotspot_cleanup_rc"
+    unset _hotspot_state_file _hotspot_cleanup_rc _hotspot_priority _hotspot_iface
+    return "$_hotspot_cleanup_result"
+}
+
+magicnet_hotspot_android_tether_priority() {
+    _hotspot_iface="$1"
+    ip rule show 2>/dev/null | awk -v expected_iface="$_hotspot_iface" '
+        $1 ~ /^[0-9]+:$/ && index($0, "iif " expected_iface " ") > 0 &&
+            index($0, "iif lo") == 0 && index($0, "lookup ") > 0 {
+            priority = $1
+            sub(/:/, "", priority)
+            if (priority + 0 > 1 && (!found || priority + 0 < found)) found = priority + 0
+        }
+        END { if (found) print found - 1 }
+    ' | sed -n '1p'
+    unset _hotspot_iface
+}
+
+magicnet_hotspot_choose_rule_priority() {
+    _hotspot_iface="$1"
+    _hotspot_upper="$(magicnet_hotspot_android_tether_priority "$_hotspot_iface" 2>/dev/null || true)"
+    case "$_hotspot_upper" in
+        '' | *[!0-9]*) _hotspot_upper=8999 ;;
+    esac
+    _hotspot_candidate="$_hotspot_upper"
+    _hotspot_rules="$(ip rule show 2>/dev/null || true)"
+    while [ "$_hotspot_candidate" -gt 0 ]; do
+        if ! printf '%s\n' "$_hotspot_rules" | awk -v expected="${_hotspot_candidate}:" \
+            '$1 == expected { found = 1 } END { exit found ? 0 : 1 }'; then
+            printf '%s\n' "$_hotspot_candidate"
+            unset _hotspot_iface _hotspot_upper _hotspot_candidate _hotspot_rules
+            return 0
+        fi
+        _hotspot_candidate=$((_hotspot_candidate - 1))
+    done
+    unset _hotspot_iface _hotspot_upper _hotspot_candidate _hotspot_rules
+    return 1
+}
+
+magicnet_hotspot_tun_route_table_ready() {
+    magicnet_iface_exists magicnet0 || return 1
+    ip route show table 2022 2>/dev/null | awk '
+        index($0, "dev magicnet0") > 0 { found = 1 }
+        END { exit found ? 0 : 1 }
+    '
+}
+
+magicnet_hotspot_reconcile() {
+    if ! magicnet_hotspot_proxy_enabled; then
+        magicnet_hotspot_route_cleanup
+        return $?
+    fi
+
+    # The selector can be enabled before sing-box has created magicnet0. That
+    # is a valid pending state; the post-start pass and the watcher will retry
+    # once the TUN route table exists. A present but incomplete TUN is a real
+    # failure and must remain visible to the caller/status output.
+    if ! magicnet_hotspot_tun_route_table_ready; then
+        magicnet_hotspot_route_cleanup >/dev/null 2>&1 || true
+        magicnet_iface_exists magicnet0 || return 0
+        magicnet_warn "magicnet0 route table 2022 is unavailable; hotspot forwarding is not intercepted"
+        return 1
+    fi
+
+    _hotspot_pairs="$(magicnet_hotspot_active_networks | awk -F'|' '!seen[$1]++')"
+    magicnet_hotspot_route_cleanup || {
+        unset _hotspot_pairs
+        return 1
+    }
+    [ -n "$_hotspot_pairs" ] || {
+        unset _hotspot_pairs
+        return 0
+    }
+
+    _hotspot_first_iface="${_hotspot_pairs%%|*}"
+    _hotspot_priority="$(magicnet_hotspot_choose_rule_priority "$_hotspot_first_iface")" || {
+        unset _hotspot_pairs _hotspot_first_iface
+        return 1
+    }
+    _hotspot_state_file="$(magicnet_hotspot_route_state_file)"
+    _hotspot_state_tmp="${_hotspot_state_file}.new.$$"
+    mkdir -p "${_hotspot_state_file%/*}" || {
+        unset _hotspot_pairs _hotspot_first_iface _hotspot_priority _hotspot_state_file _hotspot_state_tmp
+        return 1
+    }
+    : >"$_hotspot_state_tmp" || {
+        unset _hotspot_pairs _hotspot_first_iface _hotspot_priority _hotspot_state_file _hotspot_state_tmp
+        return 1
+    }
+    _hotspot_add_rc=0
+    _hotspot_current_added=0
+    while IFS='|' read -r _hotspot_iface _hotspot_cidr; do
+        [ -n "$_hotspot_iface" ] || continue
+        if ! ip rule add priority "$_hotspot_priority" iif "$_hotspot_iface" lookup 2022 \
+            >/dev/null 2>&1; then
+            _hotspot_add_rc=1
+            break
+        fi
+        _hotspot_current_added=1
+        printf '%s|%s\n' "$_hotspot_priority" "$_hotspot_iface" >>"$_hotspot_state_tmp" || {
+            _hotspot_add_rc=1
+            break
+        }
+        _hotspot_current_added=0
+    done <<EOF
+$_hotspot_pairs
+EOF
+    if [ "$_hotspot_add_rc" -ne 0 ] ||
+        ! chmod 600 "$_hotspot_state_tmp" ||
+        ! mv -f "$_hotspot_state_tmp" "$_hotspot_state_file"; then
+        if [ "$_hotspot_current_added" -eq 1 ]; then
+            magicnet_hotspot_delete_rule "$_hotspot_priority" "$_hotspot_iface" || true
+        fi
+        while IFS='|' read -r _hotspot_cleanup_priority _hotspot_cleanup_iface; do
+            [ -n "$_hotspot_cleanup_priority" ] || continue
+            magicnet_hotspot_delete_rule "$_hotspot_cleanup_priority" "$_hotspot_cleanup_iface" || true
+        done <"$_hotspot_state_tmp" 2>/dev/null || true
+        rm -f "$_hotspot_state_tmp" 2>/dev/null || true
+        unset _hotspot_pairs _hotspot_first_iface _hotspot_priority _hotspot_state_file _hotspot_state_tmp
+        unset _hotspot_add_rc _hotspot_current_added _hotspot_iface _hotspot_cidr
+        unset _hotspot_cleanup_priority _hotspot_cleanup_iface
+        return 1
+    fi
+    unset _hotspot_pairs _hotspot_first_iface _hotspot_priority _hotspot_state_file _hotspot_state_tmp
+    unset _hotspot_add_rc _hotspot_current_added _hotspot_iface _hotspot_cidr
+    unset _hotspot_cleanup_priority _hotspot_cleanup_iface
+}
+
+magicnet_hotspot_route_status() {
+    _hotspot_state_file="$(magicnet_hotspot_route_state_file)"
+    if magicnet_hotspot_tun_route_table_ready; then
+        printf 'route_table_ready=1\n'
+    else
+        printf 'route_table_ready=0\n'
+    fi
+    _hotspot_pairs="$(magicnet_hotspot_active_networks || true)"
+    _hotspot_interfaces="$(printf '%s\n' "$_hotspot_pairs" | awk -F'|' 'NF && !seen[$1]++ { print $1 }' | tr '\n' ',' | sed 's/,$//')"
+    _hotspot_networks="$(printf '%s\n' "$_hotspot_pairs" | awk -F'|' 'NF && !seen[$2]++ { print $2 }' | tr '\n' ',' | sed 's/,$//')"
+    printf 'downstream_interfaces=%s\n' "${_hotspot_interfaces:-none}"
+    printf 'downstream_networks=%s\n' "${_hotspot_networks:-none}"
+    _hotspot_rule_count=0
+    _hotspot_missing_rule_count=0
+    if [ -f "$_hotspot_state_file" ]; then
+        while IFS='|' read -r _hotspot_priority _hotspot_iface; do
+            case "$_hotspot_priority" in
+                '' | *[!0-9]*) continue ;;
+            esac
+            magicnet_hotspot_interface_allowed "$_hotspot_iface" || continue
+            printf 'policy_rule=%s iif=%s table=2022\n' "$_hotspot_priority" "$_hotspot_iface"
+            if magicnet_hotspot_rule_present "$_hotspot_priority" "$_hotspot_iface"; then
+                _hotspot_rule_count=$((_hotspot_rule_count + 1))
+            else
+                _hotspot_missing_rule_count=$((_hotspot_missing_rule_count + 1))
+            fi
+        done <"$_hotspot_state_file"
+    fi
+    printf 'policy_rule_count=%s\n' "$_hotspot_rule_count"
+    printf 'policy_rule_missing=%s\n' "$_hotspot_missing_rule_count"
+    if ! magicnet_hotspot_proxy_enabled; then
+        printf 'route_status=disabled\n'
+    elif [ -z "$_hotspot_pairs" ]; then
+        printf 'route_status=waiting-for-hotspot\n'
+    elif ! magicnet_hotspot_tun_route_table_ready || [ "$_hotspot_rule_count" -eq 0 ] ||
+        [ "$_hotspot_missing_rule_count" -ne 0 ]; then
+        printf 'route_status=degraded\n'
+    else
+        printf 'route_status=ready\n'
+    fi
+    unset _hotspot_state_file _hotspot_pairs _hotspot_interfaces _hotspot_networks
+    unset _hotspot_rule_count _hotspot_missing_rule_count _hotspot_priority _hotspot_iface
+}
+
 magicnet_hotspot_offload_value() {
     command -v settings >/dev/null 2>&1 || return 1
     settings get global tether_offload_disabled 2>/dev/null | tr -d '\r' | sed -n '1p'
@@ -34,9 +364,11 @@ magicnet_hotspot_offload_value() {
 
 magicnet_hotspot_register_offload_rollback() {
     import prop
+    _hotspot_route_rollback_cmd='_mn_rules="${0%/*}/.state/hotspot/tun-rules.list"; if [ -f "$_mn_rules" ] && command -v ip >/dev/null 2>&1; then while IFS="|" read -r _mn_priority _mn_iface; do case "$_mn_priority" in ""|*[!0-9]*) continue;; esac; case "$_mn_iface" in wlan[0-9]*|softap[0-9]*|ap_br_wlan[0-9]*|ap_br_softap[0-9]*|swlan[0-9]*|rndis[0-9]*|usb[0-9]*|bt-pan|bt-pan[0-9]*|p2p[0-9]*|p2p-*) ;; *) continue;; esac; _mn_attempt=0; while [ "$_mn_attempt" -lt 8 ]; do ip rule del priority "$_mn_priority" iif "$_mn_iface" lookup 2022 >/dev/null 2>&1 || break; _mn_attempt=$((_mn_attempt+1)); done; done <"$_mn_rules"; fi; rm -f "$_mn_rules" 2>/dev/null || true'
+    register_uninstall_cmd "$_hotspot_route_rollback_cmd" "$MODDIR" >/dev/null 2>&1 || true
     _hotspot_rollback_cmd='_mn_state="${0%/*}/.state/hotspot/tether-offload.previous"; if [ -f "$_mn_state" ]; then _mn_previous="$(sed -n "1p" "$_mn_state" 2>/dev/null)"; if [ "$_mn_previous" = unset ]; then settings delete global tether_offload_disabled >/dev/null 2>&1 || true; else settings put global tether_offload_disabled "${_mn_previous#value=}" >/dev/null 2>&1 || true; fi; rm -f "$_mn_state" 2>/dev/null || true; fi'
     register_uninstall_cmd "$_hotspot_rollback_cmd" "$MODDIR" >/dev/null 2>&1 || true
-    unset _hotspot_rollback_cmd
+    unset _hotspot_route_rollback_cmd _hotspot_rollback_cmd
 }
 
 magicnet_hotspot_offload_enable() {
@@ -78,6 +410,7 @@ magicnet_hotspot_offload_enable() {
 magicnet_hotspot_offload_restore() {
     _hotspot_state="$(magicnet_hotspot_offload_state_file)"
     [ -f "$_hotspot_state" ] || {
+        magicnet_hotspot_route_cleanup >/dev/null 2>&1 || true
         unset _hotspot_state
         return 0
     }
@@ -96,6 +429,7 @@ magicnet_hotspot_offload_restore() {
     _hotspot_rc=$?
     if [ "$_hotspot_rc" -eq 0 ]; then
         rm -f "$_hotspot_state" 2>/dev/null || true
+        magicnet_hotspot_route_cleanup >/dev/null 2>&1 || true
     fi
     unset _hotspot_state _hotspot_previous
     return "$_hotspot_rc"
@@ -126,12 +460,13 @@ magicnet_singbox_apply_hotspot_policy() {
         return 1
     }
     _tmp="${_config}.hotspot-policy.new"
-    # Forwarded Android tethering clients retain their LAN source address when
-    # entering the TUN. Device-local TUN traffic uses 172.19.0.1 and therefore
-    # does not match these hotspot source ranges.
+    # Forwarded Android tethering clients retain a private source address when
+    # entering the TUN. The policy route below selects the actual tethered
+    # interface; these RFC1918 ranges keep the sing-box rule valid even when an
+    # OEM changes the DHCP subnet after the core has already started.
     if (umask 077; "$_jq" '
         def hotspot_sources:
-          ["192.168.0.0/16", "10.42.0.0/16", "172.20.10.0/28"];
+          ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"];
         def hotspot_selector:
           {
             "type": "selector",

--- a/src/MagicNet/lib/magicnet/runtime_config.sh
+++ b/src/MagicNet/lib/magicnet/runtime_config.sh
@@ -48,13 +48,15 @@ magicnet_tailscale_apply_unlocked() (
       def managed_tailnet_rule:
         (((.ip_cidr // []) | sort) == (tailnets | sort))
           and ((.outbound // "") != "lan");
-      .endpoints = ((.endpoints // []) | map(
-        if .type == "tailscale" then
-          del(.auth_key)
-          | if (.state_directory // "") == "" then .state_directory = $state_dir else . end
-          | .system_interface = false
-        else . end
-      ))
+      if has("endpoints") then
+        .endpoints = ((.endpoints // []) | map(
+          if .type == "tailscale" then
+            del(.auth_key)
+            | if (.state_directory // "") == "" then .state_directory = $state_dir else . end
+            | .system_interface = false
+          else . end
+        ))
+      else . end
       | ((.endpoints // []) | map(select(userspace_tailscale)) | first) as $endpoint
       | if $endpoint == null then . else
           .inbounds = ((.inbounds // []) | map(

--- a/src/MagicNet/lib/magicnet/runtime_config.sh
+++ b/src/MagicNet/lib/magicnet/runtime_config.sh
@@ -204,6 +204,7 @@ magicnet_apply_runtime_config_unlocked() {
     fi
     _runtime_rc=0
     magicnet_ipset_lkm_prepare || true
+    magicnet_singbox_chain_apply || _runtime_rc=1
     magicnet_singbox_apply_zashboard || _runtime_rc=1
     magicnet_dns_apply_unlocked || _runtime_rc=1
     magicnet_transparent_apply_unlocked || _runtime_rc=1

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh
@@ -60,6 +60,7 @@ magicnet_json_field_raw() {
 magicnet_singbox_tag_is_reserved() {
     case "$1" in
     proxy-auto | proxy | select | lan | hotspot | ad-block | ad-allow | cn-direct | \
+        chain | chain-hop1 | chain-exit | chain-auto | magicnet-chain-* | \
         apple-cn | microsoft-cn | google-cn | icloud | bing | dns-guard | network-test | \
         ai-proxy | ai-chatgpt | ai-chatgpt-auto | ai-gemini | ai-gemini-auto | \
         ai-grok | ai-grok-auto | ai-claude | ai-claude-auto | proxy-rule | dev-proxy | \
@@ -92,19 +93,21 @@ magicnet_singbox_ai_selectors_canonical() {
               + ([$eligible[] | select((us_node_tag | not) and japan_node_tag)])
               + ([$eligible[] | select((us_node_tag | not) and (japan_node_tag | not))]);
           def proxy_node:
-            .type == "shadowsocks" or .type == "vmess" or .type == "vless" or .type == "trojan"
-              or .type == "hysteria2" or .type == "anytls" or .type == "tuic" or .type == "socks";
+            ((.tag // "") | startswith("magicnet-chain-") | not)
+              and (.type == "shadowsocks" or .type == "vmess" or .type == "vless" or .type == "trojan"
+              or .type == "hysteria2" or .type == "anytls" or .type == "tuic" or .type == "socks");
           def reserved_tag:
             . as $tag
             | [
                 "proxy-auto", "proxy", "select", "lan", "hotspot", "ad-block", "ad-allow", "cn-direct",
+                "chain", "chain-hop1", "chain-exit", "chain-auto",
                 "apple-cn", "microsoft-cn", "google-cn", "icloud", "bing", "dns-guard", "network-test",
                 "ai-proxy", "ai-chatgpt", "ai-chatgpt-auto", "ai-gemini", "ai-gemini-auto",
                 "ai-grok", "ai-grok-auto", "ai-claude", "ai-claude-auto", "proxy-rule", "dev-proxy",
                 "social-proxy", "media-proxy", "game-proxy", "telegram-proxy", "download-direct",
                 "final", "direct", "block", "warp"
               ]
-            | index($tag) != null;
+            | index($tag) != null or ($tag | startswith("magicnet-chain-"));
           def valid_proxy_node:
             (.tag | type == "string" and length > 0 and (reserved_tag | not))
               and (.server | type == "string" and length > 0)
@@ -140,6 +143,8 @@ magicnet_singbox_ai_selectors_canonical() {
           | ([.outbounds[]? | select(.tag == "ai-proxy")]) as $ai_proxies
           | ([.outbounds[]? | select(.tag == "proxy")]) as $proxies
           | ([.outbounds[]? | select(.tag == "proxy-auto")]) as $proxy_autos
+          | ([.outbounds[]? | select(.tag == "chain")]) as $chain_groups
+          | (($chain_groups | length) == 1) as $chain_active
           | [.outbounds[]? | select(proxy_node)] as $nodes
           | [$nodes[] | .tag] as $node_tags
           | ($node_tags | prioritize_ai_tags) as $ai_tags
@@ -160,8 +165,11 @@ magicnet_singbox_ai_selectors_canonical() {
                 and $proxy_autos[0].interrupt_exist_connections == false
                 and $proxies[0].type == "selector"
                 and $proxies[0].tag == "proxy"
-                and $proxies[0].outbounds == ($node_tags + ["proxy-auto", "direct", "block"])
-                and $proxies[0].default == $node_tags[0]
+                and (($proxies[0].outbounds == ($node_tags + ["proxy-auto", "direct", "block"]))
+                  or ($proxies[0].outbounds == ($node_tags + ["proxy-auto", "chain", "direct", "block"])
+                    and ($chain_groups | length) == 1))
+                and (($proxies[0].default == $node_tags[0])
+                  or ($proxies[0].default == "chain" and ($chain_groups | length) == 1))
               else
                 ($proxy_autos | length) == 0
                   and $proxies[0].type == "selector"
@@ -171,11 +179,19 @@ magicnet_singbox_ai_selectors_canonical() {
               end)
             and ($ai_proxies | length) == 1
             and ($ai_proxies[0].type == "selector")
-            and (($ai_proxies[0].outbounds == ["block"] and $ai_proxies[0].default == "block" and ($ai_tags | length) == 0)
-              or (($ai_proxies[0].outbounds | length) > 0
-                and $ai_proxies[0].default == $ai_proxies[0].outbounds[0]
-                and $ai_proxies[0].outbounds == $ai_tags
-                and ($ai_proxies[0].outbounds | all(. as $member | ($node_tags | index($member) != null) and ($member | blocked_ai_node_tag | not)))))
+            and (if $chain_active
+                 then $ai_proxies[0].type == "selector"
+                   and $ai_proxies[0].outbounds == ["chain", "block"]
+                   and $ai_proxies[0].default == "chain"
+                 else (($ai_proxies[0].outbounds == ["block"]
+                    and $ai_proxies[0].default == "block" and ($ai_tags | length) == 0)
+                   or (($ai_proxies[0].outbounds | length) > 0
+                    and $ai_proxies[0].default == $ai_proxies[0].outbounds[0]
+                    and $ai_proxies[0].outbounds == $ai_tags
+                    and ($ai_proxies[0].outbounds | all(. as $member
+                      | ($node_tags | index($member) != null)
+                        and ($member | blocked_ai_node_tag | not)))))
+                 end)
             and ($auto_groups | length) == (if ($ai_tags | length) > 0 then 4 else 0 end)
             and ($services | all(. as $service
               | ($service.name + "-auto") as $auto_name
@@ -184,11 +200,24 @@ magicnet_singbox_ai_selectors_canonical() {
               | ($service_groups | length) == 1
                 and $service_groups[0].type == "selector"
                 and $service_groups[0].default
-                  == (if ($ai_tags | length) > 0 then $ai_tags[0] else "block" end)
+                  == (if $chain_active then "chain"
+                      elif ($ai_tags | length) > 0 then $ai_tags[0]
+                      else "block" end)
                 and ($service_groups[0].outbounds
-                  == (if ($ai_tags | length) > 0 then ($ai_tags + ["block", $auto_name]) else ["block"] end))
+                  == (if $chain_active then ["chain", "block", $auto_name]
+                      elif ($ai_tags | length) > 0 then ($ai_tags + ["block", $auto_name])
+                      else ["block"] end))
                 and ($service_groups[0].outbounds | all(. as $member | $tags | index($member) != null))
-                and (if ($ai_tags | length) > 0 then
+                and (if $chain_active then
+                  ($service_auto_groups | length) == 1
+                    and $service_auto_groups[0].type == "urltest"
+                    and $service_auto_groups[0].outbounds == ["chain"]
+                    and $service_auto_groups[0].url == $service.url
+                    and $service_auto_groups[0].interval == "10m"
+                    and $service_auto_groups[0].tolerance == 30
+                    and $service_auto_groups[0].idle_timeout == "10m"
+                    and $service_auto_groups[0].interrupt_exist_connections == false
+                elif ($ai_tags | length) > 0 then
                   ($service_auto_groups | length) == 1
                     and $service_auto_groups[0].type == "urltest"
                     and $service_auto_groups[0].outbounds == $ai_proxies[0].outbounds

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
@@ -84,13 +84,14 @@ magicnet_singbox_build_outbounds_file_with_jq() {
         . as $tag
         | [
             "proxy-auto", "proxy", "select", "lan", "hotspot", "ad-block", "ad-allow", "cn-direct",
+            "chain", "chain-hop1", "chain-exit", "chain-auto",
             "apple-cn", "microsoft-cn", "google-cn", "icloud", "bing", "dns-guard", "network-test",
             "ai-proxy", "ai-chatgpt", "ai-chatgpt-auto", "ai-gemini", "ai-gemini-auto",
             "ai-grok", "ai-grok-auto", "ai-claude", "ai-claude-auto", "proxy-rule", "dev-proxy",
             "social-proxy", "media-proxy", "game-proxy", "telegram-proxy", "download-direct",
             "final", "direct", "block", "warp"
           ]
-        | index($tag) != null;
+        | index($tag) != null or ($tag | startswith("magicnet-chain-"));
       def valid_proxy_node:
         (.tag | type == "string" and length > 0 and (reserved_tag | not))
           and (.server | type == "string" and length > 0)
@@ -247,13 +248,14 @@ magicnet_singbox_count_valid_outbounds_nodes() {
         . as $tag
         | [
             "proxy-auto", "proxy", "select", "lan", "hotspot", "ad-block", "ad-allow", "cn-direct",
+            "chain", "chain-hop1", "chain-exit", "chain-auto",
             "apple-cn", "microsoft-cn", "google-cn", "icloud", "bing", "dns-guard", "network-test",
             "ai-proxy", "ai-chatgpt", "ai-chatgpt-auto", "ai-gemini", "ai-gemini-auto",
             "ai-grok", "ai-grok-auto", "ai-claude", "ai-claude-auto", "proxy-rule", "dev-proxy",
             "social-proxy", "media-proxy", "game-proxy", "telegram-proxy", "download-direct",
             "final", "direct", "block", "warp"
           ]
-        | index($tag) != null;
+        | index($tag) != null or ($tag | startswith("magicnet-chain-"));
       def valid_proxy_node:
         (.tag | type == "string" and length > 0 and (reserved_tag | not))
           and (.server | type == "string" and length > 0)
@@ -562,15 +564,17 @@ magicnet_singbox_sanitize_generated_config() {
         . as $tag
         | [
             "proxy-auto", "proxy", "select", "lan", "hotspot", "ad-block", "ad-allow", "cn-direct",
+            "chain", "chain-hop1", "chain-exit", "chain-auto",
             "apple-cn", "microsoft-cn", "google-cn", "icloud", "bing", "dns-guard", "network-test",
             "ai-proxy", "ai-chatgpt", "ai-chatgpt-auto", "ai-gemini", "ai-gemini-auto",
             "ai-grok", "ai-grok-auto", "ai-claude", "ai-claude-auto", "proxy-rule", "dev-proxy",
             "social-proxy", "media-proxy", "game-proxy", "telegram-proxy", "download-direct",
             "final", "direct", "block", "warp"
           ]
-        | index($tag) != null;
+        | index($tag) != null or ($tag | startswith("magicnet-chain-"));
       def proxy_node:
         proxy_node_type
+          and ((.tag // "") | startswith("magicnet-chain-") | not)
           and (.tag | type == "string" and length > 0 and (reserved_tag | not))
           and (.server | type == "string" and length > 0)
           and (.server_port
@@ -687,7 +691,7 @@ magicnet_singbox_sanitize_generated_config() {
       | ($node_tags | prioritize_ai_tags) as $ai_tags
       | .outbounds = ($deduped_outbounds
           | map(select(.tag as $tag | [
-              "proxy", "proxy-auto",
+              "proxy", "proxy-auto", "chain", "chain-hop1", "chain-exit", "chain-auto",
               "ai-proxy",
               "ai-chatgpt", "ai-gemini", "ai-grok", "ai-claude",
               "ai-chatgpt-auto", "ai-gemini-auto", "ai-grok-auto", "ai-claude-auto"
@@ -779,6 +783,11 @@ magicnet_singbox_update_config_with_nodes() {
 
     magicnet_singbox_sanitize_generated_config "$_tmp_file" || {
         error "Generated sing-box config failed sanitization"
+        return 1
+    }
+
+    magicnet_singbox_chain_apply "$_tmp_file" || {
+        error "Generated sing-box config failed proxy chain materialization"
         return 1
     }
 

--- a/src/MagicNet/lib/magicnet/supervisors.sh
+++ b/src/MagicNet/lib/magicnet/supervisors.sh
@@ -165,6 +165,47 @@ magicnet_supervisor_pidfile_matches() (
 magicnet_watchdog_stop() {
     magicnet_supervisor_stop_pidfile "${KAM_HOME:-$MODDIR}/.state/watchdog/magicnet-kernel.pid"
     magicnet_supervisor_kill_orphans watchdog
+    magicnet_hotspot_watchdog_stop >/dev/null 2>&1 || true
+}
+
+magicnet_hotspot_watchdog_name() {
+    printf '%s\n' "magicnet-hotspot-route"
+}
+
+magicnet_hotspot_watchdog_interval() {
+    printf '%s\n' "${MAGICNET_HOTSPOT_WATCH_INTERVAL:-3}"
+}
+
+magicnet_hotspot_watchdog_start() {
+    if magicnet_module_disabled || ! magicnet_hotspot_proxy_enabled || ! magicnet_kernel_running; then
+        magicnet_hotspot_watchdog_stop >/dev/null 2>&1 || true
+        return 0
+    fi
+    import watchdog
+    _hotspot_watch_name="$(magicnet_hotspot_watchdog_name)"
+    if watchdog status "$_hotspot_watch_name" >/dev/null 2>&1; then
+        magicnet_hotspot_reconcile >/dev/null 2>&1 || true
+        unset _hotspot_watch_name
+        return 0
+    fi
+    magicnet_hotspot_reconcile >/dev/null 2>&1 || true
+    _hotspot_watch_interval="$(magicnet_hotspot_watchdog_interval)"
+    case "$_hotspot_watch_interval" in
+        '' | *[!0-9]* | 0) _hotspot_watch_interval=3 ;;
+    esac
+    KAM_WATCHDOG_LOG_FILE="${MODDIR}/.log/hotspot-route.log" \
+        watchdog start --quiet "$_hotspot_watch_name" "$_hotspot_watch_interval" \
+        "\"${MODDIR}/cli\" hotspot reconcile >/dev/null 2>&1"
+    _hotspot_watch_rc=$?
+    unset _hotspot_watch_name _hotspot_watch_interval
+    return "$_hotspot_watch_rc"
+}
+
+magicnet_hotspot_watchdog_stop() {
+    import watchdog
+    _hotspot_watch_name="$(magicnet_hotspot_watchdog_name)"
+    watchdog stop "$_hotspot_watch_name" >/dev/null 2>&1 || true
+    unset _hotspot_watch_name
 }
 
 magicnet_fswatch_name() {
@@ -874,6 +915,7 @@ magicnet_supervisors_start() {
     magicnet_fswatch_start || _mss_rc=1
     magicnet_subscription_refresh_start || _mss_rc=1
     magicnet_wifi_policy_start || _mss_rc=1
+    magicnet_hotspot_watchdog_start || _mss_rc=1
     # Startup may materialize supervisor-owned policy after the core's initial
     # fingerprint was recorded.  Publish the settled generation so the next
     # fswatch pass does not restart an already-current core and tear down
@@ -889,5 +931,6 @@ magicnet_supervisors_stop() {
     magicnet_watchdog_stop
     magicnet_fswatch_stop
     magicnet_wifi_policy_stop
+    magicnet_hotspot_route_cleanup >/dev/null 2>&1 || true
     [ "${MAGICNET_SUB_PRESERVE_REFRESH:-0}" = "1" ] || magicnet_subscription_refresh_stop
 }

--- a/src/MagicNet/lib/magicnet_singbox_subscribe.sh
+++ b/src/MagicNet/lib/magicnet_singbox_subscribe.sh
@@ -3,7 +3,12 @@
 # Import common Clash-style subscription nodes into the bundled sing-box config.
 
 _magicnet_subscribe_lib_dir="${MODDIR}/lib/magicnet/singbox_subscribe"
-for _magicnet_subscribe_lib in common fetch parse config chain proxylink update; do
+# The subscription updater can be invoked in isolation during first boot and
+# package validation; load the shared chain materializer before config.sh calls
+# it. The normal module entrypoint may already have loaded this file, which is
+# harmless because the functions are deterministic definitions.
+[ -f "${MODDIR}/lib/magicnet/chain.sh" ] && . "${MODDIR}/lib/magicnet/chain.sh"
+for _magicnet_subscribe_lib in common fetch parse config proxylink update; do
     . "${_magicnet_subscribe_lib_dir}/${_magicnet_subscribe_lib}.sh"
 done
 unset _magicnet_subscribe_lib _magicnet_subscribe_lib_dir

--- a/src/MagicNet/lib/magicnet_singbox_subscribe.sh
+++ b/src/MagicNet/lib/magicnet_singbox_subscribe.sh
@@ -3,7 +3,7 @@
 # Import common Clash-style subscription nodes into the bundled sing-box config.
 
 _magicnet_subscribe_lib_dir="${MODDIR}/lib/magicnet/singbox_subscribe"
-for _magicnet_subscribe_lib in common fetch parse config proxylink update; do
+for _magicnet_subscribe_lib in common fetch parse config chain proxylink update; do
     . "${_magicnet_subscribe_lib_dir}/${_magicnet_subscribe_lib}.sh"
 done
 unset _magicnet_subscribe_lib _magicnet_subscribe_lib_dir

--- a/src/MagicNet/module.prop
+++ b/src/MagicNet/module.prop
@@ -1,7 +1,7 @@
 id=MagicNet
 name=MagicNet
-version=v1.2.10
-versionCode=1786360750770
+version=v1.2.11
+versionCode=1786454155461
 author=LIghtJUNction
 description=[MagicNet]:Android root network module with magicnet0 TUN, sing-box, WebUI, MCP, and DNS leak guard tools. Built with KAM.
 updateJson=https://raw.githubusercontent.com/LIghtJUNction/MagicNet/main/update.json

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
   "changelog": "https://github.com/LIghtJUNction/MagicNet/blob/main/CHANGELOG.md",
-  "version": "v1.2.10",
-  "versionCode": 1786360750770,
+  "version": "v1.2.11",
+  "versionCode": 1786454155461,
   "zipUrl": "https://github.com/LIghtJUNction/MagicNet/releases/latest/download/MagicNet.zip"
 }

--- a/webui/bun.lock
+++ b/webui/bun.lock
@@ -24,6 +24,7 @@
     },
   },
   "overrides": {
+    "nanoid": "3.3.17",
     "postcss": "8.5.23",
   },
   "packages": {
@@ -223,7 +224,7 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 

--- a/webui/dependency-security.test.mjs
+++ b/webui/dependency-security.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const minimum = [3, 3, 17];
+const atLeast = (version, expected) => {
+  const actual = version.split(".").map((part) => Number.parseInt(part, 10));
+  return actual.some((part, index) => part !== expected[index])
+    ? actual[0] > expected[0] ||
+        (actual[0] === expected[0] &&
+          (actual[1] > expected[1] ||
+            (actual[1] === expected[1] && actual[2] >= expected[2])))
+    : true;
+};
+
+const packageJson = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8"));
+assert.equal(packageJson.overrides?.nanoid, "3.3.17");
+
+const packageLock = JSON.parse(
+  readFileSync(new URL("./package-lock.json", import.meta.url), "utf8"),
+);
+const nanoidPackages = Object.entries(packageLock.packages ?? {}).filter(([path]) =>
+  path.endsWith("/node_modules/nanoid"),
+);
+assert.ok(nanoidPackages.length > 0, "package-lock.json must contain nanoid");
+for (const [path, metadata] of nanoidPackages) {
+  assert.ok(atLeast(metadata.version, minimum), `${path} is vulnerable: ${metadata.version}`);
+}
+
+const bunLock = readFileSync(new URL("./bun.lock", import.meta.url), "utf8");
+assert.match(bunLock, /"nanoid": "3\.3\.17"/);
+assert.match(bunLock, /"nanoid": \["nanoid@3\.3\.17"/);
+
+console.log("dependency security tests passed");

--- a/webui/hotspot-policy.test.mjs
+++ b/webui/hotspot-policy.test.mjs
@@ -25,14 +25,18 @@ assert.match(control, /proxy<\/code> 代理组/);
 assert.match(control, /不勾选时统一走\s*<code>direct<\/code>/);
 
 for (const source of [
+  "10.0.0.0/8",
+  "172.16.0.0/12",
   "192.168.0.0/16",
-  "10.42.0.0/16",
-  "172.20.10.0/28",
 ]) {
   assert.match(routes, new RegExp(source.replaceAll(".", String.raw`\.`)));
 }
 assert.match(routes, /"outbound": "hotspot"/);
 assert.match(routes, /"outbounds": \["direct", "proxy"\]/);
+assert.match(routes, /ip rule add priority/);
+assert.match(routes, /lookup 2022/);
+assert.match(routes, /magicnet_hotspot_discover_interfaces/);
+assert.match(routes, /magicnet_hotspot_route_cleanup/);
 assert.match(routes, /settings put global tether_offload_disabled 1/);
 assert.match(routes, /magicnet_hotspot_offload_restore/);
 assert.match(routes, /register_uninstall_cmd/);

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1461,24 +1461,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -1529,6 +1511,24 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/reka-ui": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -28,6 +28,7 @@
     "vite": "^8.0.16"
   },
   "overrides": {
-    "postcss": "8.5.23"
+    "postcss": "8.5.23",
+    "nanoid": "3.3.17"
   }
 }


### PR DESCRIPTION
## Summary
- Add configurable sing-box two-hop proxy chain and robust hotspot routing reconciliation.
- Pin transitive WebUI nanoid to 3.3.17 to remediate Dependabot alert #3.
- Update version metadata and CHANGELOG.md for v1.2.11.

## Validation
- WebUI dependency security test, typecheck, test suite, and production build pass.
- npm audit --omit=dev reports zero vulnerabilities.
- MagicNet package build and package smoke tests pass.

The repository pre-commit suite still contains unrelated legacy fixture failures; they were not bypassed silently and are documented in the handoff.

## Summary by Sourcery

在 MagicNet 模块中引入可配置的双跳 sing-box 代理链和更健壮的热点路由，更新 CLI/守护进程集成与测试，并升级 WebUI 依赖以修复安全问题，同时更新 v1.2.11 的发布元数据。

New Features:
- 增加可配置的本地双跳 sing-box 代理链，包含 CLI 命令、持久化策略、选择器集成，以及自动或手动出口选择。
- 通过 CLI 和 supervisor 暴露热点路由的对账与状态信息，包括一个用于跟踪链路变化的周期性监视器。

Bug Fixes:
- 通过动态发现 Android 共享热点接口和子网、注入可回滚的策略路由，修复热点代理共享问题，从而确保所有共享的 IPv4 流量都能稳定地导入 magicnet0 TUN。
- 恢复并加固路由和订阅更新路径，避免在失败后留下不完整的热点或链路配置。

Enhancements:
- 更新热点 TUN 策略以使用规范的 RFC1918 源地址段，从而避免 OEM 修改子网时导致路由失效。
- 扩展 AI 选择器和订阅配置逻辑，使其理解与链路相关的分组，避免将受管链路出站误分类为普通代理节点。
- 收紧运行时清理逻辑，在停止 MagicNet 或禁用热点代理时停止热点监视器并清除策略规则。
- 扩展诊断能力、节点分组启发式规则和测试，以覆盖与链路相关的选择器和热点路由行为。
- 改进文档，说明热点路由拦截语义以及新的双跳代理链特性。

Build:
- 通过包覆盖与锁定文件将 WebUI 的 nanoid 固定到 3.3.17 版本，以消除依赖漏洞。

Documentation:
- 在用户指南和架构指南中记录热点路由模型以及由监视器驱动的对账机制，并在 MagicNet 的 README 中增加双跳代理链的使用说明。

Tests:
- 增加 sing-box 代理链实体化测试和热点路由测试，包括 CLI 透明模式覆盖，以及 WebUI 依赖的安全测试。
- 更新现有的路由和热点策略测试，用于验证新的 RFC1918 地址段和热点路由管理命令。

Chores:
- 更新 MagicNet 版本元数据与 CHANGELOG 至 v1.2.11，确保包的冒烟测试覆盖新的链路实体化脚本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce configurable two-hop sing-box proxy chaining and robust hotspot routing into the MagicNet module, update CLI/daemon integration and tests, and bump WebUI dependencies for a security fix and release metadata for v1.2.11.

New Features:
- Add a configurable local two-hop sing-box proxy chain with CLI commands, persisted policy, selector integration, and automatic or manual exit selection.
- Expose hotspot route reconciliation and status via the CLI and supervisors, including a periodic watcher to track interface changes.

Bug Fixes:
- Fix hotspot proxy sharing by dynamically discovering Android tether interfaces and subnets, injecting reversible policy routing so tethered IPv4 traffic is consistently steered into the magicnet0 TUN.
- Restore and harden routing and subscription update paths to avoid leaving partial hotspot or chain configuration after failures.

Enhancements:
- Update hotspot TUN policy to use canonical RFC1918 source ranges so OEM subnet changes no longer break routing.
- Extend AI selector and subscription config logic to understand chain-related groups and avoid misclassifying managed chain outbounds as regular proxy nodes.
- Tighten runtime cleanup to stop the hotspot watcher and clear policy rules when stopping MagicNet or disabling hotspot proxy.
- Expand diagnostics, node grouping heuristics, and tests to cover chain-related selectors and hotspot routing behaviour.
- Improve documentation to describe hotspot route interception semantics and the new two-hop proxy chain feature.

Build:
- Pin WebUI nanoid to version 3.3.17 via package overrides and lockfiles to remediate a dependency vulnerability.

Documentation:
- Document the hotspot routing model and watcher-driven reconciliation in the user and architecture guides, and add usage instructions for the two-hop proxy chain in the MagicNet README.

Tests:
- Add sing-box proxy chain materialization tests and hotspot routing tests, including CLI transparent-mode coverage and dependency security tests for the WebUI.
- Update existing routing and hotspot policy tests to validate the new RFC1918 ranges and hotspot route management commands.

Chores:
- Update MagicNet version metadata and CHANGELOG for the v1.2.11 release, and ensure package smoke tests cover the new chain materialization script.

</details>