### PR TITLE
Fix private Wi-Fi traffic misclassified as hotspot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Select a reachable AliDNS HTTPS bootstrap across IPv4 and IPv6 to reduce DNS timeouts during proxy-node resolution.
 - Resolve WeChat and Tencent media domains with local DNS and route them directly so image CDN requests keep regional affinity and avoid slow proxy fallthrough.
+- Restrict hotspot routing to discovered tether subnets so ordinary private-address Wi-Fi traffic cannot bypass app and domain routing rules.
 
 ## v1.2.11 (2026-08-11)
 

--- a/crates/magicnet-cli/src/webui_api.rs
+++ b/crates/magicnet-cli/src/webui_api.rs
@@ -81,7 +81,13 @@ pub(crate) fn hotspot_cmd(app: &App, args: &[String]) -> Result<(), String> {
             run_magicnet_function(app, "magicnet_hotspot_route_status")?;
             Ok(())
         }
-        "reconcile" => run_magicnet_function(app, "magicnet_hotspot_reconcile"),
+        "reconcile" => {
+            run_magicnet_function(app, "magicnet_hotspot_reconcile")?;
+            if run_magicnet_function(app, "magicnet_singbox_hotspot_policy_current").is_err() {
+                apply_config(app)?;
+            }
+            Ok(())
+        }
         "enable" | "disable" => {
             let member = if action == "enable" {
                 "proxy"
@@ -108,9 +114,8 @@ pub(crate) fn hotspot_cmd(app: &App, args: &[String]) -> Result<(), String> {
             }
             if action == "enable" {
                 // The hotspot source rule is consumed at sing-box startup.
-                // Apply the canonical RFC1918 rule and restart only when the
-                // effective runtime fingerprint changed; this upgrades an
-                // already-running process from the legacy fixed subnets.
+                // Materialize the active downstream subnet and restart only
+                // when the effective runtime fingerprint changed.
                 if let Err(error) = apply_config(app) {
                     let _ = select_proxy(app, "hotspot", "direct");
                     let _ = run_magicnet_function(app, "magicnet_hotspot_offload_restore");

--- a/scripts/fake-magisk-smoke.sh
+++ b/scripts/fake-magisk-smoke.sh
@@ -758,9 +758,8 @@ hotspot_policy_ready() {
     )
     and ([.route.rules[] | select(
       .inbound == ["tun-in"]
-      and .source_ip_cidr == ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
       and .outbound == "hotspot"
-    )] | length == 1)
+    )] | length == 0)
     ' "$MODDIR/.config/sing-box/config.json" >/dev/null
 }
 for _wait_hotspot_policy in {1..20}; do

--- a/scripts/test-hotspot-routing.sh
+++ b/scripts/test-hotspot-routing.sh
@@ -10,6 +10,20 @@ RULES="$WORK/ip-rules"
 mkdir -p "$MODDIR/.state/hotspot" "$MODDIR/.config/sing-box"
 printf '%s\n' '21000: from all iif wlan2 lookup wlan0' >"$RULES"
 printf '%s\n' 'value=0' >"$MODDIR/.state/hotspot/tether-offload.previous"
+HOTSPOT_CIDR=10.199.43.0/24
+cat >"$MODDIR/.config/sing-box/config.json" <<'EOF'
+{
+  "outbounds": [
+    {"type": "selector", "tag": "hotspot", "outbounds": ["direct", "proxy"], "default": "direct"}
+  ],
+  "route": {
+    "rules": [
+      {"inbound": ["mixed-in", "tun-in"], "action": "sniff"},
+      {"domain_suffix": ["qq.com"], "outbound": "cn-direct"}
+    ]
+  }
+}
+EOF
 
 magicnet_cmd_exists() {
   case "$1" in
@@ -48,7 +62,7 @@ ip() {
   if [ "${1:-}" = route ] && [ "${2:-}" = show ] &&
     [ "${3:-}" = dev ] && [ "${4:-}" = wlan2 ] &&
     [ "${5:-}" = scope ] && [ "${6:-}" = link ]; then
-    printf '%s\n' '10.199.43.0/24 proto kernel scope link src 10.199.43.11'
+    printf '%s proto kernel scope link src 10.199.43.11\n' "$HOTSPOT_CIDR"
     return 0
   fi
   if [ "${1:-}" = rule ] && [ "${2:-}" = show ]; then
@@ -74,6 +88,39 @@ ip() {
 
 . "$ROOT/src/MagicNet/lib/magicnet/routes.sh"
 
+magicnet_singbox_apply_hotspot_policy
+jq -e '
+  [.route.rules[] | select(
+    .inbound == ["tun-in"] and .outbound == "hotspot"
+  )] == [{
+    "inbound": ["tun-in"],
+    "source_ip_cidr": ["10.199.43.0/24"],
+    "outbound": "hotspot"
+  }]
+' "$MODDIR/.config/sing-box/config.json" >/dev/null
+magicnet_singbox_hotspot_policy_current
+if jq -e '
+  [.route.rules[] | select(
+    .outbound == "hotspot"
+      and (.source_ip_cidr // [] | index("192.168.0.0/16")) != null
+  )] | length > 0
+' "$MODDIR/.config/sing-box/config.json" >/dev/null; then
+  printf '%s\n' 'phone Wi-Fi RFC1918 space leaked into the hotspot source policy' >&2
+  exit 1
+fi
+HOTSPOT_CIDR=192.168.52.0/24
+if magicnet_singbox_hotspot_policy_current; then
+  printf '%s\n' 'renumbered hotspot subnet was incorrectly treated as current' >&2
+  exit 1
+fi
+magicnet_singbox_apply_hotspot_policy
+jq -e '
+  [.route.rules[] | select(
+    .inbound == ["tun-in"] and .outbound == "hotspot"
+  )][0].source_ip_cidr == ["192.168.52.0/24"]
+' "$MODDIR/.config/sing-box/config.json" >/dev/null
+magicnet_singbox_hotspot_policy_current
+
 magicnet_hotspot_reconcile
 grep -Fqx '20999|wlan2' "$MODDIR/.state/hotspot/tun-rules.list"
 grep -Fqx '20999: from all iif wlan2 lookup 2022' "$RULES"
@@ -84,7 +131,7 @@ magicnet_hotspot_reconcile
 magicnet_hotspot_route_status >"$WORK/status"
 grep -Fqx 'route_table_ready=1' "$WORK/status"
 grep -Fqx 'downstream_interfaces=wlan2' "$WORK/status"
-grep -Fqx 'downstream_networks=10.199.43.0/24' "$WORK/status"
+grep -Fqx 'downstream_networks=192.168.52.0/24' "$WORK/status"
 grep -Fqx 'route_status=ready' "$WORK/status"
 
 magicnet_hotspot_offload_restore
@@ -92,5 +139,12 @@ magicnet_hotspot_offload_restore
 if grep -q '^20999:' "$RULES"; then
   exit 1
 fi
+magicnet_singbox_apply_hotspot_policy
+jq -e '
+  [.route.rules[] | select(
+    .inbound == ["tun-in"] and .outbound == "hotspot"
+  )] | length == 0
+' "$MODDIR/.config/sing-box/config.json" >/dev/null
+magicnet_singbox_hotspot_policy_current
 
 printf '%s\n' 'hotspot routing test passed'

--- a/src/MagicNet/lib/magicnet/routes.sh
+++ b/src/MagicNet/lib/magicnet/routes.sh
@@ -35,6 +35,11 @@ magicnet_hotspot_proxy_enabled() {
     [ -f "$(magicnet_hotspot_offload_state_file)" ]
 }
 
+magicnet_hotspot_source_cidrs() {
+    magicnet_hotspot_proxy_enabled || return 0
+    magicnet_hotspot_active_networks | awk -F'|' 'NF == 2 && !seen[$2]++ { print $2 }'
+}
+
 magicnet_hotspot_interface_allowed() {
     _hotspot_allowed_iface="$1"
     case "$_hotspot_allowed_iface" in
@@ -459,14 +464,19 @@ magicnet_singbox_apply_hotspot_policy() {
         unset _config _jq
         return 1
     }
+    _hotspot_sources="$(magicnet_hotspot_source_cidrs || true)"
+    _hotspot_sources_json="$(printf '%s\n' "$_hotspot_sources" | "$_jq" -Rsc '
+        split("\n") | map(select(length > 0))
+    ')" || {
+        unset _config _jq _hotspot_sources _hotspot_sources_json
+        return 1
+    }
     _tmp="${_config}.hotspot-policy.new"
-    # Forwarded Android tethering clients retain a private source address when
-    # entering the TUN. The policy route below selects the actual tethered
-    # interface; these RFC1918 ranges keep the sing-box rule valid even when an
-    # OEM changes the DHCP subnet after the core has already started.
-    if (umask 077; "$_jq" '
-        def hotspot_sources:
-          ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"];
+    # Forwarded clients retain an address from the active downstream subnet
+    # when entering the TUN. Match only those discovered subnets: matching all
+    # RFC1918 space also catches the phone's own Wi-Fi traffic whenever process
+    # attribution or domain sniffing is unavailable.
+    if (umask 077; "$_jq" --argjson hotspot_sources "$_hotspot_sources_json" '
         def hotspot_selector:
           {
             "type": "selector",
@@ -477,13 +487,13 @@ magicnet_singbox_apply_hotspot_policy() {
         def hotspot_rule:
           {
             "inbound": ["tun-in"],
-            "source_ip_cidr": hotspot_sources,
+            "source_ip_cidr": $hotspot_sources,
             "outbound": "hotspot"
           };
         def is_hotspot_rule:
           (.inbound // []) == ["tun-in"]
-            and (.source_ip_cidr // []) == hotspot_sources
-            and (.outbound // "") == "hotspot";
+            and (.outbound // "") == "hotspot"
+            and (.source_ip_cidr | type) == "array";
         .outbounds = (
           ((.outbounds // []) | map(select((.tag // "") != "hotspot")))
           + [hotspot_selector]
@@ -499,16 +509,51 @@ magicnet_singbox_apply_hotspot_policy() {
           ) as $action_anchor
         | (($dns_guard_anchor // $action_anchor // -1) + 1) as $insert_at
         | .route.rules = (
-            $rules[:$insert_at] + [hotspot_rule] + $rules[$insert_at:]
+            if ($hotspot_sources | length) > 0
+            then $rules[:$insert_at] + [hotspot_rule] + $rules[$insert_at:]
+            else $rules
+            end
           )
     ' "$_config" >"$_tmp") && chmod 600 "$_tmp" && mv -f "$_tmp" "$_config" && chmod 600 "$_config"; then
         :
     else
         rm -f "$_tmp" 2>/dev/null || true
-        unset _config _jq _tmp
+        unset _config _jq _hotspot_sources _hotspot_sources_json _tmp
         return 1
     fi
-    unset _config _jq _tmp
+    unset _config _jq _hotspot_sources _hotspot_sources_json _tmp
+}
+
+magicnet_singbox_hotspot_policy_current() {
+    _config="${MODDIR}/.config/sing-box/config.json"
+    [ -f "$_config" ] || return 0
+    _jq="${MODDIR}/bin/jq"
+    [ -x "$_jq" ] || _jq="$(command -v jq 2>/dev/null || true)"
+    [ -n "$_jq" ] || {
+        unset _config _jq
+        return 1
+    }
+    _hotspot_sources="$(magicnet_hotspot_source_cidrs || true)"
+    _hotspot_sources_json="$(printf '%s\n' "$_hotspot_sources" | "$_jq" -Rsc '
+        split("\n") | map(select(length > 0))
+    ')" || {
+        unset _config _jq _hotspot_sources _hotspot_sources_json
+        return 1
+    }
+    "$_jq" -e --argjson hotspot_sources "$_hotspot_sources_json" '
+        [.route.rules[]? | select(
+          (.inbound // []) == ["tun-in"]
+            and (.outbound // "") == "hotspot"
+            and (.source_ip_cidr | type) == "array"
+        )] as $rules
+        | if ($hotspot_sources | length) > 0
+          then ($rules | length) == 1 and $rules[0].source_ip_cidr == $hotspot_sources
+          else ($rules | length) == 0
+          end
+    ' "$_config" >/dev/null 2>&1
+    _hotspot_policy_rc=$?
+    unset _config _jq _hotspot_sources _hotspot_sources_json
+    return "$_hotspot_policy_rc"
 }
 
 magicnet_route_singbox_rules() {

--- a/webui/hotspot-policy.test.mjs
+++ b/webui/hotspot-policy.test.mjs
@@ -24,13 +24,9 @@ assert.match(control, /hotspot \$\{enabled \? "enable" : "disable"\}/);
 assert.match(control, /proxy<\/code> 代理组/);
 assert.match(control, /不勾选时统一走\s*<code>direct<\/code>/);
 
-for (const source of [
-  "10.0.0.0/8",
-  "172.16.0.0/12",
-  "192.168.0.0/16",
-]) {
-  assert.match(routes, new RegExp(source.replaceAll(".", String.raw`\.`)));
-}
+assert.match(routes, /magicnet_hotspot_source_cidrs/);
+assert.match(routes, /magicnet_hotspot_active_networks/);
+assert.doesNotMatch(routes, /\["10\.0\.0\.0\/8", "172\.16\.0\.0\/12", "192\.168\.0\.0\/16"\]/);
 assert.match(routes, /"outbound": "hotspot"/);
 assert.match(routes, /"outbounds": \["direct", "proxy"\]/);
 assert.match(routes, /ip rule add priority/);
@@ -42,6 +38,7 @@ assert.match(routes, /magicnet_hotspot_offload_restore/);
 assert.match(routes, /register_uninstall_cmd/);
 assert.match(control, /关闭 Android 热点硬件加速/);
 assert.match(webuiApi, /"replay"[\s\S]*sync_persisted_hotspot_offload/);
+assert.match(webuiApi, /"reconcile"[\s\S]*magicnet_singbox_hotspot_policy_current/);
 assert.match(
   network,
   /magicnet_after_kernel_start_deferred_unlocked\(\)[\s\S]*magicnet_singbox_apply_hotspot_policy/,


### PR DESCRIPTION
## What changed

- Replace the blanket RFC1918 hotspot source rule with the exact IPv4 subnets discovered on active Android tether interfaces.
- Remove the managed hotspot route when hotspot proxying is disabled or no downstream subnet exists.
- Detect hotspot subnet changes in the watchdog reconcile path and re-apply the runtime configuration only when the in-memory policy is stale.
- Extend hotspot regression coverage for normal Wi-Fi isolation, subnet renumbering, and cleanup.

## Root cause

The managed hotspot rule matched all of `10.0.0.0/8`, `172.16.0.0/12`, and `192.168.0.0/16`. The phone's own Wi-Fi address is normally inside those ranges too. When sing-box could not attribute a WeChat CDN connection to a process or sniffed domain, the early hotspot rule intercepted it before the WeChat media rule and forced `hotspot -> direct`, producing the timeout reported in #109.

## Validation

Passed locally:

- `bash scripts/test-hotspot-routing.sh`
- `bash scripts/test-wechat-routing.sh`
- `bash scripts/test-route-apply-safety.sh`
- `bash scripts/test-singbox-route-apply-safety.sh`
- `bash scripts/test-app-routing-policy.sh`
- `bash scripts/test-policy-architecture.sh`
- `bash scripts/test-action-routing.sh`
- `bash scripts/test-ad-routing.sh`
- `node webui/hotspot-policy.test.mjs`
- `git diff --check`

The local environment does not provide `cargo`, `shellcheck`, or a standalone `sing-box` binary; GitHub Actions should run the complete repository suite.

Fixes #109

## Summary by Sourcery

将热点路由限制在动态发现的共享网络（tether）子网范围内，并保持 sing-box 热点策略与当前下游网络同步，避免将普通私有 Wi‑Fi 流量误判为热点流量。

New Features:
- 添加对活动热点下游 CIDR 的运行时检测，并将其暴露给 sing-box 路由配置使用。
- 引入检查，用于判断当前 sing-box 热点策略是否与活动下游子网匹配。

Bug Fixes:
- 在无法进行进程归属或域名嗅探时，防止普通私有地址的 Wi‑Fi 流量被错误地通过热点路径转发。
- 当热点代理被禁用或不再存在任何下游子网时，确保从 sing-box 中移除热点路由规则。
- 在内存中的热点策略已过期时，通过协调 sing-box 配置，避免将已重新编号的热点子网错误地视为当前子网。

Enhancements:
- 更新 CLI 和 Web UI 中的热点协调行为，仅在 sing-box 热点策略过期时才重新应用配置。
- 简化冒烟测试的预期要求，只需在基础配置中不包含任何热点源规则。
- 扩展热点路由测试范围，覆盖子网检测、重新编号、清理，以及普通 Wi‑Fi 隔离的回归测试。

Documentation:
- 在变更日志中记录热点路由行为的更改，包括仅限制到已发现的共享网络子网。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restrict hotspot routing to dynamically discovered tether subnets and keep sing-box hotspot policy in sync with current downstream networks to avoid misclassifying private Wi-Fi traffic as hotspot.

New Features:
- Add runtime detection of active hotspot downstream CIDRs and expose them for sing-box routing configuration.
- Introduce a check for whether the current sing-box hotspot policy matches the active downstream subnet.

Bug Fixes:
- Prevent ordinary private-address Wi-Fi traffic from being routed through the hotspot path when process attribution or domain sniffing is unavailable.
- Ensure hotspot routing rules are removed from sing-box when hotspot proxying is disabled or no downstream subnet remains.
- Avoid treating a renumbered hotspot subnet as current by reconciling sing-box configuration when the in-memory hotspot policy is stale.

Enhancements:
- Update CLI and web UI hotspot reconcile behavior to reapply configuration only when the sing-box hotspot policy is out of date.
- Simplify smoke-test expectations by requiring no hotspot source rule in the base configuration.
- Expand hotspot routing tests to cover subnet detection, renumbering, cleanup, and regression for normal Wi-Fi isolation.

Documentation:
- Document the hotspot routing behavior change in the changelog, including the restriction to discovered tether subnets.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将热点路由限制在动态发现的共享网络（tether）子网范围内，并保持 sing-box 热点策略与当前下游网络同步，避免将普通私有 Wi‑Fi 流量误判为热点流量。

New Features:
- 添加对活动热点下游 CIDR 的运行时检测，并将其暴露给 sing-box 路由配置使用。
- 引入检查，用于判断当前 sing-box 热点策略是否与活动下游子网匹配。

Bug Fixes:
- 在无法进行进程归属或域名嗅探时，防止普通私有地址的 Wi‑Fi 流量被错误地通过热点路径转发。
- 当热点代理被禁用或不再存在任何下游子网时，确保从 sing-box 中移除热点路由规则。
- 在内存中的热点策略已过期时，通过协调 sing-box 配置，避免将已重新编号的热点子网错误地视为当前子网。

Enhancements:
- 更新 CLI 和 Web UI 中的热点协调行为，仅在 sing-box 热点策略过期时才重新应用配置。
- 简化冒烟测试的预期要求，只需在基础配置中不包含任何热点源规则。
- 扩展热点路由测试范围，覆盖子网检测、重新编号、清理，以及普通 Wi‑Fi 隔离的回归测试。

Documentation:
- 在变更日志中记录热点路由行为的更改，包括仅限制到已发现的共享网络子网。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restrict hotspot routing to dynamically discovered tether subnets and keep sing-box hotspot policy in sync with current downstream networks to avoid misclassifying private Wi-Fi traffic as hotspot.

New Features:
- Add runtime detection of active hotspot downstream CIDRs and expose them for sing-box routing configuration.
- Introduce a check for whether the current sing-box hotspot policy matches the active downstream subnet.

Bug Fixes:
- Prevent ordinary private-address Wi-Fi traffic from being routed through the hotspot path when process attribution or domain sniffing is unavailable.
- Ensure hotspot routing rules are removed from sing-box when hotspot proxying is disabled or no downstream subnet remains.
- Avoid treating a renumbered hotspot subnet as current by reconciling sing-box configuration when the in-memory hotspot policy is stale.

Enhancements:
- Update CLI and web UI hotspot reconcile behavior to reapply configuration only when the sing-box hotspot policy is out of date.
- Simplify smoke-test expectations by requiring no hotspot source rule in the base configuration.
- Expand hotspot routing tests to cover subnet detection, renumbering, cleanup, and regression for normal Wi-Fi isolation.

Documentation:
- Document the hotspot routing behavior change in the changelog, including the restriction to discovered tether subnets.

</details>

</details>