### PR TITLE
refactor: centralize hotspot policy updates

### DIFF
--- a/crates/magicnet-cli/src/webui_api.rs
+++ b/crates/magicnet-cli/src/webui_api.rs
@@ -67,7 +67,23 @@ fn sync_persisted_hotspot_offload(app: &App) {
     } else {
         let _ = run_magicnet_function(app, "magicnet_hotspot_watchdog_stop");
         let _ = run_magicnet_function(app, "magicnet_hotspot_route_cleanup");
+        if let Err(err) = refresh_hotspot_policy_if_stale(app) {
+            eprintln!("[warning] stale hotspot source policy could not be removed: {err}");
+        }
     }
+}
+
+fn refresh_hotspot_policy_if_stale(app: &App) -> Result<(), String> {
+    if run_magicnet_function(app, "magicnet_singbox_hotspot_policy_current").is_err() {
+        apply_config(app)?;
+    }
+    Ok(())
+}
+
+fn rollback_hotspot_enable(app: &App) {
+    let _ = select_proxy(app, "hotspot", "direct");
+    let _ = run_magicnet_function(app, "magicnet_hotspot_offload_restore");
+    let _ = run_magicnet_function(app, "magicnet_hotspot_route_cleanup");
 }
 
 pub(crate) fn hotspot_cmd(app: &App, args: &[String]) -> Result<(), String> {
@@ -83,10 +99,7 @@ pub(crate) fn hotspot_cmd(app: &App, args: &[String]) -> Result<(), String> {
         }
         "reconcile" => {
             run_magicnet_function(app, "magicnet_hotspot_reconcile")?;
-            if run_magicnet_function(app, "magicnet_singbox_hotspot_policy_current").is_err() {
-                apply_config(app)?;
-            }
-            Ok(())
+            refresh_hotspot_policy_if_stale(app)
         }
         "enable" | "disable" => {
             let member = if action == "enable" {
@@ -108,7 +121,7 @@ pub(crate) fn hotspot_cmd(app: &App, args: &[String]) -> Result<(), String> {
             };
             if let Err(error) = selected {
                 if action == "enable" {
-                    let _ = run_magicnet_function(app, "magicnet_hotspot_offload_restore");
+                    rollback_hotspot_enable(app);
                 }
                 return Err(error);
             }
@@ -117,20 +130,15 @@ pub(crate) fn hotspot_cmd(app: &App, args: &[String]) -> Result<(), String> {
                 // Materialize the active downstream subnet and restart only
                 // when the effective runtime fingerprint changed.
                 if let Err(error) = apply_config(app) {
-                    let _ = select_proxy(app, "hotspot", "direct");
-                    let _ = run_magicnet_function(app, "magicnet_hotspot_offload_restore");
+                    rollback_hotspot_enable(app);
                     return Err(format!("apply hotspot TUN policy: {error}"));
                 }
                 if let Err(error) = run_magicnet_function(app, "magicnet_hotspot_reconcile") {
-                    let _ = select_proxy(app, "hotspot", "direct");
-                    let _ = run_magicnet_function(app, "magicnet_hotspot_offload_restore");
-                    let _ = run_magicnet_function(app, "magicnet_hotspot_route_cleanup");
+                    rollback_hotspot_enable(app);
                     return Err(format!("apply hotspot TUN route: {error}"));
                 }
                 if let Err(error) = run_magicnet_function(app, "magicnet_hotspot_watchdog_start") {
-                    let _ = select_proxy(app, "hotspot", "direct");
-                    let _ = run_magicnet_function(app, "magicnet_hotspot_offload_restore");
-                    let _ = run_magicnet_function(app, "magicnet_hotspot_route_cleanup");
+                    rollback_hotspot_enable(app);
                     return Err(format!("start hotspot route watcher: {error}"));
                 }
             }
@@ -140,6 +148,7 @@ pub(crate) fn hotspot_cmd(app: &App, args: &[String]) -> Result<(), String> {
                 let cleanup_result = run_magicnet_function(app, "magicnet_hotspot_route_cleanup");
                 stop_result?;
                 cleanup_result?;
+                refresh_hotspot_policy_if_stale(app)?;
             }
             Ok(())
         }

--- a/scripts/test-hotspot-routing.sh
+++ b/scripts/test-hotspot-routing.sh
@@ -11,6 +11,8 @@ mkdir -p "$MODDIR/.state/hotspot" "$MODDIR/.config/sing-box"
 printf '%s\n' '21000: from all iif wlan2 lookup wlan0' >"$RULES"
 printf '%s\n' 'value=0' >"$MODDIR/.state/hotspot/tether-offload.previous"
 HOTSPOT_CIDR=10.199.43.0/24
+HOTSPOT_SECONDARY_CIDR=
+HOTSPOT_INTERFACE_ORDER=primary-first
 cat >"$MODDIR/.config/sing-box/config.json" <<'EOF'
 {
   "outbounds": [
@@ -19,7 +21,13 @@ cat >"$MODDIR/.config/sing-box/config.json" <<'EOF'
   "route": {
     "rules": [
       {"inbound": ["mixed-in", "tun-in"], "action": "sniff"},
-      {"domain_suffix": ["qq.com"], "outbound": "cn-direct"}
+      {"domain_suffix": ["qq.com"], "outbound": "cn-direct"},
+      {
+        "inbound": ["tun-in"],
+        "source_ip_cidr": ["198.51.100.0/24"],
+        "network": "tcp",
+        "outbound": "hotspot"
+      }
     ]
   }
 }
@@ -33,7 +41,7 @@ magicnet_cmd_exists() {
 }
 
 magicnet_iface_exists() {
-  [ "$1" = magicnet0 ] || [ "$1" = wlan2 ]
+  [ "$1" = magicnet0 ] || [ "$1" = wlan2 ] || [ "$1" = usb0 ]
 }
 
 magicnet_warn() {
@@ -42,7 +50,15 @@ magicnet_warn() {
 
 dumpsys() {
   [ "${1:-}" = tethering ] || return 1
-  printf '%s\n' 'wlan2 - TetheredState - lastError = 0'
+  if [ -n "$HOTSPOT_SECONDARY_CIDR" ] && [ "$HOTSPOT_INTERFACE_ORDER" = secondary-first ]; then
+    printf '%s\n' \
+      'usb0 - TetheredState - lastError = 0' \
+      'wlan2 - TetheredState - lastError = 0'
+  else
+    printf '%s\n' 'wlan2 - TetheredState - lastError = 0'
+    [ -z "$HOTSPOT_SECONDARY_CIDR" ] ||
+      printf '%s\n' 'usb0 - TetheredState - lastError = 0'
+  fi
 }
 
 settings() {
@@ -63,6 +79,13 @@ ip() {
     [ "${3:-}" = dev ] && [ "${4:-}" = wlan2 ] &&
     [ "${5:-}" = scope ] && [ "${6:-}" = link ]; then
     printf '%s proto kernel scope link src 10.199.43.11\n' "$HOTSPOT_CIDR"
+    return 0
+  fi
+  if [ "${1:-}" = route ] && [ "${2:-}" = show ] &&
+    [ "${3:-}" = dev ] && [ "${4:-}" = usb0 ] &&
+    [ "${5:-}" = scope ] && [ "${6:-}" = link ]; then
+    [ -z "$HOTSPOT_SECONDARY_CIDR" ] ||
+      printf '%s proto kernel scope link src 10.88.0.1\n' "$HOTSPOT_SECONDARY_CIDR"
     return 0
   fi
   if [ "${1:-}" = rule ] && [ "${2:-}" = show ]; then
@@ -92,6 +115,7 @@ magicnet_singbox_apply_hotspot_policy
 jq -e '
   [.route.rules[] | select(
     .inbound == ["tun-in"] and .outbound == "hotspot"
+      and ((has("network") | not))
   )] == [{
     "inbound": ["tun-in"],
     "source_ip_cidr": ["10.199.43.0/24"],
@@ -99,6 +123,14 @@ jq -e '
   }]
 ' "$MODDIR/.config/sing-box/config.json" >/dev/null
 magicnet_singbox_hotspot_policy_current
+jq -e '
+  [.route.rules[] | select(
+    .inbound == ["tun-in"]
+      and .source_ip_cidr == ["198.51.100.0/24"]
+      and .network == "tcp"
+      and .outbound == "hotspot"
+  )] | length == 1
+' "$MODDIR/.config/sing-box/config.json" >/dev/null
 if jq -e '
   [.route.rules[] | select(
     .outbound == "hotspot"
@@ -109,6 +141,7 @@ if jq -e '
   exit 1
 fi
 HOTSPOT_CIDR=192.168.52.0/24
+HOTSPOT_SECONDARY_CIDR=10.88.0.0/24
 if magicnet_singbox_hotspot_policy_current; then
   printf '%s\n' 'renumbered hotspot subnet was incorrectly treated as current' >&2
   exit 1
@@ -117,9 +150,13 @@ magicnet_singbox_apply_hotspot_policy
 jq -e '
   [.route.rules[] | select(
     .inbound == ["tun-in"] and .outbound == "hotspot"
-  )][0].source_ip_cidr == ["192.168.52.0/24"]
+      and ((has("network") | not))
+  )][0].source_ip_cidr == ["10.88.0.0/24", "192.168.52.0/24"]
 ' "$MODDIR/.config/sing-box/config.json" >/dev/null
 magicnet_singbox_hotspot_policy_current
+HOTSPOT_INTERFACE_ORDER=secondary-first
+magicnet_singbox_hotspot_policy_current
+HOTSPOT_SECONDARY_CIDR=
 
 magicnet_hotspot_reconcile
 grep -Fqx '20999|wlan2' "$MODDIR/.state/hotspot/tun-rules.list"
@@ -143,7 +180,16 @@ magicnet_singbox_apply_hotspot_policy
 jq -e '
   [.route.rules[] | select(
     .inbound == ["tun-in"] and .outbound == "hotspot"
+      and ((has("network") | not))
   )] | length == 0
+' "$MODDIR/.config/sing-box/config.json" >/dev/null
+jq -e '
+  [.route.rules[] | select(
+    .inbound == ["tun-in"]
+      and .source_ip_cidr == ["198.51.100.0/24"]
+      and .network == "tcp"
+      and .outbound == "hotspot"
+  )] | length == 1
 ' "$MODDIR/.config/sing-box/config.json" >/dev/null
 magicnet_singbox_hotspot_policy_current
 

--- a/src/MagicNet/lib/magicnet/routes.sh
+++ b/src/MagicNet/lib/magicnet/routes.sh
@@ -37,7 +37,27 @@ magicnet_hotspot_proxy_enabled() {
 
 magicnet_hotspot_source_cidrs() {
     magicnet_hotspot_proxy_enabled || return 0
-    magicnet_hotspot_active_networks | awk -F'|' 'NF == 2 && !seen[$2]++ { print $2 }'
+    magicnet_hotspot_active_networks |
+        awk -F'|' 'NF == 2 { print $2 }' |
+        LC_ALL=C sort -u
+}
+
+magicnet_hotspot_jq() {
+    if [ -x "${MODDIR}/bin/jq" ]; then
+        printf '%s\n' "${MODDIR}/bin/jq"
+    else
+        command -v jq 2>/dev/null || true
+    fi
+}
+
+magicnet_hotspot_source_cidrs_json() {
+    _hotspot_json_jq="$1"
+    magicnet_hotspot_source_cidrs | "$_hotspot_json_jq" -Rsc '
+        split("\n") | map(select(length > 0))
+    '
+    _hotspot_json_rc=$?
+    unset _hotspot_json_jq
+    return "$_hotspot_json_rc"
 }
 
 magicnet_hotspot_interface_allowed() {
@@ -454,24 +474,19 @@ magicnet_hotspot_offload_status() {
     unset _hotspot_value
 }
 
-magicnet_singbox_apply_hotspot_policy() {
-    _config="${MODDIR}/.config/sing-box/config.json"
-    [ -f "$_config" ] || return 0
-    _jq="${MODDIR}/bin/jq"
-    [ -x "$_jq" ] || _jq="$(command -v jq 2>/dev/null || true)"
+magicnet_singbox_render_hotspot_policy() {
+    _hotspot_render_source="$1"
+    _hotspot_render_target="$2"
+    _jq="$(magicnet_hotspot_jq)"
     [ -n "$_jq" ] || {
         magicnet_warn "jq not found; cannot apply hotspot proxy policy"
-        unset _config _jq
+        unset _hotspot_render_source _hotspot_render_target _jq
         return 1
     }
-    _hotspot_sources="$(magicnet_hotspot_source_cidrs || true)"
-    _hotspot_sources_json="$(printf '%s\n' "$_hotspot_sources" | "$_jq" -Rsc '
-        split("\n") | map(select(length > 0))
-    ')" || {
-        unset _config _jq _hotspot_sources _hotspot_sources_json
+    _hotspot_sources_json="$(magicnet_hotspot_source_cidrs_json "$_jq")" || {
+        unset _hotspot_render_source _hotspot_render_target _jq _hotspot_sources_json
         return 1
     }
-    _tmp="${_config}.hotspot-policy.new"
     # Forwarded clients retain an address from the active downstream subnet
     # when entering the TUN. Match only those discovered subnets: matching all
     # RFC1918 space also catches the phone's own Wi-Fi traffic whenever process
@@ -490,69 +505,75 @@ magicnet_singbox_apply_hotspot_policy() {
             "source_ip_cidr": $hotspot_sources,
             "outbound": "hotspot"
           };
-        def is_hotspot_rule:
-          (.inbound // []) == ["tun-in"]
+        def is_managed_hotspot_rule:
+          type == "object"
+            and (keys | sort) == ["inbound", "outbound", "source_ip_cidr"]
+            and (.inbound // []) == ["tun-in"]
             and (.outbound // "") == "hotspot"
             and (.source_ip_cidr | type) == "array";
+        def insertion_index($rules):
+          (
+            [$rules | to_entries[] | select((.value.outbound // "") == "dns-guard") | .key]
+            | last
+          ) as $dns_guard_anchor
+          | (
+              [$rules | to_entries[] | select(.value.action != null) | .key]
+              | last
+            ) as $action_anchor
+          | (($dns_guard_anchor // $action_anchor // -1) + 1);
         .outbounds = (
           ((.outbounds // []) | map(select((.tag // "") != "hotspot")))
           + [hotspot_selector]
         )
-        | ((.route.rules // []) | map(select(is_hotspot_rule | not))) as $rules
+        | (.route.rules // []) as $original_rules
+        | insertion_index($original_rules) as $managed_index
         | (
-            [$rules | to_entries[] | select((.value.outbound // "") == "dns-guard") | .key]
-            | last
-          ) as $dns_guard_anchor
-        | (
-            [$rules | to_entries[] | select(.value.action != null) | .key]
-            | last
-          ) as $action_anchor
-        | (($dns_guard_anchor // $action_anchor // -1) + 1) as $insert_at
+            if (($original_rules[$managed_index] // {}) | is_managed_hotspot_rule)
+            then $original_rules[:$managed_index] + $original_rules[($managed_index + 1):]
+            else $original_rules
+            end
+          ) as $rules
+        | insertion_index($rules) as $insert_at
         | .route.rules = (
             if ($hotspot_sources | length) > 0
             then $rules[:$insert_at] + [hotspot_rule] + $rules[$insert_at:]
             else $rules
             end
           )
-    ' "$_config" >"$_tmp") && chmod 600 "$_tmp" && mv -f "$_tmp" "$_config" && chmod 600 "$_config"; then
-        :
+    ' "$_hotspot_render_source" >"$_hotspot_render_target") && chmod 600 "$_hotspot_render_target"; then
+        _hotspot_render_rc=0
     else
+        rm -f "$_hotspot_render_target" 2>/dev/null || true
+        _hotspot_render_rc=1
+    fi
+    unset _hotspot_render_source _hotspot_render_target _jq _hotspot_sources_json
+    return "$_hotspot_render_rc"
+}
+
+magicnet_singbox_apply_hotspot_policy() {
+    _config="${MODDIR}/.config/sing-box/config.json"
+    [ -f "$_config" ] || return 0
+    _tmp="${_config}.hotspot-policy.new"
+    if ! magicnet_singbox_render_hotspot_policy "$_config" "$_tmp" ||
+        ! mv -f "$_tmp" "$_config" || ! chmod 600 "$_config"; then
         rm -f "$_tmp" 2>/dev/null || true
-        unset _config _jq _hotspot_sources _hotspot_sources_json _tmp
+        unset _config _tmp
         return 1
     fi
-    unset _config _jq _hotspot_sources _hotspot_sources_json _tmp
+    unset _config _tmp
 }
 
 magicnet_singbox_hotspot_policy_current() {
     _config="${MODDIR}/.config/sing-box/config.json"
     [ -f "$_config" ] || return 0
-    _jq="${MODDIR}/bin/jq"
-    [ -x "$_jq" ] || _jq="$(command -v jq 2>/dev/null || true)"
-    [ -n "$_jq" ] || {
-        unset _config _jq
-        return 1
-    }
-    _hotspot_sources="$(magicnet_hotspot_source_cidrs || true)"
-    _hotspot_sources_json="$(printf '%s\n' "$_hotspot_sources" | "$_jq" -Rsc '
-        split("\n") | map(select(length > 0))
-    ')" || {
-        unset _config _jq _hotspot_sources _hotspot_sources_json
-        return 1
-    }
-    "$_jq" -e --argjson hotspot_sources "$_hotspot_sources_json" '
-        [.route.rules[]? | select(
-          (.inbound // []) == ["tun-in"]
-            and (.outbound // "") == "hotspot"
-            and (.source_ip_cidr | type) == "array"
-        )] as $rules
-        | if ($hotspot_sources | length) > 0
-          then ($rules | length) == 1 and $rules[0].source_ip_cidr == $hotspot_sources
-          else ($rules | length) == 0
-          end
-    ' "$_config" >/dev/null 2>&1
-    _hotspot_policy_rc=$?
-    unset _config _jq _hotspot_sources _hotspot_sources_json
+    _tmp="${_config}.hotspot-policy.check.$$"
+    if magicnet_singbox_render_hotspot_policy "$_config" "$_tmp" && cmp -s "$_config" "$_tmp"; then
+        _hotspot_policy_rc=0
+    else
+        _hotspot_policy_rc=1
+    fi
+    rm -f "$_tmp" 2>/dev/null || true
+    unset _config _tmp
     return "$_hotspot_policy_rc"
 }
 

--- a/webui/hotspot-policy.test.mjs
+++ b/webui/hotspot-policy.test.mjs
@@ -25,6 +25,7 @@ assert.match(control, /proxy<\/code> 代理组/);
 assert.match(control, /不勾选时统一走\s*<code>direct<\/code>/);
 
 assert.match(routes, /magicnet_hotspot_source_cidrs/);
+assert.match(routes, /magicnet_hotspot_source_cidrs_json/);
 assert.match(routes, /magicnet_hotspot_active_networks/);
 assert.doesNotMatch(routes, /\["10\.0\.0\.0\/8", "172\.16\.0\.0\/12", "192\.168\.0\.0\/16"\]/);
 assert.match(routes, /"outbound": "hotspot"/);
@@ -38,7 +39,9 @@ assert.match(routes, /magicnet_hotspot_offload_restore/);
 assert.match(routes, /register_uninstall_cmd/);
 assert.match(control, /关闭 Android 热点硬件加速/);
 assert.match(webuiApi, /"replay"[\s\S]*sync_persisted_hotspot_offload/);
-assert.match(webuiApi, /"reconcile"[\s\S]*magicnet_singbox_hotspot_policy_current/);
+assert.match(webuiApi, /"reconcile"[\s\S]*refresh_hotspot_policy_if_stale/);
+assert.match(webuiApi, /"disable"[\s\S]*refresh_hotspot_policy_if_stale/);
+assert.match(webuiApi, /rollback_hotspot_enable/);
 assert.match(
   network,
   /magicnet_after_kernel_start_deferred_unlocked\(\)[\s\S]*magicnet_singbox_apply_hotspot_policy/,


### PR DESCRIPTION
## Summary

Follow-up hardening for #110 and #109.

- centralize hotspot CIDR serialization and sing-box policy rendering so apply/current checks share one implementation
- sort and deduplicate discovered downstream CIDRs to avoid needless restarts when interface discovery order changes
- replace only the generated rule at the managed insertion point, preserving user-defined hotspot rules
- refresh the running sing-box config immediately when hotspot proxying is disabled
- centralize enable rollback cleanup and extend routing regression coverage

## Test plan

- `bash scripts/test-hotspot-routing.sh`
- `node webui/hotspot-policy.test.mjs`
- `bash scripts/test-wechat-routing.sh`
- `bash scripts/test-route-apply-safety.sh`
- `bash scripts/test-singbox-route-apply-safety.sh`
- `bash scripts/test-app-routing-policy.sh`
- `bash scripts/test-policy-architecture.sh`
- `bash scripts/test-action-routing.sh`
- `bash scripts/test-ad-routing.sh`
- `git diff --check`

The full Kam build/package smoke test is delegated to GitHub Actions because the local runner does not provide Cargo.

## Summary by Sourcery

集中管理热点 CIDR 序列化和 sing-box 热点策略渲染，使 apply 和 current 检查共享统一的实现，并在路由和 CLI 流程中稳定策略行为。

Enhancements:
- 对发现的热点下游 CIDR 进行排序和去重，以在不依赖接口发现顺序的前提下生成稳定的路由指纹。
- 优化 sing-box 热点策略管理，仅在插入点替换受管规则，同时保留用户自定义的热点规则和选择锚点。
- 引入共享的 jq 发现和热点 CIDR JSON 序列化辅助工具，在策略应用和当前状态检查中复用。
- 添加 Rust 辅助函数，用于刷新过期的热点策略，并在 CLI 工作流中集中处理热点启用回滚的清理工作。
- 调整热点路由逻辑，通过比较渲染后的配置而非定制的 jq 断言来对齐 apply 和 current 检查。

Tests:
- 扩展热点路由的 shell 测试，以覆盖多个下游接口、确定性的规则排序，以及在 sing-box 中保留自定义热点规则。
- 更新 WebUI 热点策略测试，以验证新的 CIDR 序列化辅助工具、刷新后的路由行为，以及用于 reconcile/disable 流程的 CLI 辅助函数的接线情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize hotspot CIDR serialization and sing-box hotspot policy rendering so that apply and current checks share a single implementation, and stabilize policy behavior across routing and CLI flows.

Enhancements:
- Sort and deduplicate discovered hotspot downstream CIDRs to produce a stable routing fingerprint regardless of interface discovery order.
- Refine sing-box hotspot policy management to only replace the managed rule at the insertion point while preserving user-defined hotspot rules and selection anchors.
- Introduce shared helpers for jq discovery and hotspot CIDR JSON serialization reused by both policy application and current-state checks.
- Add Rust helpers to refresh stale hotspot policies and centralize hotspot enable rollback cleanup in the CLI workflow.
- Adjust hotspot routing logic to compare rendered configurations rather than bespoke jq predicates, aligning apply and current checks.

Tests:
- Expand hotspot routing shell tests to cover multiple downstream interfaces, deterministic rule ordering, and preservation of custom hotspot rules in sing-box.
- Update WebUI hotspot policy tests to validate the new CIDR serialization helper, refreshed routing behavior, and CLI helper wiring for reconcile/disable flows.

</details>

增强点：
- 对发现的热点下游 CIDR 进行排序和去重，以在接口发现顺序变化时稳定路由指纹。
- 确保在 sing-box 中插入热点规则时，仅替换锚点处的受管热点规则，同时保留用户自定义的热点规则。
- 添加辅助工具以定位 jq，并在配置应用和当前策略检查中复用共享的热点 CIDR JSON 序列化逻辑。
- 引入 Rust 辅助方法，用于在热点策略过期时进行刷新，并在 CLI 中集中处理热点启用回滚的清理逻辑。
- 调整热点路由测试，以覆盖多个下游接口、稳定的规则排序，以及在 sing-box 中保留自定义热点规则。
- 扩展 WebUI 测试，以验证新的热点策略辅助方法以及更新后的路由行为链路。

测试：
- 更新热点路由和 WebUI 热点策略测试，用于检验新的集中化策略渲染、回滚行为以及多接口 CIDR 处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

集中管理热点 CIDR 序列化和 sing-box 热点策略渲染，使 apply 和 current 检查共享统一的实现，并在路由和 CLI 流程中稳定策略行为。

Enhancements:
- 对发现的热点下游 CIDR 进行排序和去重，以在不依赖接口发现顺序的前提下生成稳定的路由指纹。
- 优化 sing-box 热点策略管理，仅在插入点替换受管规则，同时保留用户自定义的热点规则和选择锚点。
- 引入共享的 jq 发现和热点 CIDR JSON 序列化辅助工具，在策略应用和当前状态检查中复用。
- 添加 Rust 辅助函数，用于刷新过期的热点策略，并在 CLI 工作流中集中处理热点启用回滚的清理工作。
- 调整热点路由逻辑，通过比较渲染后的配置而非定制的 jq 断言来对齐 apply 和 current 检查。

Tests:
- 扩展热点路由的 shell 测试，以覆盖多个下游接口、确定性的规则排序，以及在 sing-box 中保留自定义热点规则。
- 更新 WebUI 热点策略测试，以验证新的 CIDR 序列化辅助工具、刷新后的路由行为，以及用于 reconcile/disable 流程的 CLI 辅助函数的接线情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize hotspot CIDR serialization and sing-box hotspot policy rendering so that apply and current checks share a single implementation, and stabilize policy behavior across routing and CLI flows.

Enhancements:
- Sort and deduplicate discovered hotspot downstream CIDRs to produce a stable routing fingerprint regardless of interface discovery order.
- Refine sing-box hotspot policy management to only replace the managed rule at the insertion point while preserving user-defined hotspot rules and selection anchors.
- Introduce shared helpers for jq discovery and hotspot CIDR JSON serialization reused by both policy application and current-state checks.
- Add Rust helpers to refresh stale hotspot policies and centralize hotspot enable rollback cleanup in the CLI workflow.
- Adjust hotspot routing logic to compare rendered configurations rather than bespoke jq predicates, aligning apply and current checks.

Tests:
- Expand hotspot routing shell tests to cover multiple downstream interfaces, deterministic rule ordering, and preservation of custom hotspot rules in sing-box.
- Update WebUI hotspot policy tests to validate the new CIDR serialization helper, refreshed routing behavior, and CLI helper wiring for reconcile/disable flows.

</details>

</details>