### PR TITLE
fix: update nanoid to 3.3.18

### DIFF
--- a/webui/bun.lock
+++ b/webui/bun.lock
@@ -24,7 +24,7 @@
     },
   },
   "overrides": {
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "postcss": "8.5.23",
   },
   "packages": {
@@ -224,7 +224,7 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
-    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 

--- a/webui/dependency-security.test.mjs
+++ b/webui/dependency-security.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-const minimum = [3, 3, 17];
+const minimum = [3, 3, 18];
 const atLeast = (version, expected) => {
   const actual = version.split(".").map((part) => Number.parseInt(part, 10));
   return actual.some((part, index) => part !== expected[index])
@@ -13,7 +13,7 @@ const atLeast = (version, expected) => {
 };
 
 const packageJson = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8"));
-assert.equal(packageJson.overrides?.nanoid, "3.3.17");
+assert.equal(packageJson.overrides?.nanoid, "3.3.18");
 
 const packageLock = JSON.parse(
   readFileSync(new URL("./package-lock.json", import.meta.url), "utf8"),
@@ -27,7 +27,7 @@ for (const [path, metadata] of nanoidPackages) {
 }
 
 const bunLock = readFileSync(new URL("./bun.lock", import.meta.url), "utf8");
-assert.match(bunLock, /"nanoid": "3\.3\.17"/);
-assert.match(bunLock, /"nanoid": \["nanoid@3\.3\.17"/);
+assert.match(bunLock, /"nanoid": "3\.3\.18"/);
+assert.match(bunLock, /"nanoid": \["nanoid@3\.3\.18"/);
 
 console.log("dependency security tests passed");

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1514,9 +1514,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/webui/package.json
+++ b/webui/package.json
@@ -29,6 +29,6 @@
   },
   "overrides": {
     "postcss": "8.5.23",
-    "nanoid": "3.3.17"
+    "nanoid": "3.3.18"
   }
 }


### PR DESCRIPTION
## Summary

- update the WebUI `nanoid` override from 3.3.17 to 3.3.18
- refresh npm and Bun lockfiles with the patched release and integrity hash
- raise the dependency security regression test floor to 3.3.18

## Root cause

`nanoid` versions below 3.3.18 are affected by CVE-2026-67213 / GHSA-2v37-7h3g-55p8. Passing an attacker-controlled size of zero to `customAlphabet` or `customRandom` can cause an infinite loop and denial of service. The WebUI override pinned the transitive PostCSS dependency to 3.3.17.

## Impact

The dependency graph now resolves the patched 3.x release while preserving the existing PostCSS and WebUI dependency structure.

## Validation

- dependency manifests parse successfully
- npm lockfile resolves `node_modules/postcss/node_modules/nanoid` to 3.3.18 with the published integrity hash
- Bun lockfile override and package resolution both point to 3.3.18
- dependency security regression test raises the minimum safe version to 3.3.18
- Validate Kam Module: passed
- Build Kam Module and artifact smoke checks: passed

## Summary by Sourcery

将 WebUI 的 nanoid 覆盖版本更新到已打补丁的 3.3.18 版本，并相应调整依赖检查和锁定文件。

Bug Fixes:
- 在依赖安全测试中将允许的 nanoid 最低版本提升到 3.3.18，以解决已报告的安全漏洞。

Enhancements:
- 更新 WebUI 的包覆盖配置和锁定文件预期，使 npm 和 Bun 都将 nanoid 解析为 3.3.18 版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the WebUI nanoid override to the patched 3.3.18 release and align dependency checks and lockfiles accordingly.

Bug Fixes:
- Raise the minimum allowed nanoid version in dependency security tests to 3.3.18 to address the reported vulnerability.

Enhancements:
- Update the WebUI package override and lockfile expectations so npm and Bun resolve nanoid to version 3.3.18.

</details>