### PR TITLE
Fix slow WeChat image loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Select a reachable AliDNS HTTPS bootstrap across IPv4 and IPv6 to reduce DNS timeouts during proxy-node resolution.
+- Resolve WeChat and Tencent media domains with local DNS and route them directly so image CDN requests keep regional affinity and avoid slow proxy fallthrough.
 
 ## v1.2.11 (2026-08-11)
 

--- a/scripts/package-smoke.sh
+++ b/scripts/package-smoke.sh
@@ -1045,6 +1045,18 @@ global_mode_rules = [
     index for index, rule in enumerate(dns_rules)
     if rule == {"clash_mode": "Global", "server": "doh-cloudflare"}
 ]
+wechat_media_dns_rule = {
+    "domain_suffix": [
+        "qq.com", "weixin.qq.com", "wechat.com", "wechatapp.com", "wechatpay.cn",
+        "tenpay.com", "tencent.com", "tencent-cloud.com", "myqcloud.com", "qcloud.com",
+        "gtimg.com", "idqqimg.com", "qpic.cn", "qlogo.cn", "qmail.com", "smtcdns.com",
+        "servicewechat.com", "weixinbridge.com", "weixinsxy.com", "wx.gtimg.com", "wx.qq.com",
+    ],
+    "server": "bootstrap-local-dns",
+}
+wechat_media_dns_rules = [
+    index for index, rule in enumerate(dns_rules) if rule == wechat_media_dns_rule
+]
 domestic_connectivity_rules = [
     index for index, rule in enumerate(dns_rules) if rule == domestic_connectivity_rule
 ]
@@ -1095,7 +1107,8 @@ if len(direct_mode_rules) != 1 or len(global_mode_rules) != 1:
         f"Direct={direct_mode_rules} Global={global_mode_rules}"
     )
 if (
-    len(domestic_connectivity_rules) != 1
+    len(wechat_media_dns_rules) != 1
+    or len(domestic_connectivity_rules) != 1
     or len(foreign_connectivity_rules) != 1
     or len(apple_icloud_rules) != 1
     or len(cn_bing_dns_rules) != 1
@@ -1114,6 +1127,7 @@ if (
 ):
     raise SystemExit(
         "expected unique exact explicit DNS policy rules, "
+        f"wechat_media={wechat_media_dns_rules} "
         f"domestic={domestic_connectivity_rules} "
         f"foreign={foreign_connectivity_rules} "
         f"apple={apple_icloud_rules} cn_bing={cn_bing_dns_rules} "
@@ -1128,6 +1142,7 @@ if (
     )
 direct_mode_index = direct_mode_rules[0]
 global_mode_index = global_mode_rules[0]
+wechat_media_dns_index = wechat_media_dns_rules[0]
 domestic_connectivity_index = domestic_connectivity_rules[0]
 foreign_connectivity_index = foreign_connectivity_rules[0]
 apple_icloud_index = apple_icloud_rules[0]
@@ -1146,10 +1161,15 @@ x_social_dns_index = x_social_dns_rules[0]
 canonical_cn_dns_index = canonical_cn_dns_rules[0]
 if global_mode_index != direct_mode_index + 1:
     raise SystemExit("Global DNS override must remain immediately after the Direct override")
-if domestic_connectivity_index != global_mode_index + 1:
+if wechat_media_dns_index != global_mode_index + 1:
+    raise SystemExit(
+        f"WeChat media DNS rule index {wechat_media_dns_index} must immediately "
+        f"follow Direct/Global overrides ending at {global_mode_index}"
+    )
+if domestic_connectivity_index != wechat_media_dns_index + 1:
     raise SystemExit(
         f"domestic connectivity DNS rule index {domestic_connectivity_index} must immediately "
-        f"follow Direct/Global overrides ending at {global_mode_index}"
+        f"follow WeChat media DNS rule index {wechat_media_dns_index}"
     )
 if foreign_connectivity_index != domestic_connectivity_index + 1:
     raise SystemExit(

--- a/scripts/test-default-routing-policy.sh
+++ b/scripts/test-default-routing-policy.sh
@@ -205,6 +205,15 @@ apple_icloud_dns_rule = {
 }
 direct_mode_dns_rule = {"clash_mode": "Direct", "server": "bootstrap-local-dns"}
 global_mode_dns_rule = {"clash_mode": "Global", "server": "doh-cloudflare"}
+wechat_media_dns_rule = {
+    "domain_suffix": [
+        "qq.com", "weixin.qq.com", "wechat.com", "wechatapp.com", "wechatpay.cn",
+        "tenpay.com", "tencent.com", "tencent-cloud.com", "myqcloud.com", "qcloud.com",
+        "gtimg.com", "idqqimg.com", "qpic.cn", "qlogo.cn", "qmail.com", "smtcdns.com",
+        "servicewechat.com", "weixinbridge.com", "weixinsxy.com", "wx.gtimg.com", "wx.qq.com",
+    ],
+    "server": "bootstrap-local-dns",
+}
 domestic_connectivity_dns_rule = {
     "domain_suffix": ["connect.rom.miui.com", "connectivitycheck.platform.hicloud.com"],
     "server": "bootstrap-local-dns",
@@ -315,6 +324,7 @@ ordered_dns_policy_indexes = []
 for expected_rule in (
     direct_mode_dns_rule,
     global_mode_dns_rule,
+    wechat_media_dns_rule,
     domestic_connectivity_dns_rule,
     foreign_network_test_dns_rule,
     apple_icloud_dns_rule,
@@ -331,13 +341,14 @@ if not all(
     for left, right in zip(ordered_dns_policy_indexes, ordered_dns_policy_indexes[1:])
 ):
     raise AssertionError(
-        "required DNS order is Direct -> Global -> domestic connectivity -> foreign network-test "
-        "-> Apple -> cn Bing -> global Bing -> local Microsoft: "
+        "required DNS order is Direct -> Global -> WeChat media -> domestic connectivity "
+        "-> foreign network-test -> Apple -> cn Bing -> global Bing -> local Microsoft: "
         f"indexes={ordered_dns_policy_indexes}"
     )
 (
     direct_mode_dns_index,
     global_mode_dns_index,
+    wechat_media_dns_index,
     domestic_connectivity_dns_index,
     foreign_network_test_dns_index,
     apple_icloud_dns_index,

--- a/scripts/test-default-routing-policy.sh
+++ b/scripts/test-default-routing-policy.sh
@@ -2350,7 +2350,7 @@ network_connectivity_keyword_index=$(jq -er '
 
 assert_connectivity_dns_safety() {
     local config_file="$1"
-    local default_mode direct_mode_index global_mode_index domestic_rule_index foreign_rule_index
+    local default_mode direct_mode_index global_mode_index wechat_rule_index domestic_rule_index foreign_rule_index
     local apple_rule_index cn_bing_rule_index global_bing_rule_index local_service_index
     local private_dns_index mmstat_dns_index ad_suffix_dns_index ad_keyword_dns_index ad_rule_set_dns_index
     local game_dns_index foreign_priority_dns_index x_social_dns_index cn_dns_index
@@ -2369,7 +2369,7 @@ assert_connectivity_dns_safety() {
         printf 'DNS safety guard: default Clash mode must remain Rule\n' >&2
         return 1
     }
-    read -r direct_mode_index global_mode_index domestic_rule_index foreign_rule_index \
+    read -r direct_mode_index global_mode_index wechat_rule_index domestic_rule_index foreign_rule_index \
         apple_rule_index cn_bing_rule_index global_bing_rule_index local_service_index \
         private_dns_index mmstat_dns_index ad_suffix_dns_index ad_keyword_dns_index ad_rule_set_dns_index \
         game_dns_index foreign_priority_dns_index x_social_dns_index cn_dns_index < <(jq -er '
@@ -2379,6 +2379,15 @@ assert_connectivity_dns_safety() {
       [
         unique_index({clash_mode: "Direct", server: "bootstrap-local-dns"}),
         unique_index({clash_mode: "Global", server: "doh-cloudflare"}),
+        unique_index({
+          domain_suffix: [
+            "qq.com", "weixin.qq.com", "wechat.com", "wechatapp.com", "wechatpay.cn",
+            "tenpay.com", "tencent.com", "tencent-cloud.com", "myqcloud.com", "qcloud.com",
+            "gtimg.com", "idqqimg.com", "qpic.cn", "qlogo.cn", "qmail.com", "smtcdns.com",
+            "servicewechat.com", "weixinbridge.com", "weixinsxy.com", "wx.gtimg.com", "wx.qq.com"
+          ],
+          server: "bootstrap-local-dns"
+        }),
         unique_index({
           domain_suffix: ["connect.rom.miui.com", "connectivitycheck.platform.hicloud.com"],
           server: "bootstrap-local-dns"
@@ -2491,7 +2500,8 @@ assert_connectivity_dns_safety() {
         return 1
     }
     ((global_mode_index == direct_mode_index + 1 \
-        && domestic_rule_index == global_mode_index + 1 \
+        && wechat_rule_index == global_mode_index + 1 \
+        && domestic_rule_index == wechat_rule_index + 1 \
         && foreign_rule_index == domestic_rule_index + 1 \
         && apple_rule_index == foreign_rule_index + 1 \
         && cn_bing_rule_index == apple_rule_index + 1 \

--- a/scripts/test-wechat-routing.sh
+++ b/scripts/test-wechat-routing.sh
@@ -22,6 +22,15 @@ with open(sys.argv[1], encoding="utf-8") as handle:
     config = json.load(handle)
 
 route_rules = config["route"]["rules"]
+dns_rules = config["dns"]["rules"]
+wechat_domains = [
+    "qq.com", "weixin.qq.com", "wechat.com", "wechatapp.com", "wechatpay.cn",
+    "tenpay.com", "tencent.com", "tencent-cloud.com", "myqcloud.com", "qcloud.com",
+    "gtimg.com", "idqqimg.com", "qpic.cn", "qlogo.cn", "qmail.com", "smtcdns.com",
+    "servicewechat.com", "weixinbridge.com", "weixinsxy.com", "wx.gtimg.com", "wx.qq.com",
+]
+wechat_route = {"domain_suffix": wechat_domains, "outbound": "cn-direct"}
+wechat_dns = {"domain_suffix": wechat_domains, "server": "bootstrap-local-dns"}
 
 
 def exact_indexes(rules, expected):
@@ -53,15 +62,36 @@ def domain_matches(rule, domain):
     )
 
 
+wechat_route_indexes = exact_indexes(route_rules, wechat_route)
+wechat_dns_indexes = exact_indexes(dns_rules, wechat_dns)
+if len(wechat_route_indexes) != 1:
+    raise AssertionError(f"expected one canonical WeChat direct route, got {wechat_route_indexes}")
+if len(wechat_dns_indexes) != 1:
+    raise AssertionError(f"expected one canonical WeChat local-DNS rule, got {wechat_dns_indexes}")
+
+global_route_indexes = [
+    index for index, rule in enumerate(route_rules) if rule.get("clash_mode") == "Global"
+]
+global_dns_indexes = [
+    index for index, rule in enumerate(dns_rules) if rule.get("clash_mode") == "Global"
+]
+if global_route_indexes and wechat_route_indexes[0] <= global_route_indexes[-1]:
+    raise AssertionError("Global route mode must retain priority over the WeChat direct route")
+if global_dns_indexes and wechat_dns_indexes[0] <= global_dns_indexes[-1]:
+    raise AssertionError("Global DNS mode must retain priority over the WeChat local resolver")
+
 if any(
-    any(
-        token in suffix
-        for suffix in rule.get("domain_suffix", [])
-        for token in ("qq", "wechat", "weixin", "qpic", "qlogo", "tencent")
-    )
+    "com.tencent.mm" in rule.get("package_name", [])
+    and rule.get("outbound") == "cn-direct"
     for rule in route_rules
 ):
-    raise AssertionError("routing policy must not contain QQ/WeChat/Tencent-specific exceptions")
+    raise AssertionError("WeChat must not be forced wholly direct by package name")
 
-print("Generic domestic routing policy test passed")
+for domain in ("mmbiz.qpic.cn", "wx.qlogo.cn", "res.wx.qq.com", "weixin.qq.com"):
+    if not domain_matches(wechat_route, domain):
+        raise AssertionError(f"WeChat media domain is missing from direct routing: {domain}")
+    if not domain_matches(wechat_dns, domain):
+        raise AssertionError(f"WeChat media domain is missing from local DNS: {domain}")
+
+print("WeChat media routing policy test passed")
 PY


### PR DESCRIPTION
## What changed

- Update the pinned MagicSingBox policy with local-DNS and direct routing for WeChat/Tencent media domains.
- Replace the regression that forbade service-specific routes with coverage for image CDN routing and DNS ownership.
- Keep Global mode ahead of the optimized route and reject whole-app `com.tencent.mm` direct routing.
- Document the behavior change in the changelog.

## Root cause

Generic CN rule sets can omit or misclassify a Tencent media hostname. The request then falls through to remote DNS or the default proxy, losing the CDN's regional affinity and making image viewing slow.

## Validation

- `jq empty src/MagicNet/.config/sing-box/config.json`
- `bash -n scripts/test-wechat-routing.sh`
- `bash scripts/test-wechat-routing.sh`
- `git diff --check` in MagicNet and MagicSingBox

The full default routing test could not run locally because the `sing-box` executable is unavailable in this environment.

Depends on the companion MagicSingBox PR: https://github.com/LIghtJUNction/MagicSingBox/pull/10

## Summary by Sourcery

收紧微信媒体路由和 DNS 行为，确保腾讯图片域名使用本地解析和直连路径，同时保持 Global 模式优先级，并避免整个应用被设置为直连路由。

Bug 修复：
- 确保微信和腾讯媒体域名通过本地 DNS 解析并走直连路由，防止由于代理回退导致图片加载缓慢。
- 防止通过包名将 `com.tencent.mm` 整体设置为直连路由，以避免覆盖已优化的媒体专用路由策略。

增强：
- 在 sing-box 配置中添加显式校验，确保微信媒体路由和 DNS 规则存在、规范，并且排列在 Global 模式之后。

文档：
- 在变更日志中记录更新后的微信/腾讯媒体路由行为及性能改进。

测试：
- 扩展微信路由测试脚本，用于断言规范的本地 DNS 与直连路由规则、Global 模式的顺序，以及对关键媒体 CDN 域名的覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten WeChat media routing and DNS behavior to ensure Tencent image domains use local resolution and direct paths while preserving Global mode precedence and avoiding whole-app direct routing.

Bug Fixes:
- Ensure WeChat and Tencent media domains are resolved via local DNS and routed directly to prevent slow image loading caused by proxy fallthrough.
- Prevent com.tencent.mm from being routed wholly direct by package name to avoid overriding optimized media-specific routing.

Enhancements:
- Add explicit validation that WeChat media routing and DNS rules are present, canonical, and ordered after Global mode in the sing-box configuration.

Documentation:
- Document the updated WeChat/Tencent media routing behavior and performance improvement in the changelog.

Tests:
- Extend the WeChat routing test script to assert canonical local-DNS and direct-route rules, Global mode ordering, and coverage of key media CDN domains.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

收紧微信媒体路由和 DNS 行为，确保腾讯图片域名使用本地解析和直连路径，同时保持 Global 模式优先级，并避免整个应用被设置为直连路由。

Bug 修复：
- 确保微信和腾讯媒体域名通过本地 DNS 解析并走直连路由，防止由于代理回退导致图片加载缓慢。
- 防止通过包名将 `com.tencent.mm` 整体设置为直连路由，以避免覆盖已优化的媒体专用路由策略。

增强：
- 在 sing-box 配置中添加显式校验，确保微信媒体路由和 DNS 规则存在、规范，并且排列在 Global 模式之后。

文档：
- 在变更日志中记录更新后的微信/腾讯媒体路由行为及性能改进。

测试：
- 扩展微信路由测试脚本，用于断言规范的本地 DNS 与直连路由规则、Global 模式的顺序，以及对关键媒体 CDN 域名的覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten WeChat media routing and DNS behavior to ensure Tencent image domains use local resolution and direct paths while preserving Global mode precedence and avoiding whole-app direct routing.

Bug Fixes:
- Ensure WeChat and Tencent media domains are resolved via local DNS and routed directly to prevent slow image loading caused by proxy fallthrough.
- Prevent com.tencent.mm from being routed wholly direct by package name to avoid overriding optimized media-specific routing.

Enhancements:
- Add explicit validation that WeChat media routing and DNS rules are present, canonical, and ordered after Global mode in the sing-box configuration.

Documentation:
- Document the updated WeChat/Tencent media routing behavior and performance improvement in the changelog.

Tests:
- Extend the WeChat routing test script to assert canonical local-DNS and direct-route rules, Global mode ordering, and coverage of key media CDN domains.

</details>

</details>