### PR TITLE
fix: restore X comment routing in synced configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fix #115 by aligning config-editor template sync with the packaged MagicSingBox routing baseline, removing the stale FakeIP blackhole and restoring early X domain ownership.
 - Select a reachable AliDNS HTTPS bootstrap across IPv4 and IPv6 to reduce DNS timeouts during proxy-node resolution.
 - Resolve WeChat and Tencent media domains with local DNS and route them directly so image CDN requests keep regional affinity and avoid slow proxy fallthrough.
 - Restrict hotspot routing to discovered tether subnets so ordinary private-address Wi-Fi traffic cannot bypass app and domain routing rules.

--- a/crates/magicnet-cli/src/config_editor.rs
+++ b/crates/magicnet-cli/src/config_editor.rs
@@ -20,9 +20,9 @@ use crate::{decode_base64, write_secret_file, write_text_file, App};
 const VALIDATOR_TIMEOUT: Duration = Duration::from_secs(20);
 const TEMPLATE_FETCH_TIMEOUT: Duration = Duration::from_secs(45);
 const TEMPLATE_MAX_BYTES: usize = 1024 * 1024;
-const MAGIC_SINGBOX_TEMPLATE_URL: &str = "https://raw.githubusercontent.com/LIghtJUNction/MagicSingBox/9f6dc75833ee435c7f15ee4cd5ba273af1d4022e/config.json";
+const MAGIC_SINGBOX_TEMPLATE_URL: &str = "https://raw.githubusercontent.com/LIghtJUNction/MagicSingBox/9d354b0717636271eaa4bb1a3cbe5bb93cafd8f5/config.json";
 const MAGIC_SINGBOX_TEMPLATE_SHA256: &str =
-    "5f7d822c66159fb126fa4187083000367946e2dcc9c5290b19059712c9f54500";
+    "8e91177e9222b2e5dee91ec849716757601156a28e7a056e6091ab5c71e102a5";
 const STANDALONE_CONFIG_MARKER: &str = ".config/sing-box/standalone-config";
 const TAILSCALE_AUTH_PATH: &str = ".config/sing-box/tailscale-auth.json";
 static CONFIG_EDITOR_STAGE_SEQUENCE: AtomicUsize = AtomicUsize::new(0);

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -35,6 +35,7 @@ shellcheck -s sh -e SC1091,SC1090,SC2329,SC2059 "${posix_shell_files[@]}"
 
 jq empty src/MagicNet/.config/sing-box/config.json
 bash scripts/test-repository-hygiene.sh
+bash scripts/test-config-template-pin.sh
 sh scripts/test-kamfw-i18n.sh
 bash scripts/test-default-routing-policy.sh
 bash scripts/test-policy-architecture.sh

--- a/scripts/test-config-template-pin.sh
+++ b/scripts/test-config-template-pin.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG_DIR="$ROOT/src/MagicNet/.config/sing-box"
+EDITOR="$ROOT/crates/magicnet-cli/src/config_editor.rs"
+
+fail() {
+    printf 'config template pin test failed: %s\n' "$*" >&2
+    exit 1
+}
+
+[[ -f "$CONFIG_DIR/config.json" ]] || fail "MagicSingBox submodule is not initialized"
+
+submodule_revision=$(git -C "$CONFIG_DIR" rev-parse HEAD)
+pinned_revision=$(sed -n 's#.*MagicSingBox/\([0-9a-f]\{40\}\)/config\.json.*#\1#p' "$EDITOR")
+[[ "$pinned_revision" == "$submodule_revision" ]] ||
+    fail "runtime template revision $pinned_revision differs from submodule $submodule_revision"
+
+pinned_sha256=$(sed -n '/MAGIC_SINGBOX_TEMPLATE_SHA256/{n;s/.*"\([0-9a-f]\{64\}\)".*/\1/p;}' "$EDITOR")
+config_sha256=$(sha256sum "$CONFIG_DIR/config.json" | awk '{print $1}')
+[[ "$pinned_sha256" == "$config_sha256" ]] ||
+    fail "runtime template checksum $pinned_sha256 differs from packaged config $config_sha256"
+
+printf 'Config template pin test passed\n'


### PR DESCRIPTION
## What changed

- update the config editor's immutable MagicSingBox template pin to the same revision packaged by MagicNet
- update the verified SHA-256 for that template
- add a regression check that fails when the runtime pin drifts from the MagicSingBox submodule
- document the fix in the changelog

## Root cause

The packaged MagicSingBox submodule already removed the stale FakeIP blackhole and moved X domain ownership ahead of CN IP classification, but `config-editor sync-template` was still pinned to an older template. Syncing or repairing a config could therefore restore the unsafe routing order. X requests without reliable Android package attribution could be blocked or sent direct, which matches the failures reported in #115.

## Impact

Template sync now keeps the current subscription-facing outbounds/endpoints while applying the same safe X routing baseline as new installations.

## Validation

- `bash scripts/test-config-template-pin.sh`
- `bash scripts/test-repository-hygiene.sh`
- `bash scripts/test-policy-architecture.sh`
- `bash scripts/test-wechat-routing.sh`
- `bash scripts/test-transparent-mode-config-safety.sh`
- `bash scripts/test-action-routing.sh`
- `git diff --check`
- downloaded the pinned template and verified SHA-256 `8e91177e9222b2e5dee91ec849716757601156a28e7a056e6091ab5c71e102a5`

Full Cargo validation was unavailable in the current environment because `cargo` is not installed. The full default routing test also requires generated `.srs` rule assets that are produced by the build hooks.

Closes #115

## 由 Sourcery 生成的摘要

对配置编辑器中固定的 MagicSingBox 模板进行对齐，使其与打包的路由基线保持一致，以修复过期的 X 域名路由，并确保同步配置使用安全的模板。

Bug 修复：
- 确保同步的配置使用更新后的 MagicSingBox 模板，该模板移除了过期的 FakeIP 黑洞，并恢复了正确的 X 域名路由顺序。

增强优化：
- 新增回归检查脚本，用于验证配置编辑器中固定的 MagicSingBox 模板版本和 SHA-256 校验和是否与打包的子模块一致。
- 将配置模板固定检测集成进 pre-commit 工作流，以便及早发现运行时固定版本与打包模板之间的偏差。

文档：
- 在变更日志中记录 X 路由基线修复和 FakeIP 黑洞移除的相关说明。

测试：
- 新增专门的配置模板固定测试，用于校验固定的 MagicSingBox 版本及其校验和是否与打包的配置一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align the config editor’s pinned MagicSingBox template with the packaged routing baseline to fix outdated X domain routing and ensure synced configs use the safe template.

Bug Fixes:
- Ensure synced configs use the updated MagicSingBox template that removes the stale FakeIP blackhole and restores correct X domain routing order.

Enhancements:
- Add a regression check script that verifies the config editor’s pinned MagicSingBox template revision and SHA-256 checksum match the packaged submodule.
- Integrate the config template pin test into the pre-commit workflow to catch drift between the runtime pin and bundled template early.

Documentation:
- Document the X routing baseline fix and FakeIP blackhole removal in the changelog.

Tests:
- Introduce a dedicated config template pin test that validates the pinned MagicSingBox revision and checksum against the packaged config.

</details>

Bug 修复：
- 确保已同步的配置使用更新后的 MagicSingBox 模板，该模板移除了过时的 FakeIP 黑洞，并恢复了正确的 X 域名路由顺序。

改进：
- 添加回归测试脚本，用于验证配置编辑器中固定的 MagicSingBox 模板版本及校验和是否与打包的子模块匹配。
- 将配置模板固定性测试集成到 pre-commit 工作流中，以在早期发现运行时固定版本与捆绑模板之间的漂移。

文档：
- 在更新日志中记录 X 域名路由基线修复以及移除 FakeIP 黑洞的变更。

测试：
- 引入专门的配置模板固定性测试，以验证已固定的 MagicSingBox 版本和 SHA-256 是否与打包的配置一致。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 生成的摘要

对配置编辑器中固定的 MagicSingBox 模板进行对齐，使其与打包的路由基线保持一致，以修复过期的 X 域名路由，并确保同步配置使用安全的模板。

Bug 修复：
- 确保同步的配置使用更新后的 MagicSingBox 模板，该模板移除了过期的 FakeIP 黑洞，并恢复了正确的 X 域名路由顺序。

增强优化：
- 新增回归检查脚本，用于验证配置编辑器中固定的 MagicSingBox 模板版本和 SHA-256 校验和是否与打包的子模块一致。
- 将配置模板固定检测集成进 pre-commit 工作流，以便及早发现运行时固定版本与打包模板之间的偏差。

文档：
- 在变更日志中记录 X 路由基线修复和 FakeIP 黑洞移除的相关说明。

测试：
- 新增专门的配置模板固定测试，用于校验固定的 MagicSingBox 版本及其校验和是否与打包的配置一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align the config editor’s pinned MagicSingBox template with the packaged routing baseline to fix outdated X domain routing and ensure synced configs use the safe template.

Bug Fixes:
- Ensure synced configs use the updated MagicSingBox template that removes the stale FakeIP blackhole and restores correct X domain routing order.

Enhancements:
- Add a regression check script that verifies the config editor’s pinned MagicSingBox template revision and SHA-256 checksum match the packaged submodule.
- Integrate the config template pin test into the pre-commit workflow to catch drift between the runtime pin and bundled template early.

Documentation:
- Document the X routing baseline fix and FakeIP blackhole removal in the changelog.

Tests:
- Introduce a dedicated config template pin test that validates the pinned MagicSingBox revision and checksum against the packaged config.

</details>

</details>