### PR TITLE
Fix interrupted subscription update recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fix #119 by propagating CLI parent death to privileged workers, preserving subscription rollback traps, bounding status lock recovery, and reconciling interrupted transactions during startup.
 - Fix #115 by aligning config-editor template sync with the packaged MagicSingBox routing baseline, removing the stale FakeIP blackhole and restoring early X domain ownership.
 - Select a reachable AliDNS HTTPS bootstrap across IPv4 and IPv6 to reduce DNS timeouts during proxy-node resolution.
 - Resolve WeChat and Tencent media domains with local DNS and route them directly so image CDN requests keep regional affinity and avoid slow proxy fallthrough.

--- a/crates/magicnet-cli/src/main.rs
+++ b/crates/magicnet-cli/src/main.rs
@@ -767,6 +767,9 @@ fn run_process_group(
     command: &mut Command,
     timeout: Duration,
 ) -> Result<std::process::ExitStatus, String> {
+    let mut watchdog = ParentDeathWatchdog::arm(timeout)?;
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    let watchdog_worker_fd = watchdog.worker_pid_fd();
     #[cfg(any(target_os = "android", target_os = "linux"))]
     let parent_pid = unsafe { libc::getpid() };
     // SAFETY: pre_exec only invokes async-signal-safe libc operations before
@@ -774,7 +777,8 @@ fn run_process_group(
     // leaving its privileged shell alive with subscription/config locks.  The
     // parent check closes the fork-to-prctl race: if the CLI died before the
     // child armed PR_SET_PDEATHSIG, the child aborts instead of becoming an
-    // untracked session leader.
+    // untracked session leader. The child publishes its process-group ID to a
+    // watchdog that was armed before spawn, closing the post-spawn gap too.
     unsafe {
         command.pre_exec(move || {
             #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -789,6 +793,19 @@ fn run_process_group(
             if libc::setsid() == -1 {
                 Err(io::Error::last_os_error())
             } else {
+                #[cfg(any(target_os = "android", target_os = "linux"))]
+                {
+                    let worker_pid = libc::getpid();
+                    let written = libc::write(
+                        watchdog_worker_fd,
+                        (&worker_pid as *const libc::pid_t).cast::<libc::c_void>(),
+                        std::mem::size_of::<libc::pid_t>(),
+                    );
+                    libc::close(watchdog_worker_fd);
+                    if written != std::mem::size_of::<libc::pid_t>() as isize {
+                        return Err(io::Error::last_os_error());
+                    }
+                }
                 Ok(())
             }
         });
@@ -796,17 +813,7 @@ fn run_process_group(
     let mut child = command
         .spawn()
         .map_err(|err| format!("spawn failed: {err}"))?;
-    let _watchdog = match ParentDeathWatchdog::spawn(child.id() as i32) {
-        Ok(watchdog) => watchdog,
-        Err(err) => {
-            let group = -(child.id() as i32);
-            unsafe {
-                libc::kill(group, libc::SIGKILL);
-            }
-            let _ = child.wait();
-            return Err(err);
-        }
-    };
+    watchdog.worker_spawned();
     let deadline = Instant::now() + timeout;
     loop {
         if let Some(status) = child
@@ -835,15 +842,27 @@ fn run_process_group(
 struct ParentDeathWatchdog {
     pid: libc::pid_t,
     control_fd: libc::c_int,
+    worker_pid_fd: libc::c_int,
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 impl ParentDeathWatchdog {
-    fn spawn(worker_pid: i32) -> Result<Self, String> {
+    fn arm(timeout: Duration) -> Result<Self, String> {
         let mut control = [-1; 2];
         if unsafe { libc::pipe2(control.as_mut_ptr(), libc::O_CLOEXEC) } == -1 {
             return Err(format!(
                 "parent-death watchdog pipe failed: {}",
+                io::Error::last_os_error()
+            ));
+        }
+        let mut worker_pid_pipe = [-1; 2];
+        if unsafe { libc::pipe2(worker_pid_pipe.as_mut_ptr(), libc::O_CLOEXEC) } == -1 {
+            unsafe {
+                libc::close(control[0]);
+                libc::close(control[1]);
+            }
+            return Err(format!(
+                "parent-death watchdog PID pipe failed: {}",
                 io::Error::last_os_error()
             ));
         }
@@ -853,6 +872,8 @@ impl ParentDeathWatchdog {
             unsafe {
                 libc::close(control[0]);
                 libc::close(control[1]);
+                libc::close(worker_pid_pipe[0]);
+                libc::close(worker_pid_pipe[1]);
             }
             return Err(format!(
                 "parent-death watchdog fork failed: {}",
@@ -860,46 +881,79 @@ impl ParentDeathWatchdog {
             ));
         }
         if watchdog_pid == 0 {
-            // SAFETY: this post-fork child uses only libc calls and exits via
-            // _exit. The CLI owns the pipe's write end; an EOF means the CLI
-            // died without disarming us. Give the worker shell's PDEATHSIG
-            // handler a short rollback window, then kill every process still
-            // left in its independent process group, including grandchildren.
+            // SAFETY: this post-fork child uses stack values and libc calls,
+            // then exits via _exit. The worker publishes its process-group ID
+            // before exec. After that, EOF on the control pipe means the CLI
+            // died without disarming us. Let the TERM rollback finish (up to
+            // the same bounded command timeout), then reap any descendants
+            // still left in the independent process group.
             unsafe {
                 libc::close(control[1]);
-                let mut marker = 0_u8;
-                loop {
+                libc::close(worker_pid_pipe[1]);
+                let mut worker_pid: libc::pid_t = 0;
+                let worker_pid_size = std::mem::size_of::<libc::pid_t>();
+                let mut worker_pid_read = 0_usize;
+                while worker_pid_read < worker_pid_size {
                     let read_result = libc::read(
-                        control[0],
-                        (&mut marker as *mut u8).cast::<libc::c_void>(),
-                        1,
+                        worker_pid_pipe[0],
+                        ((&mut worker_pid as *mut libc::pid_t).cast::<u8>())
+                            .add(worker_pid_read)
+                            .cast::<libc::c_void>(),
+                        worker_pid_size - worker_pid_read,
                     );
-                    if read_result == -1
-                        && io::Error::last_os_error().kind() == io::ErrorKind::Interrupted
-                    {
-                        continue;
+                    if read_result <= 0 {
+                        libc::close(worker_pid_pipe[0]);
+                        libc::close(control[0]);
+                        libc::_exit(0);
                     }
-                    if read_result == 0 {
-                        let grace = libc::timespec {
-                            tv_sec: 2,
-                            tv_nsec: 0,
-                        };
-                        libc::nanosleep(&grace, std::ptr::null_mut());
-                        libc::kill(-worker_pid, libc::SIGKILL);
-                    }
-                    libc::close(control[0]);
-                    libc::_exit(0);
+                    worker_pid_read += read_result as usize;
                 }
+                libc::close(worker_pid_pipe[0]);
+
+                let mut marker = 0_u8;
+                let read_result = libc::read(
+                    control[0],
+                    (&mut marker as *mut u8).cast::<libc::c_void>(),
+                    1,
+                );
+                if read_result == 0 {
+                    let poll_interval = libc::timespec {
+                        tv_sec: 0,
+                        tv_nsec: 100_000_000,
+                    };
+                    let max_polls = timeout.as_millis().saturating_add(99) / 100;
+                    let mut polls = 0_u128;
+                    while polls < max_polls && libc::kill(worker_pid, 0) == 0 {
+                        libc::nanosleep(&poll_interval, std::ptr::null_mut());
+                        polls += 1;
+                    }
+                    libc::kill(-worker_pid, libc::SIGKILL);
+                }
+                libc::close(control[0]);
+                libc::_exit(0);
             }
         }
 
         unsafe {
             libc::close(control[0]);
+            libc::close(worker_pid_pipe[0]);
         }
         Ok(Self {
             pid: watchdog_pid,
             control_fd: control[1],
+            worker_pid_fd: worker_pid_pipe[1],
         })
+    }
+
+    fn worker_pid_fd(&self) -> libc::c_int {
+        self.worker_pid_fd
+    }
+
+    fn worker_spawned(&mut self) {
+        unsafe {
+            libc::close(self.worker_pid_fd);
+        }
+        self.worker_pid_fd = -1;
     }
 }
 
@@ -918,6 +972,9 @@ impl Drop for ParentDeathWatchdog {
                 }
             }
             libc::close(self.control_fd);
+            if self.worker_pid_fd != -1 {
+                libc::close(self.worker_pid_fd);
+            }
         }
     }
 }
@@ -927,9 +984,11 @@ struct ParentDeathWatchdog;
 
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
 impl ParentDeathWatchdog {
-    fn spawn(_worker_pid: i32) -> Result<Self, String> {
+    fn arm(_timeout: Duration) -> Result<Self, String> {
         Ok(Self)
     }
+
+    fn worker_spawned(&mut self) {}
 }
 
 fn should_report_startup_error(function_name: &str) -> bool {

--- a/crates/magicnet-cli/src/main.rs
+++ b/crates/magicnet-cli/src/main.rs
@@ -767,6 +767,7 @@ fn run_process_group(
     command: &mut Command,
     timeout: Duration,
 ) -> Result<std::process::ExitStatus, String> {
+    #[cfg(any(target_os = "android", target_os = "linux"))]
     let parent_pid = unsafe { libc::getpid() };
     // SAFETY: pre_exec only invokes async-signal-safe libc operations before
     // exec.  The parent-death signal prevents an externally killed CLI from
@@ -776,11 +777,16 @@ fn run_process_group(
     // untracked session leader.
     unsafe {
         command.pre_exec(move || {
-            if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) == -1 {
-                Err(io::Error::last_os_error())
-            } else if libc::getppid() != parent_pid {
-                Err(io::Error::from_raw_os_error(libc::ECHILD))
-            } else if libc::setsid() == -1 {
+            #[cfg(any(target_os = "android", target_os = "linux"))]
+            {
+                if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) == -1 {
+                    return Err(io::Error::last_os_error());
+                }
+                if libc::getppid() != parent_pid {
+                    return Err(io::Error::from_raw_os_error(libc::ECHILD));
+                }
+            }
+            if libc::setsid() == -1 {
                 Err(io::Error::last_os_error())
             } else {
                 Ok(())
@@ -790,6 +796,17 @@ fn run_process_group(
     let mut child = command
         .spawn()
         .map_err(|err| format!("spawn failed: {err}"))?;
+    let _watchdog = match ParentDeathWatchdog::spawn(child.id() as i32) {
+        Ok(watchdog) => watchdog,
+        Err(err) => {
+            let group = -(child.id() as i32);
+            unsafe {
+                libc::kill(group, libc::SIGKILL);
+            }
+            let _ = child.wait();
+            return Err(err);
+        }
+    };
     let deadline = Instant::now() + timeout;
     loop {
         if let Some(status) = child
@@ -811,6 +828,107 @@ fn run_process_group(
             return Err(format!("timed out after {}ms", timeout.as_millis()));
         }
         thread::sleep(Duration::from_millis(40));
+    }
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+struct ParentDeathWatchdog {
+    pid: libc::pid_t,
+    control_fd: libc::c_int,
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+impl ParentDeathWatchdog {
+    fn spawn(worker_pid: i32) -> Result<Self, String> {
+        let mut control = [-1; 2];
+        if unsafe { libc::pipe2(control.as_mut_ptr(), libc::O_CLOEXEC) } == -1 {
+            return Err(format!(
+                "parent-death watchdog pipe failed: {}",
+                io::Error::last_os_error()
+            ));
+        }
+
+        let watchdog_pid = unsafe { libc::fork() };
+        if watchdog_pid == -1 {
+            unsafe {
+                libc::close(control[0]);
+                libc::close(control[1]);
+            }
+            return Err(format!(
+                "parent-death watchdog fork failed: {}",
+                io::Error::last_os_error()
+            ));
+        }
+        if watchdog_pid == 0 {
+            // SAFETY: this post-fork child uses only libc calls and exits via
+            // _exit. The CLI owns the pipe's write end; an EOF means the CLI
+            // died without disarming us. Give the worker shell's PDEATHSIG
+            // handler a short rollback window, then kill every process still
+            // left in its independent process group, including grandchildren.
+            unsafe {
+                libc::close(control[1]);
+                let mut marker = 0_u8;
+                loop {
+                    let read_result = libc::read(
+                        control[0],
+                        (&mut marker as *mut u8).cast::<libc::c_void>(),
+                        1,
+                    );
+                    if read_result == -1
+                        && io::Error::last_os_error().kind() == io::ErrorKind::Interrupted
+                    {
+                        continue;
+                    }
+                    if read_result == 0 {
+                        let grace = libc::timespec {
+                            tv_sec: 2,
+                            tv_nsec: 0,
+                        };
+                        libc::nanosleep(&grace, std::ptr::null_mut());
+                        libc::kill(-worker_pid, libc::SIGKILL);
+                    }
+                    libc::close(control[0]);
+                    libc::_exit(0);
+                }
+            }
+        }
+
+        unsafe {
+            libc::close(control[0]);
+        }
+        Ok(Self {
+            pid: watchdog_pid,
+            control_fd: control[1],
+        })
+    }
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+impl Drop for ParentDeathWatchdog {
+    fn drop(&mut self) {
+        // A normal CLI path disarms the watcher before closing the pipe. If
+        // the CLI is killed, Drop cannot run and pipe EOF triggers cleanup.
+        unsafe {
+            libc::kill(self.pid, libc::SIGTERM);
+            loop {
+                if libc::waitpid(self.pid, std::ptr::null_mut(), 0) != -1
+                    || io::Error::last_os_error().kind() != io::ErrorKind::Interrupted
+                {
+                    break;
+                }
+            }
+            libc::close(self.control_fd);
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "android", target_os = "linux")))]
+struct ParentDeathWatchdog;
+
+#[cfg(not(any(target_os = "android", target_os = "linux")))]
+impl ParentDeathWatchdog {
+    fn spawn(_worker_pid: i32) -> Result<Self, String> {
+        Ok(Self)
     }
 }
 

--- a/crates/magicnet-cli/src/main.rs
+++ b/crates/magicnet-cli/src/main.rs
@@ -767,10 +767,20 @@ fn run_process_group(
     command: &mut Command,
     timeout: Duration,
 ) -> Result<std::process::ExitStatus, String> {
-    // SAFETY: pre_exec only invokes async-signal-safe setsid before exec.
+    let parent_pid = unsafe { libc::getpid() };
+    // SAFETY: pre_exec only invokes async-signal-safe libc operations before
+    // exec.  The parent-death signal prevents an externally killed CLI from
+    // leaving its privileged shell alive with subscription/config locks.  The
+    // parent check closes the fork-to-prctl race: if the CLI died before the
+    // child armed PR_SET_PDEATHSIG, the child aborts instead of becoming an
+    // untracked session leader.
     unsafe {
-        command.pre_exec(|| {
-            if libc::setsid() == -1 {
+        command.pre_exec(move || {
+            if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) == -1 {
+                Err(io::Error::last_os_error())
+            } else if libc::getppid() != parent_pid {
+                Err(io::Error::from_raw_os_error(libc::ECHILD))
+            } else if libc::setsid() == -1 {
                 Err(io::Error::last_os_error())
             } else {
                 Ok(())

--- a/crates/magicnet-cli/src/main.rs
+++ b/crates/magicnet-cli/src/main.rs
@@ -839,6 +839,65 @@ fn run_process_group(
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
+unsafe fn watchdog_worker_is_live(pid: libc::pid_t) -> bool {
+    if pid <= 0 {
+        return false;
+    }
+
+    let mut path = [0_u8; 64];
+    let prefix = b"/proc/";
+    path[..prefix.len()].copy_from_slice(prefix);
+    let mut path_len = prefix.len();
+    let mut digits = [0_u8; 20];
+    let mut digit_len = 0_usize;
+    let mut remaining = pid as u64;
+    loop {
+        digits[digit_len] = b'0' + (remaining % 10) as u8;
+        digit_len += 1;
+        remaining /= 10;
+        if remaining == 0 {
+            break;
+        }
+    }
+    while digit_len > 0 {
+        digit_len -= 1;
+        path[path_len] = digits[digit_len];
+        path_len += 1;
+    }
+    let suffix = b"/stat\0";
+    path[path_len..path_len + suffix.len()].copy_from_slice(suffix);
+
+    let stat_fd = libc::open(
+        path.as_ptr().cast::<libc::c_char>(),
+        libc::O_RDONLY | libc::O_CLOEXEC,
+    );
+    if stat_fd == -1 {
+        return false;
+    }
+    let mut stat = [0_u8; 512];
+    let stat_len = libc::read(
+        stat_fd,
+        stat.as_mut_ptr().cast::<libc::c_void>(),
+        stat.len(),
+    );
+    libc::close(stat_fd);
+    if stat_len < 4 {
+        return false;
+    }
+
+    let mut index = stat_len as usize - 3;
+    loop {
+        if stat[index] == b')' && stat[index + 1] == b' ' {
+            return !matches!(stat[index + 2], b'Z' | b'X' | b'x');
+        }
+        if index == 0 {
+            return false;
+        }
+        index -= 1;
+    }
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
 struct ParentDeathWatchdog {
     pid: libc::pid_t,
     control_fd: libc::c_int,
@@ -923,7 +982,7 @@ impl ParentDeathWatchdog {
                     };
                     let max_polls = timeout.as_millis().saturating_add(99) / 100;
                     let mut polls = 0_u128;
-                    while polls < max_polls && libc::kill(worker_pid, 0) == 0 {
+                    while polls < max_polls && watchdog_worker_is_live(worker_pid) {
                         libc::nanosleep(&poll_interval, std::ptr::null_mut());
                         polls += 1;
                     }
@@ -1158,6 +1217,20 @@ mod process_group_tests {
     use std::fs;
     use std::process::Command;
     use std::time::Duration;
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[test]
+    fn watchdog_treats_a_zombie_worker_as_finished() {
+        let mut child = Command::new("sh").args(["-c", "exit 0"]).spawn().unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while unsafe { super::watchdog_worker_is_live(child.id() as libc::pid_t) }
+            && std::time::Instant::now() < deadline
+        {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(!unsafe { super::watchdog_worker_is_live(child.id() as libc::pid_t) });
+        let _ = child.wait();
+    }
 
     #[test]
     fn command_timeout_is_finite_and_rejects_zero_or_overflow() {

--- a/crates/magicnet-cli/tests/process_lifecycle.rs
+++ b/crates/magicnet-cli/tests/process_lifecycle.rs
@@ -1,0 +1,74 @@
+use std::fs;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+fn process_is_live(pid: i32) -> bool {
+    let Ok(stat) = fs::read_to_string(format!("/proc/{pid}/stat")) else {
+        return false;
+    };
+    stat.rsplit_once(") ")
+        .and_then(|(_, fields)| fields.split_whitespace().next())
+        != Some("Z")
+}
+
+#[test]
+fn killing_cli_parent_terminates_privileged_shell() {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let fixture = std::env::temp_dir().join(format!(
+        "magicnet-parent-death-{}-{nonce}",
+        std::process::id()
+    ));
+    fs::create_dir_all(fixture.join("lib/kamfw")).unwrap();
+    fs::write(fixture.join("lib/kamfw/.kamfwrc"), "import() { :; }\n").unwrap();
+    fs::write(fixture.join("lib/magicnet.sh"), "").unwrap();
+    fs::write(
+        fixture.join("lib/magicnet_singbox_subscribe.sh"),
+        r#"magicnet_singbox_status() {
+    printf '%s\n' "$$" >"$MODDIR/status-shell.pid"
+    while :; do :; done
+}
+"#,
+    )
+    .unwrap();
+
+    let mut cli = Command::new(env!("CARGO_BIN_EXE_magicnet-cli"))
+        .args(["sub", "status"])
+        .env("MODDIR", &fixture)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn fixture CLI");
+
+    let pid_file = fixture.join("status-shell.pid");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !pid_file.exists() && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(20));
+    }
+    let shell_pid = fs::read_to_string(&pid_file)
+        .expect("status shell did not publish its PID")
+        .trim()
+        .parse::<i32>()
+        .unwrap();
+    assert!(process_is_live(shell_pid));
+
+    cli.kill().expect("kill CLI parent");
+    let _ = cli.wait();
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while process_is_live(shell_pid) && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(20));
+    }
+    if process_is_live(shell_pid) {
+        unsafe {
+            libc::kill(-shell_pid, libc::SIGKILL);
+            libc::kill(shell_pid, libc::SIGKILL);
+        }
+        panic!("privileged status shell survived its CLI parent");
+    }
+
+    let _ = fs::remove_dir_all(fixture);
+}

--- a/crates/magicnet-cli/tests/process_lifecycle.rs
+++ b/crates/magicnet-cli/tests/process_lifecycle.rs
@@ -1,8 +1,12 @@
+#![cfg(any(target_os = "android", target_os = "linux"))]
+
 use std::fs;
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+/// Reports whether Linux `/proc` still contains a non-zombie process.
+/// Stopped processes count as live because they still retain runtime state.
 fn process_is_live(pid: i32) -> bool {
     let Ok(stat) = fs::read_to_string(format!("/proc/{pid}/stat")) else {
         return false;
@@ -10,6 +14,24 @@ fn process_is_live(pid: i32) -> bool {
     stat.rsplit_once(") ")
         .and_then(|(_, fields)| fields.split_whitespace().next())
         != Some("Z")
+}
+
+#[test]
+fn process_is_live_treats_a_zombie_as_terminated() {
+    let mut child = Command::new("sh")
+        .args(["-c", "exit 0"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn short-lived child");
+    let pid = child.id() as i32;
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while process_is_live(pid) && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(10));
+    }
+    assert!(!process_is_live(pid));
+    let _ = child.wait();
 }
 
 #[test]
@@ -29,7 +51,9 @@ fn killing_cli_parent_terminates_privileged_shell() {
         fixture.join("lib/magicnet_singbox_subscribe.sh"),
         r#"magicnet_singbox_status() {
     printf '%s\n' "$$" >"$MODDIR/status-shell.pid"
-    while :; do :; done
+    sleep 30 &
+    printf '%s\n' "$!" >"$MODDIR/status-grandchild.pid"
+    wait
 }
 "#,
     )
@@ -45,8 +69,9 @@ fn killing_cli_parent_terminates_privileged_shell() {
         .expect("spawn fixture CLI");
 
     let pid_file = fixture.join("status-shell.pid");
+    let grandchild_pid_file = fixture.join("status-grandchild.pid");
     let deadline = Instant::now() + Duration::from_secs(5);
-    while !pid_file.exists() && Instant::now() < deadline {
+    while (!pid_file.exists() || !grandchild_pid_file.exists()) && Instant::now() < deadline {
         thread::sleep(Duration::from_millis(20));
     }
     let shell_pid = fs::read_to_string(&pid_file)
@@ -54,20 +79,29 @@ fn killing_cli_parent_terminates_privileged_shell() {
         .trim()
         .parse::<i32>()
         .unwrap();
+    let grandchild_pid = fs::read_to_string(&grandchild_pid_file)
+        .expect("status grandchild did not publish its PID")
+        .trim()
+        .parse::<i32>()
+        .unwrap();
     assert!(process_is_live(shell_pid));
+    assert!(process_is_live(grandchild_pid));
 
     cli.kill().expect("kill CLI parent");
     let _ = cli.wait();
-    let deadline = Instant::now() + Duration::from_secs(3);
-    while process_is_live(shell_pid) && Instant::now() < deadline {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while (process_is_live(shell_pid) || process_is_live(grandchild_pid))
+        && Instant::now() < deadline
+    {
         thread::sleep(Duration::from_millis(20));
     }
-    if process_is_live(shell_pid) {
+    if process_is_live(shell_pid) || process_is_live(grandchild_pid) {
         unsafe {
             libc::kill(-shell_pid, libc::SIGKILL);
             libc::kill(shell_pid, libc::SIGKILL);
+            libc::kill(grandchild_pid, libc::SIGKILL);
         }
-        panic!("privileged status shell survived its CLI parent");
+        panic!("privileged status process group survived its CLI parent");
     }
 
     let _ = fs::remove_dir_all(fixture);

--- a/crates/magicnet-cli/tests/process_lifecycle.rs
+++ b/crates/magicnet-cli/tests/process_lifecycle.rs
@@ -51,6 +51,7 @@ fn killing_cli_parent_terminates_privileged_shell() {
         fixture.join("lib/magicnet_singbox_subscribe.sh"),
         r#"magicnet_singbox_status() {
     printf '%s\n' "$$" >"$MODDIR/status-shell.pid"
+    trap 'sleep 1; printf "%s\n" complete >"$MODDIR/rollback-marker"; exit 143' TERM
     sleep 30 &
     printf '%s\n' "$!" >"$MODDIR/status-grandchild.pid"
     wait
@@ -103,6 +104,11 @@ fn killing_cli_parent_terminates_privileged_shell() {
         }
         panic!("privileged status process group survived its CLI parent");
     }
+    assert_eq!(
+        fs::read_to_string(fixture.join("rollback-marker"))
+            .expect("watchdog killed the worker before TERM rollback completed"),
+        "complete\n"
+    );
 
     let _ = fs::remove_dir_all(fixture);
 }

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -83,6 +83,7 @@ else
 fi
 cargo check -p magicnet-cli
 cargo check -p magicnet-mcp-server
+cargo test -p magicnet-cli --test process_lifecycle
 if compgen -G "dist/*.zip" >/dev/null; then
     package_zip="$(compgen -G "dist/*.zip" | head -n1)"
     scripts/package-smoke.sh "$package_zip"

--- a/scripts/test-config-lock-safety.sh
+++ b/scripts/test-config-lock-safety.sh
@@ -22,6 +22,17 @@ printf '%s:%s\n' "$$" "$start" >"$MODDIR/.state/config.lock/pid"
 magicnet_config_lock_release
 test ! -e "$MODDIR/.state/config.lock"
 
+# Locking must not replace a caller's transaction/signal cleanup handlers.
+# The subscription updater relies on its TERM trap to roll back its journal.
+trap 'exit 143' TERM
+caller_term_trap="$(trap -p TERM)"
+assert_caller_trap_preserved() {
+    test "$(trap -p TERM)" = "$caller_term_trap"
+}
+magicnet_with_config_lock assert_caller_trap_preserved
+test "$(trap -p TERM)" = "$caller_term_trap"
+trap - TERM
+
 # Stale and marker-less owners are reclaimed without recursive deletion.
 mkdir -p "$MODDIR/.state/config.lock"
 printf '%s\n' '999999:1' >"$MODDIR/.state/config.lock/pid"

--- a/scripts/test-subscription-lifecycle.sh
+++ b/scripts/test-subscription-lifecycle.sh
@@ -295,6 +295,21 @@ run_fault_recovery_case after-core-verification 1
 run_fault_recovery_case after-work-switch
 run_fault_recovery_case after-url-commit
 
+# Service startup checks the durable subscription journal before accepting an
+# already-running core, so a reboot/startup also repairs an interrupted update.
+(
+  startup_recovery="$MODDIR/.state/sing-box/subscription-transaction"
+  mkdir -p "$startup_recovery"
+  magicnet_singbox_update_lock_active() { return 1; }
+  magicnet_singbox_status_reconcile_locked() {
+    rm -rf "$startup_recovery"
+    printf '%s\n' recovered >"$fixture/startup-recovery"
+  }
+  magicnet_recover_interrupted_subscription
+  test ! -e "$startup_recovery"
+  assert_file "$fixture/startup-recovery" recovered
+)
+
 # A crash after changing source modes restores both source files exactly.
 printf 'old-url-before-local\n' >"$active_url"
 rm -f "$MODDIR/.config/sing-box/subscription.local"

--- a/scripts/test-subscription-lifecycle.sh
+++ b/scripts/test-subscription-lifecycle.sh
@@ -128,7 +128,17 @@ write_local_candidate() {
   chmod 600 "$candidate_local"
 }
 
-magicnet_with_config_lock() { "$@"; }
+magicnet_with_config_lock() {
+  if test "${MAGICNET_CONFIG_LOCK_HELD:-0}" -eq 1; then
+    "$@"
+    return $?
+  fi
+  MAGICNET_CONFIG_LOCK_HELD=1
+  "$@"
+  local lock_rc=$?
+  unset MAGICNET_CONFIG_LOCK_HELD
+  return "$lock_rc"
+}
 magicnet_fswatch_status() { return 1; }
 RUNNING=0
 NATIVE_NODE_COUNT=1

--- a/scripts/test-subscription-lifecycle.sh
+++ b/scripts/test-subscription-lifecycle.sh
@@ -310,6 +310,21 @@ run_fault_recovery_case after-url-commit
   assert_file "$fixture/startup-recovery" recovered
 )
 
+# `service ensure` has its own live-core fast path. It must run recovery before
+# accepting that core, just like an explicit service start.
+(
+  # shellcheck disable=SC1090
+  . "$ROOT/src/MagicNet/lib/magicnet/core.sh"
+  ensure_recovery_count=0
+  magicnet_module_disabled() { return 1; }
+  magicnet_kernel_running() { return 0; }
+  magicnet_recover_interrupted_subscription() {
+    ensure_recovery_count=$((ensure_recovery_count + 1))
+  }
+  magicnet_ensure_kernel
+  test "$ensure_recovery_count" -eq 1
+)
+
 # A crash after changing source modes restores both source files exactly.
 printf 'old-url-before-local\n' >"$active_url"
 rm -f "$MODDIR/.config/sing-box/subscription.local"

--- a/scripts/test-subscription-transaction-atomicity.sh
+++ b/scripts/test-subscription-transaction-atomicity.sh
@@ -76,6 +76,7 @@ touch "$TRANSACTION/had-config" "$TRANSACTION/was-running"
 restart_count=0
 policy_count=0
 magicnet_singbox_owned_ready() { return 0; }
+magicnet_singbox_runtime_fingerprint_matches() { return 0; }
 magicnet_singbox_restart_owned() { restart_count=$((restart_count + 1)); }
 magicnet_after_kernel_start_unlocked() { policy_count=$((policy_count + 1)); }
 magicnet_singbox_transaction_reconcile
@@ -102,6 +103,7 @@ mkdir -p "$TRANSACTION"
 printf '%s\n' stable-config >"$TRANSACTION/old-config"
 touch "$TRANSACTION/had-config" "$TRANSACTION/was-running"
 magicnet_singbox_owned_ready() { return 1; }
+magicnet_singbox_runtime_fingerprint_matches() { return 0; }
 magicnet_singbox_restart_owned() { restart_count=$((restart_count + 1)); }
 magicnet_singbox_transaction_reconcile
 [ "$restart_count" -eq 1 ]
@@ -109,12 +111,26 @@ magicnet_singbox_transaction_reconcile
 
 printf '%s\n' 'subscription unready-core recovery test passed'
 
+# A ready PID can still be running the newer generation after recovery restored
+# old-config on disk. A runtime fingerprint mismatch must force the restart.
+mkdir -p "$TRANSACTION"
+printf '%s\n' stable-config >"$TRANSACTION/old-config"
+touch "$TRANSACTION/had-config" "$TRANSACTION/was-running"
+magicnet_singbox_owned_ready() { return 0; }
+magicnet_singbox_runtime_fingerprint_matches() { return 1; }
+magicnet_singbox_transaction_reconcile
+[ "$restart_count" -eq 2 ]
+[ ! -e "$TRANSACTION" ]
+
+printf '%s\n' 'subscription mismatched-generation recovery test passed'
+
 # A failed runtime-policy repair must retain the durable journal so startup or
 # a later bounded status call can retry instead of accepting a half-ready core.
 mkdir -p "$TRANSACTION"
 printf '%s\n' stable-config >"$TRANSACTION/old-config"
 touch "$TRANSACTION/had-config" "$TRANSACTION/was-running"
 magicnet_singbox_owned_ready() { return 0; }
+magicnet_singbox_runtime_fingerprint_matches() { return 0; }
 magicnet_after_kernel_start_unlocked() { return 1; }
 set +e
 magicnet_singbox_transaction_reconcile

--- a/scripts/test-subscription-transaction-atomicity.sh
+++ b/scripts/test-subscription-transaction-atomicity.sh
@@ -64,3 +64,28 @@ unset -f mv
 }
 
 printf '%s\n' 'subscription transaction atomicity test passed'
+
+# If an idempotent activation was interrupted after publishing the same config
+# and the old core is still healthy, recovery should restore journaled metadata
+# without an unnecessary stop/start cycle. This keeps status recovery bounded.
+rm -rf "$TRANSACTION" "$ACTIVE_WORK"
+mkdir -p "$TRANSACTION"
+printf '%s\n' stable-config >"$MODDIR/.config/sing-box/config.json"
+printf '%s\n' stable-config >"$TRANSACTION/old-config"
+touch "$TRANSACTION/had-config" "$TRANSACTION/was-running"
+restart_count=0
+magicnet_singbox_is_running() { return 0; }
+magicnet_singbox_restart_owned() { restart_count=$((restart_count + 1)); }
+magicnet_singbox_transaction_reconcile
+
+[ "$restart_count" -eq 0 ] || {
+    printf '%s\n' 'idempotent recovery restarted an already healthy core' >&2
+    exit 1
+}
+[ ! -e "$TRANSACTION" ] || {
+    printf '%s\n' 'idempotent recovery left its transaction journal behind' >&2
+    exit 1
+}
+[ "$(<"$MODDIR/.config/sing-box/config.json")" = stable-config ]
+
+printf '%s\n' 'subscription idempotent recovery test passed'

--- a/scripts/test-subscription-transaction-atomicity.sh
+++ b/scripts/test-subscription-transaction-atomicity.sh
@@ -75,7 +75,7 @@ printf '%s\n' stable-config >"$TRANSACTION/old-config"
 touch "$TRANSACTION/had-config" "$TRANSACTION/was-running"
 restart_count=0
 policy_count=0
-magicnet_singbox_is_running() { return 0; }
+magicnet_singbox_owned_ready() { return 0; }
 magicnet_singbox_restart_owned() { restart_count=$((restart_count + 1)); }
 magicnet_after_kernel_start_unlocked() { policy_count=$((policy_count + 1)); }
 magicnet_singbox_transaction_reconcile
@@ -96,11 +96,25 @@ magicnet_singbox_transaction_reconcile
 
 printf '%s\n' 'subscription idempotent recovery test passed'
 
+# A merely spawned core is not enough to suppress rollback restart. If its
+# listener/API readiness probe fails, recovery must take the restart path.
+mkdir -p "$TRANSACTION"
+printf '%s\n' stable-config >"$TRANSACTION/old-config"
+touch "$TRANSACTION/had-config" "$TRANSACTION/was-running"
+magicnet_singbox_owned_ready() { return 1; }
+magicnet_singbox_restart_owned() { restart_count=$((restart_count + 1)); }
+magicnet_singbox_transaction_reconcile
+[ "$restart_count" -eq 1 ]
+[ ! -e "$TRANSACTION" ]
+
+printf '%s\n' 'subscription unready-core recovery test passed'
+
 # A failed runtime-policy repair must retain the durable journal so startup or
 # a later bounded status call can retry instead of accepting a half-ready core.
 mkdir -p "$TRANSACTION"
 printf '%s\n' stable-config >"$TRANSACTION/old-config"
 touch "$TRANSACTION/had-config" "$TRANSACTION/was-running"
+magicnet_singbox_owned_ready() { return 0; }
 magicnet_after_kernel_start_unlocked() { return 1; }
 set +e
 magicnet_singbox_transaction_reconcile

--- a/scripts/test-subscription-transaction-atomicity.sh
+++ b/scripts/test-subscription-transaction-atomicity.sh
@@ -74,12 +74,18 @@ printf '%s\n' stable-config >"$MODDIR/.config/sing-box/config.json"
 printf '%s\n' stable-config >"$TRANSACTION/old-config"
 touch "$TRANSACTION/had-config" "$TRANSACTION/was-running"
 restart_count=0
+policy_count=0
 magicnet_singbox_is_running() { return 0; }
 magicnet_singbox_restart_owned() { restart_count=$((restart_count + 1)); }
+magicnet_after_kernel_start_unlocked() { policy_count=$((policy_count + 1)); }
 magicnet_singbox_transaction_reconcile
 
 [ "$restart_count" -eq 0 ] || {
     printf '%s\n' 'idempotent recovery restarted an already healthy core' >&2
+    exit 1
+}
+[ "$policy_count" -eq 1 ] || {
+    printf '%s\n' 'idempotent recovery did not reapply runtime network policy' >&2
     exit 1
 }
 [ ! -e "$TRANSACTION" ] || {
@@ -89,3 +95,18 @@ magicnet_singbox_transaction_reconcile
 [ "$(<"$MODDIR/.config/sing-box/config.json")" = stable-config ]
 
 printf '%s\n' 'subscription idempotent recovery test passed'
+
+# A failed runtime-policy repair must retain the durable journal so startup or
+# a later bounded status call can retry instead of accepting a half-ready core.
+mkdir -p "$TRANSACTION"
+printf '%s\n' stable-config >"$TRANSACTION/old-config"
+touch "$TRANSACTION/had-config" "$TRANSACTION/was-running"
+magicnet_after_kernel_start_unlocked() { return 1; }
+set +e
+magicnet_singbox_transaction_reconcile
+policy_recovery_rc=$?
+set -e
+[ "$policy_recovery_rc" -ne 0 ]
+[ -d "$TRANSACTION" ]
+
+printf '%s\n' 'subscription runtime-policy recovery failure test passed'

--- a/scripts/test-subscription-update-lock-safety.sh
+++ b/scripts/test-subscription-update-lock-safety.sh
@@ -87,7 +87,9 @@ printf '%s\n' 'subscription update lock publication-window safety test passed'
 (
     status_lock_held=0
     status_cache="$MODDIR/.state/sing-box/subscription-cache"
-    mkdir -p "$MODDIR/.config/sing-box" "$status_cache"
+    status_transaction="$MODDIR/.state/sing-box/subscription-transaction"
+    status_timeout_file="$MODDIR/.state/sing-box/status-lock-timeout"
+    mkdir -p "$MODDIR/.config/sing-box" "$status_cache" "$status_transaction"
     magicnet_singbox_subscription_status_file() {
         printf '%s\n' "$MODDIR/.state/sing-box/subscription-status"
     }
@@ -99,6 +101,7 @@ printf '%s\n' 'subscription update lock publication-window safety test passed'
     }
     magicnet_with_config_lock() {
         status_lock_held=1
+        printf '%s\n' "$MAGICNET_CONFIG_LOCK_TIMEOUT" >"$status_timeout_file"
         "$@"
         local status_rc=$?
         status_lock_held=0
@@ -106,11 +109,14 @@ printf '%s\n' 'subscription update lock publication-window safety test passed'
     }
     magicnet_singbox_transaction_reconcile() {
         [ "$status_lock_held" -eq 1 ]
+        rm -rf "$status_transaction"
     }
     magicnet_singbox_status_reconcile() {
         [ "$status_lock_held" -eq 1 ]
     }
-    magicnet_singbox_status >/dev/null
+    status_output="$(magicnet_singbox_status)"
+    [ "$(<"$status_timeout_file")" -eq 3 ]
+    grep -q '^recovery_result=recovered$' <<<"$status_output"
 )
 printf '%s\n' 'subscription status reconciliation lock-safety test passed'
 

--- a/scripts/test-subscription-update-lock-safety.sh
+++ b/scripts/test-subscription-update-lock-safety.sh
@@ -128,7 +128,8 @@ set +e
 (
     MAGICNET_CONFIG_LOCK_HELD=1
     MAGICNET_SUB_DEFER_FSWATCH_RESTORE=1
-    MAGICNET_SUB_FSWATCH_RESTORE_PENDING=1
+    MAGICNET_SUB_FSWATCH_RESTORE_PENDING=0
+    MAGICNET_SUB_FSWATCH_WAS_ACTIVE=1
     magicnet_singbox_transaction_reconcile() { :; }
     magicnet_singbox_update_cleanup_stage() { :; }
     magicnet_singbox_status_mark_interrupted() { :; }

--- a/scripts/test-subscription-update-lock-safety.sh
+++ b/scripts/test-subscription-update-lock-safety.sh
@@ -149,6 +149,28 @@ set -e
 
 printf '%s\n' 'subscription interrupt fswatch restoration test passed'
 
+# A signal while config-lock acquisition is still waiting must not reconcile
+# another operation's files without owning that lock. Leave the journal for a
+# later status/startup recovery and release only the update lock.
+prelock_interrupt_trace="$MODDIR/.state/sing-box/prelock-interrupt-trace"
+set +e
+(
+    unset MAGICNET_CONFIG_LOCK_HELD MAGICNET_SUB_FSWATCH_RESTORE_PENDING
+    unset MAGICNET_SUB_FSWATCH_WAS_ACTIVE MAGICNET_SUB_DEFER_FSWATCH_RESTORE
+    magicnet_singbox_transaction_reconcile() { printf '%s\n' reconcile >>"$prelock_interrupt_trace"; }
+    magicnet_singbox_update_cleanup_stage() { :; }
+    magicnet_singbox_status_mark_interrupted() { :; }
+    magicnet_config_lock_release() { printf '%s\n' config-release >>"$prelock_interrupt_trace"; }
+    magicnet_singbox_update_lock_release() { printf '%s\n' update-release >>"$prelock_interrupt_trace"; }
+    magicnet_singbox_update_interrupt 143
+)
+prelock_interrupt_rc=$?
+set -e
+[ "$prelock_interrupt_rc" -eq 143 ]
+[ "$(<"$prelock_interrupt_trace")" = update-release ]
+
+printf '%s\n' 'subscription pre-lock interrupt serialization test passed'
+
 # An owner marker write failure must not leave an empty directory that blocks
 # every later subscription update until a timeout-based reclamation.
 rm -rf "$UPDATE_LOCK"

--- a/scripts/test-subscription-update-lock-safety.sh
+++ b/scripts/test-subscription-update-lock-safety.sh
@@ -120,6 +120,34 @@ printf '%s\n' 'subscription update lock publication-window safety test passed'
 )
 printf '%s\n' 'subscription status reconciliation lock-safety test passed'
 
+# A signal can arrive after restart_owned stopped fswatch but before the update
+# wrapper reached its normal deferred restore. The interrupt path must release
+# the config lock first, then restore fswatch before dropping the update lock.
+interrupt_trace="$MODDIR/.state/sing-box/interrupt-trace"
+set +e
+(
+    MAGICNET_CONFIG_LOCK_HELD=1
+    MAGICNET_SUB_DEFER_FSWATCH_RESTORE=1
+    MAGICNET_SUB_FSWATCH_RESTORE_PENDING=1
+    magicnet_singbox_transaction_reconcile() { :; }
+    magicnet_singbox_update_cleanup_stage() { :; }
+    magicnet_singbox_status_mark_interrupted() { :; }
+    magicnet_config_lock_release() { printf '%s\n' config-release >>"$interrupt_trace"; }
+    magicnet_singbox_supervisor_restore() {
+        [ "$1" -eq 1 ]
+        [ -z "${MAGICNET_SUB_DEFER_FSWATCH_RESTORE+x}" ]
+        printf '%s\n' fswatch-restore >>"$interrupt_trace"
+    }
+    magicnet_singbox_update_lock_release() { printf '%s\n' update-release >>"$interrupt_trace"; }
+    magicnet_singbox_update_interrupt 143
+)
+interrupt_rc=$?
+set -e
+[ "$interrupt_rc" -eq 143 ]
+[ "$(<"$interrupt_trace")" = $'config-release\nfswatch-restore\nupdate-release' ]
+
+printf '%s\n' 'subscription interrupt fswatch restoration test passed'
+
 # An owner marker write failure must not leave an empty directory that blocks
 # every later subscription update until a timeout-based reclamation.
 rm -rf "$UPDATE_LOCK"

--- a/src/MagicNet/lib/magicnet/common.sh
+++ b/src/MagicNet/lib/magicnet/common.sh
@@ -433,12 +433,53 @@ magicnet_with_config_lock() {
     fi
     magicnet_config_lock_acquire || return 1
     MAGICNET_CONFIG_LOCK_HELD=1
-    trap 'magicnet_config_lock_release' INT TERM HUP
+    # Do not replace caller-owned signal handlers here.  Subscription updates
+    # install a transaction rollback handler before entering this critical
+    # section; replacing and then clearing it made an interrupted activation
+    # leave both journals and locks behind.  An uncatchable process death is
+    # still safe because lock ownership is PID/start-time bound and the next
+    # caller can reclaim it.
     "$@"
     _lock_rc=$?
-    trap - INT TERM HUP
     magicnet_config_lock_release
     MAGICNET_CONFIG_LOCK_HELD=0
     unset MAGICNET_CONFIG_LOCK_HELD
     return "$_lock_rc"
+}
+
+magicnet_recover_interrupted_subscription() {
+    _recover_tx="${MODDIR}/.state/sing-box/subscription-transaction"
+    [ -d "$_recover_tx" ] || {
+        unset _recover_tx
+        return 0
+    }
+
+    if ! command -v magicnet_singbox_transaction_reconcile >/dev/null 2>&1; then
+        . "${MODDIR}/lib/magicnet_singbox_subscribe.sh" || {
+            unset _recover_tx
+            return 1
+        }
+    fi
+    if magicnet_singbox_update_lock_active; then
+        # A live updater owns the journal.  Startup must not race it.
+        unset _recover_tx
+        return 0
+    fi
+
+    _recover_lock_was_set="${MAGICNET_CONFIG_LOCK_TIMEOUT+x}"
+    _recover_lock_timeout="${MAGICNET_SUB_CONFIG_LOCK_TIMEOUT:-45}"
+    case "$_recover_lock_timeout" in
+        '' | *[!0-9]*) _recover_lock_timeout=45 ;;
+    esac
+    _recover_old_lock_timeout="${MAGICNET_CONFIG_LOCK_TIMEOUT:-}"
+    MAGICNET_CONFIG_LOCK_TIMEOUT="$_recover_lock_timeout"
+    magicnet_with_config_lock magicnet_singbox_status_reconcile_locked
+    _recover_rc=$?
+    if [ -n "$_recover_lock_was_set" ]; then
+        MAGICNET_CONFIG_LOCK_TIMEOUT="$_recover_old_lock_timeout"
+    else
+        unset MAGICNET_CONFIG_LOCK_TIMEOUT
+    fi
+    unset _recover_tx _recover_lock_was_set _recover_lock_timeout _recover_old_lock_timeout
+    return "$_recover_rc"
 }

--- a/src/MagicNet/lib/magicnet/core.sh
+++ b/src/MagicNet/lib/magicnet/core.sh
@@ -123,6 +123,11 @@ magicnet_ensure_kernel() {
         magicnet_supervisors_stop >/dev/null 2>&1 || true
         return 1
     }
+    if command -v magicnet_recover_interrupted_subscription >/dev/null 2>&1 &&
+        ! magicnet_recover_interrupted_subscription; then
+        magicnet_warn "Interrupted subscription transaction recovery failed"
+        return 1
+    fi
     magicnet_kernel_running && return 0
     magicnet_require_subscription_or_stop || return 1
     MAGICNET_WATCHDOG=1 magicnet_start_kernel

--- a/src/MagicNet/lib/magicnet/core.sh
+++ b/src/MagicNet/lib/magicnet/core.sh
@@ -80,6 +80,11 @@ magicnet_start_kernel() {
         magicnet_supervisors_stop >/dev/null 2>&1 || true
         return 1
     }
+    if command -v magicnet_recover_interrupted_subscription >/dev/null 2>&1 &&
+        ! magicnet_recover_interrupted_subscription; then
+        magicnet_warn "Interrupted subscription transaction recovery failed"
+        return 1
+    fi
     if magicnet_kernel_running; then
         return 0
     fi

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
@@ -1026,6 +1026,24 @@ magicnet_singbox_listener_owned() {
     ss -lntp 2>/dev/null | grep -E '127\.0\.0\.1:9090[[:space:]]' | grep -q "pid=${_listener_pid},"
 }
 
+magicnet_singbox_owned_ready() {
+    _ready_owned_config="$1"
+    _ready_api_expected=0
+    magicnet_singbox_config_has_clash_api "$_ready_owned_config" && _ready_api_expected=1
+    for _ready_owned_pid in $(magicnet_singbox_owned_pids "$_ready_owned_config"); do
+        if [ "$_ready_api_expected" -eq 0 ] || {
+            magicnet_singbox_listener_owned "$_ready_owned_pid" &&
+                curl -fsS --max-time 1 http://127.0.0.1:9090/version 2>/dev/null |
+                grep -q '"version"'
+        }; then
+            unset _ready_owned_config _ready_api_expected _ready_owned_pid
+            return 0
+        fi
+    done
+    unset _ready_owned_config _ready_api_expected _ready_owned_pid
+    return 1
+}
+
 magicnet_singbox_supervisor_restore() {
     _restore_fswatch_active="${1:-${_owned_fswatch_active:-0}}"
     [ "$_restore_fswatch_active" -eq 1 ] || {

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
@@ -237,7 +237,7 @@ magicnet_singbox_transaction_reconcile() {
         if [ -f "$_tx_dir/had-config" ] && [ -f "$_tx_dir/old-config" ] &&
             [ -f "$_tx_active_config" ] && command -v cmp >/dev/null 2>&1 &&
             cmp -s "$_tx_dir/old-config" "$_tx_active_config" &&
-            magicnet_singbox_is_running "$_tx_active_config"; then
+            magicnet_singbox_owned_ready "$_tx_active_config"; then
             _tx_restart_required=0
         fi
     fi
@@ -602,9 +602,14 @@ magicnet_singbox_update_interrupt() {
     MAGICNET_CONFIG_LOCK_HELD=0
     unset MAGICNET_CONFIG_LOCK_HELD
     unset MAGICNET_SUB_DEFER_FSWATCH_RESTORE
-    if [ "${MAGICNET_SUB_FSWATCH_RESTORE_PENDING:-0}" -eq 1 ]; then
+    _update_restore_fswatch="${MAGICNET_SUB_FSWATCH_RESTORE_PENDING:-0}"
+    if [ "${MAGICNET_SUB_FSWATCH_WAS_ACTIVE:-0}" -eq 1 ]; then
+        _update_restore_fswatch=1
+    fi
+    if [ "$_update_restore_fswatch" -eq 1 ]; then
         magicnet_singbox_supervisor_restore 1 >/dev/null 2>&1 || true
     fi
+    unset _update_restore_fswatch
     unset MAGICNET_SUB_FSWATCH_RESTORE_PENDING MAGICNET_SUB_FSWATCH_WAS_ACTIVE
     magicnet_singbox_update_lock_release
     exit "$_update_interrupt_code"

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
@@ -237,7 +237,9 @@ magicnet_singbox_transaction_reconcile() {
         if [ -f "$_tx_dir/had-config" ] && [ -f "$_tx_dir/old-config" ] &&
             [ -f "$_tx_active_config" ] && command -v cmp >/dev/null 2>&1 &&
             cmp -s "$_tx_dir/old-config" "$_tx_active_config" &&
-            magicnet_singbox_owned_ready "$_tx_active_config"; then
+            magicnet_singbox_owned_ready "$_tx_active_config" &&
+            command -v magicnet_singbox_runtime_fingerprint_matches >/dev/null 2>&1 &&
+            magicnet_singbox_runtime_fingerprint_matches; then
             _tx_restart_required=0
         fi
     fi
@@ -593,23 +595,27 @@ magicnet_singbox_update_cleanup_stage() {
 magicnet_singbox_update_interrupt() {
     _update_interrupt_code="$1"
     trap - EXIT HUP INT TERM
-    magicnet_singbox_transaction_reconcile >/dev/null 2>&1 || true
+    _update_interrupt_had_config_lock="${MAGICNET_CONFIG_LOCK_HELD:-0}"
+    if [ "$_update_interrupt_had_config_lock" = 1 ]; then
+        magicnet_singbox_transaction_reconcile >/dev/null 2>&1 || true
+    fi
     magicnet_singbox_update_cleanup_stage
     magicnet_singbox_status_mark_interrupted
-    if command -v magicnet_config_lock_release >/dev/null 2>&1; then
+    if [ "$_update_interrupt_had_config_lock" = 1 ] &&
+        command -v magicnet_config_lock_release >/dev/null 2>&1; then
         magicnet_config_lock_release
     fi
     MAGICNET_CONFIG_LOCK_HELD=0
     unset MAGICNET_CONFIG_LOCK_HELD
     unset MAGICNET_SUB_DEFER_FSWATCH_RESTORE
     _update_restore_fswatch="${MAGICNET_SUB_FSWATCH_RESTORE_PENDING:-0}"
-    if [ "${MAGICNET_SUB_FSWATCH_WAS_ACTIVE:-0}" -eq 1 ]; then
+    if [ "${MAGICNET_SUB_FSWATCH_WAS_ACTIVE:-0}" = 1 ]; then
         _update_restore_fswatch=1
     fi
-    if [ "$_update_restore_fswatch" -eq 1 ]; then
+    if [ "$_update_restore_fswatch" = 1 ]; then
         magicnet_singbox_supervisor_restore 1 >/dev/null 2>&1 || true
     fi
-    unset _update_restore_fswatch
+    unset _update_restore_fswatch _update_interrupt_had_config_lock
     unset MAGICNET_SUB_FSWATCH_RESTORE_PENDING MAGICNET_SUB_FSWATCH_WAS_ACTIVE
     magicnet_singbox_update_lock_release
     exit "$_update_interrupt_code"

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
@@ -226,7 +226,21 @@ magicnet_singbox_transaction_reconcile() {
     _tx_active_work="${MODDIR}/.state/sing-box/subscription-work"
     _tx_active_url="${MODDIR}/.config/sing-box/subscription.url"
     _tx_active_local="${MODDIR}/.config/sing-box/subscription.local"
-    _tx_generation=$(sed -n '1p' "$_tx_dir/generation-id" 2>/dev/null)
+    _tx_generation=$(sed -n '1p' "$_tx_dir/generation-id" 2>/dev/null || true)
+    _tx_restart_required=0
+    if [ -f "$_tx_dir/was-running" ]; then
+        _tx_restart_required=1
+        # An activation can be interrupted immediately after an idempotent
+        # config rename.  If the durable backup and active config are already
+        # byte-identical and that config still owns a live core, restoring
+        # metadata does not require a disruptive stop/start cycle.
+        if [ -f "$_tx_dir/had-config" ] && [ -f "$_tx_dir/old-config" ] &&
+            [ -f "$_tx_active_config" ] && command -v cmp >/dev/null 2>&1 &&
+            cmp -s "$_tx_dir/old-config" "$_tx_active_config" &&
+            magicnet_singbox_is_running "$_tx_active_config"; then
+            _tx_restart_required=0
+        fi
+    fi
 
     mkdir -p "${_tx_active_config%/*}" "${_tx_active_work%/*}" || return 1
     if [ -f "$_tx_dir/had-config" ]; then
@@ -297,7 +311,7 @@ magicnet_singbox_transaction_reconcile() {
             "${_tx_active_config}.candidate-${_tx_generation}.new" 2>/dev/null || true
     fi
 
-    if [ -f "$_tx_dir/was-running" ]; then
+    if [ "$_tx_restart_required" -eq 1 ]; then
         MAGICNET_SUB_PRESERVE_REFRESH=1
         export MAGICNET_SUB_PRESERVE_REFRESH
         magicnet_singbox_restart_owned "$_tx_active_config" >/dev/null 2>&1 || {
@@ -309,7 +323,7 @@ magicnet_singbox_transaction_reconcile() {
 
     rm -rf "$_tx_dir" 2>/dev/null || return 1
     unset _tx_dir _tx_active_config _tx_active_work _tx_active_url _tx_active_local
-    unset _tx_generation _tx_tmp _tx_work_tmp _tx_work_backup
+    unset _tx_generation _tx_restart_required _tx_tmp _tx_work_tmp _tx_work_backup
 }
 
 magicnet_singbox_transaction_begin_abort() {
@@ -428,9 +442,50 @@ magicnet_singbox_fault() {
     return 1
 }
 
+magicnet_singbox_status_try_reconcile() {
+    _status_lock_was_set="${MAGICNET_CONFIG_LOCK_TIMEOUT+x}"
+    _status_old_lock_timeout="${MAGICNET_CONFIG_LOCK_TIMEOUT:-}"
+    _status_lock_timeout="${MAGICNET_SUB_STATUS_LOCK_TIMEOUT:-3}"
+    case "$_status_lock_timeout" in
+        '' | *[!0-9]*) _status_lock_timeout=3 ;;
+    esac
+    [ "$_status_lock_timeout" -le 10 ] || _status_lock_timeout=10
+    MAGICNET_CONFIG_LOCK_TIMEOUT="$_status_lock_timeout"
+    magicnet_with_config_lock magicnet_singbox_status_reconcile_locked >/dev/null 2>&1
+    _status_reconcile_rc=$?
+    if [ -n "$_status_lock_was_set" ]; then
+        MAGICNET_CONFIG_LOCK_TIMEOUT="$_status_old_lock_timeout"
+    else
+        unset MAGICNET_CONFIG_LOCK_TIMEOUT
+    fi
+    unset _status_lock_was_set _status_old_lock_timeout _status_lock_timeout
+    return "$_status_reconcile_rc"
+}
+
 magicnet_singbox_status() {
-    if ! magicnet_singbox_update_lock_active; then
-        magicnet_with_config_lock magicnet_singbox_status_reconcile_locked >/dev/null 2>&1 || true
+    _status_tx_dir=$(magicnet_singbox_transaction_dir)
+    _status_recovery_needed=0
+    [ -d "$_status_tx_dir" ] && _status_recovery_needed=1
+    [ "$(magicnet_singbox_status_value result never)" = running ] && _status_recovery_needed=1
+    if magicnet_singbox_update_lock_active; then
+        if [ "$_status_recovery_needed" -eq 1 ]; then
+            _status_recovery_result=active
+        else
+            _status_recovery_result=none
+        fi
+    elif magicnet_singbox_status_try_reconcile; then
+        if [ "$_status_recovery_needed" -eq 1 ] && [ ! -d "$_status_tx_dir" ] &&
+            [ "$(magicnet_singbox_status_value result never)" != running ]; then
+            _status_recovery_result=recovered
+        elif [ "$_status_recovery_needed" -eq 1 ]; then
+            _status_recovery_result=pending
+        else
+            _status_recovery_result=none
+        fi
+    elif [ "$_status_recovery_needed" -eq 1 ]; then
+        _status_recovery_result=pending
+    else
+        _status_recovery_result=busy
     fi
     _status_active_url="${MODDIR}/.config/sing-box/subscription.url"
     _status_active_local="${MODDIR}/.config/sing-box/subscription.local"
@@ -461,6 +516,7 @@ magicnet_singbox_status() {
     printf 'source_mode=%s\n' "$_status_source_mode"
     printf 'update_running=%s\n' "$_status_running"
     printf 'update_lock_owner=%s\n' "$_status_lock_owner"
+    printf 'recovery_result=%s\n' "$_status_recovery_result"
     printf 'last_phase=%s\n' "$(magicnet_singbox_status_value phase never)"
     printf 'last_result=%s\n' "$(magicnet_singbox_status_value result never)"
     printf 'last_attempt_epoch=%s\n' "$(magicnet_singbox_status_value attempt_epoch 0)"
@@ -490,6 +546,7 @@ magicnet_singbox_status() {
     unset _status_active_url _status_active_local _status_source_mode _status_configured
     unset _status_cache_dir _status_cache_count _status_running
     unset _status_lock_owner _status_cache_provenance_count _status_cache_probe _status_cache_source
+    unset _status_tx_dir _status_recovery_needed _status_recovery_result _status_reconcile_rc
 }
 
 magicnet_singbox_status_reconcile_locked() {
@@ -497,8 +554,14 @@ magicnet_singbox_status_reconcile_locked() {
     # status read must serialize them with an update transaction, otherwise a
     # just-started updater can race the recovery path and lose its active
     # files intermittently.
-    magicnet_singbox_transaction_reconcile >/dev/null 2>&1 || true
-    magicnet_singbox_status_reconcile >/dev/null 2>&1 || true
+    _status_locked_rc=0
+    magicnet_singbox_transaction_reconcile >/dev/null 2>&1 || _status_locked_rc=1
+    if [ "$_status_locked_rc" -eq 0 ]; then
+        magicnet_singbox_status_reconcile >/dev/null 2>&1 || _status_locked_rc=1
+    fi
+    set -- "$_status_locked_rc"
+    unset _status_locked_rc
+    return "$1"
 }
 
 magicnet_singbox_update_status() {
@@ -513,12 +576,27 @@ magicnet_singbox_update_cleanup_stage() {
     [ -n "${_sub_stage_dir:-}" ] && rm -rf "$_sub_stage_dir" 2>/dev/null || true
 }
 
+magicnet_singbox_update_interrupt() {
+    _update_interrupt_code="$1"
+    trap - EXIT HUP INT TERM
+    magicnet_singbox_transaction_reconcile >/dev/null 2>&1 || true
+    magicnet_singbox_update_cleanup_stage
+    magicnet_singbox_status_mark_interrupted
+    if command -v magicnet_config_lock_release >/dev/null 2>&1; then
+        magicnet_config_lock_release
+    fi
+    MAGICNET_CONFIG_LOCK_HELD=0
+    unset MAGICNET_CONFIG_LOCK_HELD
+    magicnet_singbox_update_lock_release
+    exit "$_update_interrupt_code"
+}
+
 magicnet_singbox_update_subscription() {
     magicnet_singbox_update_lock_acquire || return 1
     trap 'magicnet_singbox_update_lock_release' EXIT
-    trap 'magicnet_singbox_transaction_reconcile >/dev/null 2>&1 || true; magicnet_singbox_update_cleanup_stage; magicnet_singbox_status_mark_interrupted; magicnet_singbox_update_lock_release; exit 129' HUP
-    trap 'magicnet_singbox_transaction_reconcile >/dev/null 2>&1 || true; magicnet_singbox_update_cleanup_stage; magicnet_singbox_status_mark_interrupted; magicnet_singbox_update_lock_release; exit 130' INT
-    trap 'magicnet_singbox_transaction_reconcile >/dev/null 2>&1 || true; magicnet_singbox_update_cleanup_stage; magicnet_singbox_status_mark_interrupted; magicnet_singbox_update_lock_release; exit 143' TERM
+    trap 'magicnet_singbox_update_interrupt 129' HUP
+    trap 'magicnet_singbox_update_interrupt 130' INT
+    trap 'magicnet_singbox_update_interrupt 143' TERM
     if ! magicnet_with_config_lock magicnet_singbox_transaction_reconcile; then
         trap - EXIT HUP INT TERM
         magicnet_singbox_update_lock_release

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
@@ -319,11 +319,25 @@ magicnet_singbox_transaction_reconcile() {
             return 1
         }
         unset MAGICNET_SUB_PRESERVE_REFRESH
+    elif [ -f "$_tx_dir/was-running" ]; then
+        # The core can still be alive while a signal interrupts restart_owned
+        # after it removed DNS interception and the leak guard. Reapply the
+        # complete post-start policy before treating an identical config as
+        # recovered; otherwise startup would see a live core and return early
+        # with the TUN/DNS runtime only half initialized.
+        _tx_policy_rc=0
+        if command -v magicnet_after_kernel_start_unlocked >/dev/null 2>&1; then
+            magicnet_after_kernel_start_unlocked || _tx_policy_rc=1
+        else
+            magicnet_enable_dns_capture || _tx_policy_rc=1
+            magicnet_enable_dns_leak_guard || _tx_policy_rc=1
+        fi
+        [ "$_tx_policy_rc" -eq 0 ] || return 1
     fi
 
     rm -rf "$_tx_dir" 2>/dev/null || return 1
     unset _tx_dir _tx_active_config _tx_active_work _tx_active_url _tx_active_local
-    unset _tx_generation _tx_restart_required _tx_tmp _tx_work_tmp _tx_work_backup
+    unset _tx_generation _tx_restart_required _tx_policy_rc _tx_tmp _tx_work_tmp _tx_work_backup
 }
 
 magicnet_singbox_transaction_begin_abort() {
@@ -587,6 +601,11 @@ magicnet_singbox_update_interrupt() {
     fi
     MAGICNET_CONFIG_LOCK_HELD=0
     unset MAGICNET_CONFIG_LOCK_HELD
+    unset MAGICNET_SUB_DEFER_FSWATCH_RESTORE
+    if [ "${MAGICNET_SUB_FSWATCH_RESTORE_PENDING:-0}" -eq 1 ]; then
+        magicnet_singbox_supervisor_restore 1 >/dev/null 2>&1 || true
+    fi
+    unset MAGICNET_SUB_FSWATCH_RESTORE_PENDING MAGICNET_SUB_FSWATCH_WAS_ACTIVE
     magicnet_singbox_update_lock_release
     exit "$_update_interrupt_code"
 }


### PR DESCRIPTION
Fixes #119

## Summary

- terminate privileged status/update workers when the CLI parent is killed
- preserve subscription rollback traps and release held locks on interruption
- bound `sub status` recovery lock waits and report the recovery result
- reconcile stale subscription journals during service startup without restarting an already healthy core when the config is unchanged
- add regression coverage for parent death, lock/trap safety, idempotent recovery, status recovery, and startup recovery

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p magicnet-cli`
- `cargo check -p magicnet-cli`
- `cargo check -p magicnet-mcp-server`
- subscription/config lock shell regression tests
- `kam validate`
- `kam check`

The full local pre-commit wrapper still reaches an unrelated baseline failure in the pinned kamfw PID-discovery helper tests. No adb device was connected, so real-device validation was not performed.

## Summary by Sourcery

使在订阅更新被中断的情况下，能够在 CLI 终止、状态检查以及服务启动过程中安全恢复。

New Features:
- 在 `sub status` 中报告订阅恢复结果。
- 在服务启动时恢复被中断的订阅事务。

Bug Fixes:
- 当 CLI 父进程退出时，终止具有特权的 CLI worker 及其进程组。
- 在中断期间保留订阅回滚处理，并可靠地释放配置和更新锁。
- 当中断恢复发现活动配置未变化时，避免重启状态良好的核心服务。

Enhancements:
- 限制状态恢复锁的等待时间，并在和解失败时进行传播，而不是静默忽略。
- 当幂等恢复保持现有核心运行时，恢复运行时策略。

Build:
- 在 pre-commit 检查中运行 CLI 进程生命周期集成测试。

Tests:
- 增加以下场景的回归测试覆盖：父进程死亡、事务恢复、锁和信号处理器安全性、状态恢复、启动恢复、幂等恢复以及运行时策略恢复失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make interrupted subscription updates recover safely across CLI termination, status checks, and service startup.

New Features:
- Report subscription recovery outcomes in `sub status`.
- Recover interrupted subscription transactions during service startup.

Bug Fixes:
- Terminate privileged CLI workers and their process groups when the CLI parent exits.
- Preserve subscription rollback handling and reliably release configuration and update locks during interruption.
- Avoid restarting a healthy core when interrupted recovery finds the active configuration unchanged.

Enhancements:
- Bound status recovery lock waits and propagate reconciliation failures instead of silently ignoring them.
- Restore runtime policy when idempotent recovery keeps the existing core running.

Build:
- Run the CLI process-lifecycle integration test in pre-commit checks.

Tests:
- Add regression coverage for parent-process death, transaction recovery, lock and signal-handler safety, status recovery, startup recovery, idempotent recovery, and runtime-policy recovery failures.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使在订阅更新被中断的情况下，能够在 CLI 终止、状态检查以及服务启动过程中安全恢复。

New Features:
- 在 `sub status` 中报告订阅恢复结果。
- 在服务启动时恢复被中断的订阅事务。

Bug Fixes:
- 当 CLI 父进程退出时，终止具有特权的 CLI worker 及其进程组。
- 在中断期间保留订阅回滚处理，并可靠地释放配置和更新锁。
- 当中断恢复发现活动配置未变化时，避免重启状态良好的核心服务。

Enhancements:
- 限制状态恢复锁的等待时间，并在和解失败时进行传播，而不是静默忽略。
- 当幂等恢复保持现有核心运行时，恢复运行时策略。

Build:
- 在 pre-commit 检查中运行 CLI 进程生命周期集成测试。

Tests:
- 增加以下场景的回归测试覆盖：父进程死亡、事务恢复、锁和信号处理器安全性、状态恢复、启动恢复、幂等恢复以及运行时策略恢复失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make interrupted subscription updates recover safely across CLI termination, status checks, and service startup.

New Features:
- Report subscription recovery outcomes in `sub status`.
- Recover interrupted subscription transactions during service startup.

Bug Fixes:
- Terminate privileged CLI workers and their process groups when the CLI parent exits.
- Preserve subscription rollback handling and reliably release configuration and update locks during interruption.
- Avoid restarting a healthy core when interrupted recovery finds the active configuration unchanged.

Enhancements:
- Bound status recovery lock waits and propagate reconciliation failures instead of silently ignoring them.
- Restore runtime policy when idempotent recovery keeps the existing core running.

Build:
- Run the CLI process-lifecycle integration test in pre-commit checks.

Tests:
- Add regression coverage for parent-process death, transaction recovery, lock and signal-handler safety, status recovery, startup recovery, idempotent recovery, and runtime-policy recovery failures.

</details>

</details>

新特性：
- 在 `sub status` 中报告订阅恢复结果。
- 在服务启动时恢复被中断的订阅事务。

缺陷修复：
- 当 CLI 父进程退出时，终止特权 CLI worker 及其进程组。
- 在中断期间保留订阅回滚处理程序，并可靠地释放配置和更新锁。
- 当中断恢复发现当前配置未发生变化时，避免重启健康的核心服务。

改进：
- 为状态恢复锁等待设置上限，并在和解失败时进行传播，而非静默忽略。

构建：
- 在 pre-commit 检查中运行 CLI 进程生命周期集成测试。

测试：
- 增加针对父进程死亡、事务恢复、锁与信号处理器安全性、状态恢复、启动恢复、幂等恢复以及运行时策略恢复失败的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使在订阅更新被中断的情况下，能够在 CLI 终止、状态检查以及服务启动过程中安全恢复。

New Features:
- 在 `sub status` 中报告订阅恢复结果。
- 在服务启动时恢复被中断的订阅事务。

Bug Fixes:
- 当 CLI 父进程退出时，终止具有特权的 CLI worker 及其进程组。
- 在中断期间保留订阅回滚处理，并可靠地释放配置和更新锁。
- 当中断恢复发现活动配置未变化时，避免重启状态良好的核心服务。

Enhancements:
- 限制状态恢复锁的等待时间，并在和解失败时进行传播，而不是静默忽略。
- 当幂等恢复保持现有核心运行时，恢复运行时策略。

Build:
- 在 pre-commit 检查中运行 CLI 进程生命周期集成测试。

Tests:
- 增加以下场景的回归测试覆盖：父进程死亡、事务恢复、锁和信号处理器安全性、状态恢复、启动恢复、幂等恢复以及运行时策略恢复失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make interrupted subscription updates recover safely across CLI termination, status checks, and service startup.

New Features:
- Report subscription recovery outcomes in `sub status`.
- Recover interrupted subscription transactions during service startup.

Bug Fixes:
- Terminate privileged CLI workers and their process groups when the CLI parent exits.
- Preserve subscription rollback handling and reliably release configuration and update locks during interruption.
- Avoid restarting a healthy core when interrupted recovery finds the active configuration unchanged.

Enhancements:
- Bound status recovery lock waits and propagate reconciliation failures instead of silently ignoring them.
- Restore runtime policy when idempotent recovery keeps the existing core running.

Build:
- Run the CLI process-lifecycle integration test in pre-commit checks.

Tests:
- Add regression coverage for parent-process death, transaction recovery, lock and signal-handler safety, status recovery, startup recovery, idempotent recovery, and runtime-policy recovery failures.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使在订阅更新被中断的情况下，能够在 CLI 终止、状态检查以及服务启动过程中安全恢复。

New Features:
- 在 `sub status` 中报告订阅恢复结果。
- 在服务启动时恢复被中断的订阅事务。

Bug Fixes:
- 当 CLI 父进程退出时，终止具有特权的 CLI worker 及其进程组。
- 在中断期间保留订阅回滚处理，并可靠地释放配置和更新锁。
- 当中断恢复发现活动配置未变化时，避免重启状态良好的核心服务。

Enhancements:
- 限制状态恢复锁的等待时间，并在和解失败时进行传播，而不是静默忽略。
- 当幂等恢复保持现有核心运行时，恢复运行时策略。

Build:
- 在 pre-commit 检查中运行 CLI 进程生命周期集成测试。

Tests:
- 增加以下场景的回归测试覆盖：父进程死亡、事务恢复、锁和信号处理器安全性、状态恢复、启动恢复、幂等恢复以及运行时策略恢复失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make interrupted subscription updates recover safely across CLI termination, status checks, and service startup.

New Features:
- Report subscription recovery outcomes in `sub status`.
- Recover interrupted subscription transactions during service startup.

Bug Fixes:
- Terminate privileged CLI workers and their process groups when the CLI parent exits.
- Preserve subscription rollback handling and reliably release configuration and update locks during interruption.
- Avoid restarting a healthy core when interrupted recovery finds the active configuration unchanged.

Enhancements:
- Bound status recovery lock waits and propagate reconciliation failures instead of silently ignoring them.
- Restore runtime policy when idempotent recovery keeps the existing core running.

Build:
- Run the CLI process-lifecycle integration test in pre-commit checks.

Tests:
- Add regression coverage for parent-process death, transaction recovery, lock and signal-handler safety, status recovery, startup recovery, idempotent recovery, and runtime-policy recovery failures.

</details>

</details>

</details>

新特性：
- 在 `sub status` 中报告订阅恢复结果。
- 在服务启动期间恢复被中断的订阅事务。

错误修复：
- 确保在父进程被杀死时，特权 CLI worker 能够终止。
- 在中断期间保留订阅回滚处理程序，并可靠地释放配置和更新锁。
- 当中断恢复发现活动配置未发生变化时，避免重启健康的核心进程。

改进：
- 限制状态恢复锁的等待时间，并传播对账失败，而不是静默忽略。

构建：
- 在 pre-commit 检查中运行 CLI 进程生命周期集成测试。

测试：
- 增加以下场景的回归覆盖：父进程死亡、事务恢复、锁与信号处理器安全性、状态恢复、启动恢复以及幂等恢复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使在订阅更新被中断的情况下，能够在 CLI 终止、状态检查以及服务启动过程中安全恢复。

New Features:
- 在 `sub status` 中报告订阅恢复结果。
- 在服务启动时恢复被中断的订阅事务。

Bug Fixes:
- 当 CLI 父进程退出时，终止具有特权的 CLI worker 及其进程组。
- 在中断期间保留订阅回滚处理，并可靠地释放配置和更新锁。
- 当中断恢复发现活动配置未变化时，避免重启状态良好的核心服务。

Enhancements:
- 限制状态恢复锁的等待时间，并在和解失败时进行传播，而不是静默忽略。
- 当幂等恢复保持现有核心运行时，恢复运行时策略。

Build:
- 在 pre-commit 检查中运行 CLI 进程生命周期集成测试。

Tests:
- 增加以下场景的回归测试覆盖：父进程死亡、事务恢复、锁和信号处理器安全性、状态恢复、启动恢复、幂等恢复以及运行时策略恢复失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make interrupted subscription updates recover safely across CLI termination, status checks, and service startup.

New Features:
- Report subscription recovery outcomes in `sub status`.
- Recover interrupted subscription transactions during service startup.

Bug Fixes:
- Terminate privileged CLI workers and their process groups when the CLI parent exits.
- Preserve subscription rollback handling and reliably release configuration and update locks during interruption.
- Avoid restarting a healthy core when interrupted recovery finds the active configuration unchanged.

Enhancements:
- Bound status recovery lock waits and propagate reconciliation failures instead of silently ignoring them.
- Restore runtime policy when idempotent recovery keeps the existing core running.

Build:
- Run the CLI process-lifecycle integration test in pre-commit checks.

Tests:
- Add regression coverage for parent-process death, transaction recovery, lock and signal-handler safety, status recovery, startup recovery, idempotent recovery, and runtime-policy recovery failures.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使在订阅更新被中断的情况下，能够在 CLI 终止、状态检查以及服务启动过程中安全恢复。

New Features:
- 在 `sub status` 中报告订阅恢复结果。
- 在服务启动时恢复被中断的订阅事务。

Bug Fixes:
- 当 CLI 父进程退出时，终止具有特权的 CLI worker 及其进程组。
- 在中断期间保留订阅回滚处理，并可靠地释放配置和更新锁。
- 当中断恢复发现活动配置未变化时，避免重启状态良好的核心服务。

Enhancements:
- 限制状态恢复锁的等待时间，并在和解失败时进行传播，而不是静默忽略。
- 当幂等恢复保持现有核心运行时，恢复运行时策略。

Build:
- 在 pre-commit 检查中运行 CLI 进程生命周期集成测试。

Tests:
- 增加以下场景的回归测试覆盖：父进程死亡、事务恢复、锁和信号处理器安全性、状态恢复、启动恢复、幂等恢复以及运行时策略恢复失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make interrupted subscription updates recover safely across CLI termination, status checks, and service startup.

New Features:
- Report subscription recovery outcomes in `sub status`.
- Recover interrupted subscription transactions during service startup.

Bug Fixes:
- Terminate privileged CLI workers and their process groups when the CLI parent exits.
- Preserve subscription rollback handling and reliably release configuration and update locks during interruption.
- Avoid restarting a healthy core when interrupted recovery finds the active configuration unchanged.

Enhancements:
- Bound status recovery lock waits and propagate reconciliation failures instead of silently ignoring them.
- Restore runtime policy when idempotent recovery keeps the existing core running.

Build:
- Run the CLI process-lifecycle integration test in pre-commit checks.

Tests:
- Add regression coverage for parent-process death, transaction recovery, lock and signal-handler safety, status recovery, startup recovery, idempotent recovery, and runtime-policy recovery failures.

</details>

</details>

新特性：
- 在 `sub status` 中报告订阅恢复结果。
- 在服务启动时恢复被中断的订阅事务。

缺陷修复：
- 当 CLI 父进程退出时，终止特权 CLI worker 及其进程组。
- 在中断期间保留订阅回滚处理程序，并可靠地释放配置和更新锁。
- 当中断恢复发现当前配置未发生变化时，避免重启健康的核心服务。

改进：
- 为状态恢复锁等待设置上限，并在和解失败时进行传播，而非静默忽略。

构建：
- 在 pre-commit 检查中运行 CLI 进程生命周期集成测试。

测试：
- 增加针对父进程死亡、事务恢复、锁与信号处理器安全性、状态恢复、启动恢复、幂等恢复以及运行时策略恢复失败的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使在订阅更新被中断的情况下，能够在 CLI 终止、状态检查以及服务启动过程中安全恢复。

New Features:
- 在 `sub status` 中报告订阅恢复结果。
- 在服务启动时恢复被中断的订阅事务。

Bug Fixes:
- 当 CLI 父进程退出时，终止具有特权的 CLI worker 及其进程组。
- 在中断期间保留订阅回滚处理，并可靠地释放配置和更新锁。
- 当中断恢复发现活动配置未变化时，避免重启状态良好的核心服务。

Enhancements:
- 限制状态恢复锁的等待时间，并在和解失败时进行传播，而不是静默忽略。
- 当幂等恢复保持现有核心运行时，恢复运行时策略。

Build:
- 在 pre-commit 检查中运行 CLI 进程生命周期集成测试。

Tests:
- 增加以下场景的回归测试覆盖：父进程死亡、事务恢复、锁和信号处理器安全性、状态恢复、启动恢复、幂等恢复以及运行时策略恢复失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make interrupted subscription updates recover safely across CLI termination, status checks, and service startup.

New Features:
- Report subscription recovery outcomes in `sub status`.
- Recover interrupted subscription transactions during service startup.

Bug Fixes:
- Terminate privileged CLI workers and their process groups when the CLI parent exits.
- Preserve subscription rollback handling and reliably release configuration and update locks during interruption.
- Avoid restarting a healthy core when interrupted recovery finds the active configuration unchanged.

Enhancements:
- Bound status recovery lock waits and propagate reconciliation failures instead of silently ignoring them.
- Restore runtime policy when idempotent recovery keeps the existing core running.

Build:
- Run the CLI process-lifecycle integration test in pre-commit checks.

Tests:
- Add regression coverage for parent-process death, transaction recovery, lock and signal-handler safety, status recovery, startup recovery, idempotent recovery, and runtime-policy recovery failures.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使在订阅更新被中断的情况下，能够在 CLI 终止、状态检查以及服务启动过程中安全恢复。

New Features:
- 在 `sub status` 中报告订阅恢复结果。
- 在服务启动时恢复被中断的订阅事务。

Bug Fixes:
- 当 CLI 父进程退出时，终止具有特权的 CLI worker 及其进程组。
- 在中断期间保留订阅回滚处理，并可靠地释放配置和更新锁。
- 当中断恢复发现活动配置未变化时，避免重启状态良好的核心服务。

Enhancements:
- 限制状态恢复锁的等待时间，并在和解失败时进行传播，而不是静默忽略。
- 当幂等恢复保持现有核心运行时，恢复运行时策略。

Build:
- 在 pre-commit 检查中运行 CLI 进程生命周期集成测试。

Tests:
- 增加以下场景的回归测试覆盖：父进程死亡、事务恢复、锁和信号处理器安全性、状态恢复、启动恢复、幂等恢复以及运行时策略恢复失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make interrupted subscription updates recover safely across CLI termination, status checks, and service startup.

New Features:
- Report subscription recovery outcomes in `sub status`.
- Recover interrupted subscription transactions during service startup.

Bug Fixes:
- Terminate privileged CLI workers and their process groups when the CLI parent exits.
- Preserve subscription rollback handling and reliably release configuration and update locks during interruption.
- Avoid restarting a healthy core when interrupted recovery finds the active configuration unchanged.

Enhancements:
- Bound status recovery lock waits and propagate reconciliation failures instead of silently ignoring them.
- Restore runtime policy when idempotent recovery keeps the existing core running.

Build:
- Run the CLI process-lifecycle integration test in pre-commit checks.

Tests:
- Add regression coverage for parent-process death, transaction recovery, lock and signal-handler safety, status recovery, startup recovery, idempotent recovery, and runtime-policy recovery failures.

</details>

</details>

</details>

</details>