### PR TITLE
refactor(webui): 抽出共享 UI 原语并统一页面视觉

### DIFF
--- a/crates/magicnet-cli/src/base64.rs
+++ b/crates/magicnet-cli/src/base64.rs
@@ -46,7 +46,7 @@ pub(crate) fn decode_base64(input: &str) -> Result<Vec<u8>, String> {
     }
 
     let mut out = Vec::with_capacity(data.len() * 3 / 4);
-    for chunk in data.chunks_exact(4) {
+    for chunk in data.as_chunks::<4>().0 {
         let a = value(chunk[0])? as u32;
         let b = value(chunk[1])? as u32;
         let c = value(chunk[2])? as u32;

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -26,6 +26,8 @@ import OnboardingDialog from "@/components/OnboardingDialog.vue";
 import OpenSourceSupportNote from "@/components/OpenSourceSupportNote.vue";
 import Badge from "@/components/ui/Badge.vue";
 import Button from "@/components/ui/Button.vue";
+import Eyebrow from "@/components/ui/Eyebrow.vue";
+import StatusDot from "@/components/ui/StatusDot.vue";
 import IssueReporterDialog from "@/components/IssueReporterDialog.vue";
 import { useMagicNet } from "@/composables/useMagicNet";
 import { useTheme } from "@/composables/useTheme";
@@ -152,10 +154,10 @@ const runtimeStateLabel = computed(() => {
   return "状态未知";
 });
 
-const statusDotClass = computed(() => {
-  if (state.runtime.singBoxState === "sing-box") return "mn-status-dot-ok";
-  if (state.runtime.singBoxState === "stopped") return "mn-status-dot-stop";
-  return "mn-status-dot-unknown";
+const statusDotTone = computed(() => {
+  if (state.runtime.singBoxState === "sing-box") return "ok" as const;
+  if (state.runtime.singBoxState === "stopped") return "stop" as const;
+  return "unknown" as const;
 });
 
 function setTab(tab: TabKey): void {
@@ -437,9 +439,9 @@ onUnmounted(() => {
         <div class="rounded-[0.95rem] bg-[color-mix(in_srgb,var(--mn-cactus)_34%,var(--mn-carrier))] px-4 py-3">
           <div class="flex items-center justify-between gap-3">
             <div class="min-w-0 flex-1">
-              <span class="text-[9px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-faint)]">运行状态</span>
+              <Eyebrow tone="faint">运行状态</Eyebrow>
               <div class="mt-1.5 flex min-w-0 items-center gap-2.5">
-                <span :class="['size-2.5 shrink-0 rounded-full', statusDotClass]" />
+                <StatusDot :tone="statusDotTone" />
                 <strong class="w-0 min-w-0 flex-1 truncate text-lg font-semibold tracking-[-0.03em] text-[var(--mn-ink)]">
                   {{ runtimeStateLabel }}
                 </strong>
@@ -451,11 +453,11 @@ onUnmounted(() => {
 
         <div class="grid min-w-0 grid-cols-2 gap-2 px-2 pb-2 md:px-3 md:pb-0">
           <div class="min-w-0">
-            <span class="text-[9px] font-semibold uppercase tracking-[0.2em] text-[var(--mn-ink-faint)]">模式</span>
+            <Eyebrow tone="faint">模式</Eyebrow>
             <code class="mn-code mt-1 block truncate text-xs md:text-sm">TUN</code>
           </div>
           <div class="min-w-0">
-            <span class="text-[9px] font-semibold uppercase tracking-[0.2em] text-[var(--mn-ink-faint)]">核心</span>
+            <Eyebrow tone="faint">核心</Eyebrow>
             <code class="mn-code mt-1 block truncate text-xs md:text-sm">{{ state.runtime.singBox }}</code>
           </div>
           <div class="col-span-2 flex min-w-0 items-center gap-2 text-xs leading-5 text-[var(--mn-ink-muted)] md:text-sm">
@@ -478,7 +480,7 @@ onUnmounted(() => {
 
     <main class="grid min-w-0 gap-5 md:grid-cols-[204px_minmax(0,1fr)] md:items-start md:gap-6">
       <nav class="desktop-rail mn-chrome sticky top-36 hidden gap-1 rounded-[1.25rem] p-2 md:grid" aria-label="MagicNet 页面">
-        <div class="px-3 pb-1 pt-2 text-[9px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-faint)]">常用工作区</div>
+        <div class="px-3 pb-1 pt-2"><Eyebrow tone="faint">常用工作区</Eyebrow></div>
         <button
           v-for="item in primaryTabs"
           :key="item.key"
@@ -495,7 +497,7 @@ onUnmounted(() => {
           <span class="min-w-0 truncate">{{ item.label }}</span>
         </button>
 
-        <div class="mt-3 px-3 pb-1 text-[9px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-faint)]">进阶工具</div>
+        <div class="mt-3 px-3 pb-1"><Eyebrow tone="faint">进阶工具</Eyebrow></div>
         <button
           v-for="item in advancedTabs"
           :key="item.key"
@@ -566,11 +568,11 @@ onUnmounted(() => {
 
     <Transition name="sheet">
       <div v-if="showAdvancedNav" class="fixed inset-0 z-40 md:hidden">
-        <button class="absolute inset-0 size-full bg-[color-mix(in_srgb,var(--mn-ink)_35%,transparent)]" type="button" aria-label="关闭进阶导航" @click="closeAdvancedNav()" />
+        <button class="mn-overlay absolute inset-0 size-full" type="button" aria-label="关闭进阶导航" @click="closeAdvancedNav()" />
         <div ref="advancedDialog" class="mn-chrome-raised absolute inset-x-3 bottom-[max(0.75rem,env(safe-area-inset-bottom))] rounded-[1.5rem] p-2 pb-2.5" role="dialog" aria-modal="true" aria-label="进阶导航" tabindex="-1">
           <div class="flex items-center justify-between px-3 pb-2 pt-2">
             <div>
-              <span class="text-[9px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-faint)]">更多工作区</span>
+              <Eyebrow tone="faint">更多工作区</Eyebrow>
               <h2 class="mt-1 text-lg font-semibold tracking-[-0.03em] text-[var(--mn-ink)]">进阶工具</h2>
             </div>
             <Button data-dialog-initial-focus variant="ghost" size="icon" aria-label="关闭进阶导航" @click="closeAdvancedNav()"><X :size="18" /></Button>

--- a/webui/src/components/IssueReporterDialog.vue
+++ b/webui/src/components/IssueReporterDialog.vue
@@ -2,6 +2,9 @@
 import { computed, nextTick, onMounted, onUnmounted, ref } from "vue";
 import { Bug, ShieldCheck, X } from "lucide-vue-next";
 import Button from "@/components/ui/Button.vue";
+import Eyebrow from "@/components/ui/Eyebrow.vue";
+import Field from "@/components/ui/Field.vue";
+import Textarea from "@/components/ui/Textarea.vue";
 import { trapFocusWithin } from "@/lib/focus";
 import {
   ISSUE_KIND_OPTIONS,
@@ -60,7 +63,7 @@ onUnmounted(() => {
 <template>
   <div class="fixed inset-0 z-[70] grid place-items-end p-3 sm:place-items-center sm:p-6">
     <button
-      class="absolute inset-0 size-full bg-[color-mix(in_srgb,var(--mn-ink)_42%,transparent)]"
+      class="mn-overlay absolute inset-0 size-full"
       type="button"
       aria-label="取消创建 Issue"
       @click="emit('cancel')"
@@ -79,9 +82,9 @@ onUnmounted(() => {
       <div class="rounded-[5px] bg-[var(--mn-ivory)] p-4 sm:p-5">
         <div class="flex items-start justify-between gap-4">
           <div class="min-w-0">
-            <span class="inline-flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--mn-clay-ink)]">
+            <Eyebrow tone="clay" class="inline-flex items-center gap-2">
               <Bug :size="14" /> Issue Context
-            </span>
+            </Eyebrow>
             <h2 id="issue-reporter-title" class="mt-2 text-xl font-semibold tracking-[-0.03em] text-[var(--mn-ink)]">
               你遇到了哪类问题？
             </h2>
@@ -100,10 +103,10 @@ onUnmounted(() => {
             v-for="option in ISSUE_KIND_OPTIONS"
             :key="option.value"
             :class="[
-              'grid cursor-pointer grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 rounded-md border p-3 transition-colors',
+              'mn-choice grid cursor-pointer grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 rounded-md p-3 transition-colors',
               selected === option.value
-                ? 'border-[var(--mn-cactus)] bg-[color-mix(in_srgb,var(--mn-cactus)_12%,var(--mn-ivory))]'
-                : 'border-[var(--mn-border)] bg-[var(--mn-carrier)] hover:bg-[var(--mn-carrier-deep)]',
+                ? 'mn-choice-active'
+                : 'hover:bg-[var(--mn-carrier-deep)]',
             ]"
           >
             <input
@@ -124,64 +127,58 @@ onUnmounted(() => {
         </fieldset>
 
         <div class="mt-4 grid gap-3 border-t border-[var(--mn-border)] pt-4">
-          <div>
-            <label for="issue-summary" class="block text-sm font-semibold text-[var(--mn-ink)]">
-              问题概述 <span class="text-[var(--mn-clay-ink)]">*</span>
-            </label>
-            <textarea
+          <Field
+            label="问题概述"
+            hint="用一句话说明看到的现象；这是必填项。"
+            hint-id="issue-summary-hint"
+            required
+            for-id="issue-summary"
+          >
+            <Textarea
               id="issue-summary"
               v-model="summary"
-              class="mt-1.5 min-h-20 w-full resize-y rounded-md border border-[var(--mn-border)] bg-[var(--mn-carrier)] px-3 py-2 text-sm leading-6 text-[var(--mn-ink)] outline-none transition-colors placeholder:text-[var(--mn-ink-faint)] focus:border-[var(--mn-cactus)] focus:ring-2 focus:ring-[color-mix(in_srgb,var(--mn-cactus)_22%,transparent)]"
+              class="min-h-20"
               maxlength="240"
               placeholder="例如：更新订阅后节点数量变成 0，sing-box 没有启动"
               aria-describedby="issue-summary-hint"
               @keydown.ctrl.enter="confirm"
             />
-            <p id="issue-summary-hint" class="mt-1 text-xs leading-5 text-[var(--mn-ink-muted)]">
-              用一句话说明看到的现象；这是必填项。
-            </p>
-          </div>
+          </Field>
 
           <div class="grid gap-3 sm:grid-cols-2">
-            <label class="grid gap-1.5">
-              <span class="text-sm font-semibold text-[var(--mn-ink)]">复现步骤</span>
-              <textarea
+            <Field label="复现步骤">
+              <Textarea
                 v-model="reproduction"
-                class="min-h-28 w-full resize-y rounded-md border border-[var(--mn-border)] bg-[var(--mn-carrier)] px-3 py-2 text-sm leading-6 text-[var(--mn-ink)] outline-none transition-colors placeholder:text-[var(--mn-ink-faint)] focus:border-[var(--mn-cactus)] focus:ring-2 focus:ring-[color-mix(in_srgb,var(--mn-cactus)_22%,transparent)]"
                 maxlength="1200"
                 placeholder="1. 做了什么操作？&#10;2. 何时开始异常？&#10;3. 是否每次都能复现？"
               />
-            </label>
-            <label class="grid gap-1.5">
-              <span class="text-sm font-semibold text-[var(--mn-ink)]">期望结果</span>
-              <textarea
+            </Field>
+            <Field label="期望结果">
+              <Textarea
                 v-model="expected"
-                class="min-h-28 w-full resize-y rounded-md border border-[var(--mn-border)] bg-[var(--mn-carrier)] px-3 py-2 text-sm leading-6 text-[var(--mn-ink)] outline-none transition-colors placeholder:text-[var(--mn-ink-faint)] focus:border-[var(--mn-cactus)] focus:ring-2 focus:ring-[color-mix(in_srgb,var(--mn-cactus)_22%,transparent)]"
                 maxlength="600"
                 placeholder="例如：订阅应导入节点并启动 sing-box。"
               />
-            </label>
+            </Field>
           </div>
 
           <div class="grid gap-3 sm:grid-cols-2">
-            <label class="grid gap-1.5">
-              <span class="text-sm font-semibold text-[var(--mn-ink)]">实际结果</span>
-              <textarea
+            <Field label="实际结果">
+              <Textarea
                 v-model="actual"
-                class="min-h-24 w-full resize-y rounded-md border border-[var(--mn-border)] bg-[var(--mn-carrier)] px-3 py-2 text-sm leading-6 text-[var(--mn-ink)] outline-none transition-colors placeholder:text-[var(--mn-ink-faint)] focus:border-[var(--mn-cactus)] focus:ring-2 focus:ring-[color-mix(in_srgb,var(--mn-cactus)_22%,transparent)]"
+                class="min-h-24"
                 maxlength="800"
                 placeholder="例如：报告 last_reason=no_supported_nodes，核心 stopped。"
               />
-            </label>
-            <label class="grid gap-1.5">
-              <span class="text-sm font-semibold text-[var(--mn-ink)]">发生频率 / 影响范围</span>
-              <textarea
+            </Field>
+            <Field label="发生频率 / 影响范围">
+              <Textarea
                 v-model="frequency"
-                class="min-h-24 w-full resize-y rounded-md border border-[var(--mn-border)] bg-[var(--mn-carrier)] px-3 py-2 text-sm leading-6 text-[var(--mn-ink)] outline-none transition-colors placeholder:text-[var(--mn-ink-faint)] focus:border-[var(--mn-cactus)] focus:ring-2 focus:ring-[color-mix(in_srgb,var(--mn-cactus)_22%,transparent)]"
+                class="min-h-24"
                 maxlength="400"
                 placeholder="例如：仅 Android 15、只影响某个订阅、每次更新都会发生。"
               />
-            </label>
+            </Field>
           </div>
         </div>
 

--- a/webui/src/components/OnboardingDialog.vue
+++ b/webui/src/components/OnboardingDialog.vue
@@ -2,6 +2,8 @@
 import { computed, nextTick, onMounted, onUnmounted, ref } from "vue";
 import { ArrowRight, CheckCircle2, DownloadCloud, Gauge, Stethoscope, Terminal, X } from "lucide-vue-next";
 import Button from "@/components/ui/Button.vue";
+import Eyebrow from "@/components/ui/Eyebrow.vue";
+import StatusDot from "@/components/ui/StatusDot.vue";
 import { trapFocusWithin } from "@/lib/focus";
 
 type GuideTarget = "subs" | "control" | "health" | "output";
@@ -117,7 +119,7 @@ onUnmounted(() => {
 <template>
   <div class="fixed inset-0 z-[70] grid place-items-end p-3 sm:place-items-center sm:p-6">
     <button
-      class="absolute inset-0 size-full bg-[color-mix(in_srgb,var(--mn-ink)_42%,transparent)]"
+      class="mn-overlay absolute inset-0 size-full"
       type="button"
       aria-label="关闭新手引导"
       @click="emit('dismiss')"
@@ -136,9 +138,9 @@ onUnmounted(() => {
       <div class="rounded-[5px] bg-[var(--mn-ivory)] p-4 sm:p-5">
         <div class="flex items-start justify-between gap-4">
           <div class="min-w-0">
-            <span class="inline-flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--mn-clay-ink)]">
+            <Eyebrow tone="clay" class="inline-flex items-center gap-2">
               <CheckCircle2 :size="14" /> 新手引导
-            </span>
+            </Eyebrow>
             <h2 id="onboarding-title" class="mt-2 text-xl font-semibold tracking-[-0.03em] text-[var(--mn-ink)]">
               第一次使用 MagicNet
             </h2>
@@ -157,17 +159,15 @@ onUnmounted(() => {
               v-for="(step, index) in steps"
               :key="step.title"
               :class="[
-                'rounded-md border p-3 text-left',
-                index === currentStep
-                  ? 'border-[var(--mn-cactus)] bg-[color-mix(in_srgb,var(--mn-cactus)_12%,var(--mn-ivory))]'
-                  : 'border-[var(--mn-border)] bg-[var(--mn-carrier)] text-[var(--mn-ink-soft)]',
+                'mn-choice rounded-md p-3 text-left',
+                index === currentStep ? 'mn-choice-active' : 'text-[var(--mn-ink-soft)]',
               ]"
             >
               <div class="flex items-center justify-between gap-3">
                 <strong class="text-sm font-semibold text-[var(--mn-ink)]">{{ index + 1 }}. {{ step.title }}</strong>
-                <span class="shrink-0 whitespace-nowrap text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--mn-clay-ink)]">
+                <Eyebrow tone="clay" class="shrink-0 whitespace-nowrap tracking-[0.16em]">
                   {{ index === currentStep ? "当前" : "待完成" }}
-                </span>
+                </Eyebrow>
               </div>
               <p class="mt-1 text-xs leading-5 text-[var(--mn-ink-muted)]">{{ step.eyebrow }}</p>
             </li>
@@ -175,9 +175,9 @@ onUnmounted(() => {
 
           <article class="rounded-md border border-[var(--mn-border)] bg-[var(--mn-carrier)] p-4 sm:p-5">
             <div class="flex flex-wrap items-center justify-between gap-3">
-              <span class="text-[10px] font-semibold uppercase tracking-[0.2em] text-[var(--mn-clay-ink)]">{{ progressLabel }}</span>
+              <Eyebrow tone="clay">{{ progressLabel }}</Eyebrow>
               <div class="flex items-center gap-2 text-xs text-[var(--mn-ink-muted)]">
-                <span class="inline-flex size-2.5 rounded-full bg-[var(--mn-cactus)]" aria-hidden="true" />
+                <StatusDot tone="ok" />
                 <span>可随时重新打开，不会修改现有运行状态</span>
               </div>
             </div>

--- a/webui/src/components/OpenSourceSupportNote.vue
+++ b/webui/src/components/OpenSourceSupportNote.vue
@@ -7,7 +7,7 @@
       class="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 rounded-[0.95rem] bg-[color-mix(in_srgb,var(--mn-ink)_3%,transparent)] px-4 py-3 text-left text-[var(--mn-ink)] transition-[background-color,transform,opacity] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--mn-cactus)_70%,var(--mn-ink))] active:scale-[0.99]"
     >
       <span class="min-w-0">
-        <span class="block text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--mn-ink-faint)]">可选</span>
+        <span class="mn-eyebrow mn-eyebrow-faint block tracking-[0.18em]">可选</span>
         <span class="mt-1 block text-sm font-semibold text-[var(--mn-ink)]">关于 MagicNet 的维护与支持</span>
       </span>
       <span

--- a/webui/src/components/pages/AppsPage.vue
+++ b/webui/src/components/pages/AppsPage.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
-import { CheckCheck, CheckCircle2, Copy, ListFilter, Plus, RefreshCw, RotateCcw, Search, ShieldCheck, Trash2, X } from "lucide-vue-next";
+import { CheckCheck, CheckCircle2, Copy, ListFilter, Plus, RefreshCw, RotateCcw, ShieldCheck, Trash2, X } from "lucide-vue-next";
 import { computed, onMounted, ref } from "vue";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
+import ConfirmPanel from "@/components/ui/ConfirmPanel.vue";
 import Input from "@/components/ui/Input.vue";
+import InsightChip from "@/components/ui/InsightChip.vue";
 import PageHeader from "@/components/ui/PageHeader.vue";
+import RemovableTag from "@/components/ui/RemovableTag.vue";
+import SearchField from "@/components/ui/SearchField.vue";
 import { useActionLock } from "@/composables/useActionLock";
 import { useMagicNet } from "@/composables/useMagicNet";
 import { copyText, execFailed, redactedCliPreview } from "@/utils";
@@ -441,44 +445,40 @@ onMounted(() => {
       <Transition name="sheet">
         <div v-if="pendingAppAction" class="fixed inset-0 z-[70]" role="presentation">
           <button
-            class="absolute inset-0 size-full bg-[color-mix(in_srgb,var(--mn-ink)_38%,transparent)]"
+            class="mn-overlay absolute inset-0 size-full"
             type="button"
             aria-label="取消应用策略操作"
             @click="cancelAppAction"
           />
           <div
-            class="mn-chrome absolute inset-x-3 bottom-[max(1rem,env(safe-area-inset-bottom))] mx-auto grid max-h-[min(80dvh,680px)] max-w-3xl gap-3 overflow-auto rounded-md p-1"
+            class="absolute inset-x-3 bottom-[max(1rem,env(safe-area-inset-bottom))] mx-auto max-h-[min(80dvh,680px)] max-w-3xl overflow-auto"
             role="dialog"
             aria-modal="true"
             aria-labelledby="app-policy-confirm-title"
           >
-            <div class="rounded-[5px] bg-[color-mix(in_srgb,var(--mn-warning)_14%,var(--mn-carrier))] p-4">
-              <span class="text-[11px] font-bold uppercase tracking-wide text-[var(--mn-warning)]">Confirm app policy</span>
-              <p id="app-policy-confirm-title" class="mt-1 text-sm leading-6 text-[var(--mn-warning)]">{{ pendingAppAction.message }}</p>
-              <code class="mt-2 block break-all rounded-md bg-[var(--mn-ivory)]/60 px-3 py-2 text-xs text-[var(--mn-ink)]">{{ pendingAppAction.command }}</code>
-              <div class="mt-3 grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-5">
-                <span
+            <ConfirmPanel
+              title="Confirm app policy"
+              :detail="pendingAppAction.message"
+              :command="pendingAppAction.command"
+              :loading="isRunning(pendingAppAction.key)"
+              confirm-variant="secondary"
+              @cancel="cancelAppAction"
+              @confirm="confirmAppAction"
+            >
+              <p id="app-policy-confirm-title" class="sr-only">{{ pendingAppAction.message }}</p>
+              <div class="mt-3 flex flex-wrap gap-2">
+                <InsightChip
                   v-for="item in pendingAppAction.plan.items"
                   :key="item.label"
-                  class="rounded border px-2 py-1"
-                  :class="{
-                    'mn-chip-ok': item.tone === 'success',
-                    'mn-chip-warn': item.tone === 'warning',
-                    'border-[color-mix(in_srgb,var(--mn-coral)_70%,transparent)] text-[var(--mn-danger)]': item.tone === 'danger',
-                    'mn-chip-neutral': item.tone === 'neutral',
-                  }"
-                >
-                  {{ item.label }}: <b class="font-medium">{{ item.value }}</b>
-                </span>
+                  :label="item.label"
+                  :value="item.value"
+                  :tone="item.tone"
+                />
               </div>
               <p v-if="pendingAppAction.plan.warnings.length" class="mt-2 text-xs leading-5 text-[var(--mn-warning)]/80">
                 {{ pendingAppAction.plan.warnings.join("；") }}
               </p>
-              <div class="mt-4 grid grid-cols-2 gap-2">
-                <Button variant="secondary" :loading="isRunning(pendingAppAction.key)" @click="confirmAppAction">确认执行</Button>
-                <Button variant="outline" @click="cancelAppAction">取消</Button>
-              </div>
-            </div>
+            </ConfirmPanel>
           </div>
         </div>
       </Transition>
@@ -486,7 +486,7 @@ onMounted(() => {
 
     <Card class="grid gap-3">
       <div class="flex flex-wrap items-center gap-3">
-        <div class="inline-flex w-fit rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] p-1">
+        <div class="mn-segmented">
           <button class="min-h-12 whitespace-nowrap rounded px-3 text-sm font-medium text-[var(--mn-ink-muted)] transition-colors disabled:cursor-progress disabled:opacity-60" :disabled="isRunning('mode-blacklist') || state.appPolicy.mode === 'blacklist'" :class="{ 'bg-[var(--mn-cactus)] text-[var(--mn-on-accent)]': state.appPolicy.mode === 'blacklist' }" @click="requestSetMode('blacklist')">全局接管</button>
           <button class="min-h-12 whitespace-nowrap rounded px-3 text-sm font-medium text-[var(--mn-ink-muted)] transition-colors disabled:cursor-progress disabled:opacity-60" :disabled="isRunning('mode-whitelist') || state.appPolicy.mode === 'whitelist'" :class="{ 'bg-[var(--mn-cactus)] text-[var(--mn-on-accent)]': state.appPolicy.mode === 'whitelist' }" @click="requestSetMode('whitelist')">仅名单接管</button>
         </div>
@@ -518,20 +518,14 @@ onMounted(() => {
           {{ policySummary.conflicts.length ? `${policySummary.conflicts.length} 个冲突` : '无冲突' }}
         </span>
       </div>
-      <div class="grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-6">
-        <span
+      <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-6">
+        <InsightChip
           v-for="item in policySummary.items"
           :key="item.label"
-          class="rounded border px-2 py-1"
-          :class="{
-            'mn-chip-ok': item.tone === 'success',
-            'mn-chip-warn': item.tone === 'warning',
-            'border-[color-mix(in_srgb,var(--mn-coral)_70%,transparent)] text-[var(--mn-danger)]': item.tone === 'danger',
-            'border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] text-[var(--mn-ink-muted)]': item.tone === 'neutral',
-          }"
-        >
-          {{ item.label }}: <b class="font-medium">{{ item.value }}</b>
-        </span>
+          :label="item.label"
+          :value="item.value"
+          :tone="item.tone"
+        />
       </div>
       <p v-if="policySummary.conflicts.length" class="break-all text-xs text-[var(--mn-danger)]">
         冲突包名：{{ policySummary.conflicts.join(", ") }}
@@ -541,10 +535,7 @@ onMounted(() => {
     <div class="grid gap-3 lg:grid-cols-[minmax(0,1.25fr)_minmax(280px,0.75fr)]">
       <Card class="grid gap-3">
         <div class="flex flex-wrap items-center gap-2">
-          <div class="relative min-w-0 flex-1">
-            <Search class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[var(--mn-ink-faint)]" :size="16" />
-            <Input v-model="state.packageQuery" class="pl-9" placeholder="搜索已安装应用包名" spellcheck="false" @keyup.enter="searchPackages" />
-          </div>
+          <SearchField v-model="state.packageQuery" placeholder="搜索已安装应用包名" @keyup.enter="searchPackages" />
           <Button variant="secondary" :loading="isRunning('search-packages')" @click="searchPackages">重新读取</Button>
         </div>
         <div class="flex min-w-0 flex-wrap items-center gap-2">
@@ -573,7 +564,7 @@ onMounted(() => {
             <Button size="sm" variant="outline" :loading="isRunning(`pick-direct-${app.packageName}`)" @click="requestAddPackage(app.packageName, 'direct', `pick-direct-${app.packageName}`)">Direct</Button>
             <Button size="sm" variant="outline" :loading="isRunning(`pick-bypass-${app.packageName}`)" @click="requestAddPackage(app.packageName, 'bypass', `pick-bypass-${app.packageName}`)">Bypass TUN</Button>
           </div>
-          <em v-if="!filteredPackages.length" class="text-sm not-italic text-[var(--mn-ink-muted)]">暂无结果，点“列出应用”或输入关键字过滤。</em>
+          <em v-if="!filteredPackages.length" class="mn-empty">暂无结果，点“列出应用”或输入关键字过滤。</em>
         </div>
       </Card>
 
@@ -586,8 +577,8 @@ onMounted(() => {
           <CheckCircle2 class="shrink-0 text-[var(--mn-ink-muted)]" :size="18" />
         </div>
         <div class="flex max-h-64 flex-wrap gap-2 overflow-auto">
-          <span v-for="pkg in availableRecommendedBypass" :key="pkg" class="inline-flex max-w-full items-center rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] px-2 py-1 text-xs text-[var(--mn-ink-soft)] break-all">{{ pkg }}</span>
-          <em v-if="!availableRecommendedBypass.length" class="text-sm not-italic text-[var(--mn-ink-muted)]">推荐项已在名单中，或当前设备未读取到匹配应用。</em>
+          <span v-for="pkg in availableRecommendedBypass" :key="pkg" class="mn-tag text-[var(--mn-ink-soft)]">{{ pkg }}</span>
+          <em v-if="!availableRecommendedBypass.length" class="mn-empty">推荐项已在名单中，或当前设备未读取到匹配应用。</em>
         </div>
       </Card>
     </div>
@@ -596,31 +587,40 @@ onMounted(() => {
       <Card>
         <h3 class="mb-2 text-base font-semibold">Proxy</h3>
         <div class="flex max-h-80 flex-wrap gap-2 overflow-auto">
-          <span v-for="pkg in state.appPolicy.proxy" :key="pkg" class="inline-flex max-w-full items-center gap-1 rounded-full border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] px-2 py-1 text-xs break-all">
-            {{ pkg }}
-            <button class="grid size-6 place-items-center rounded-full bg-[var(--mn-cactus)] text-[var(--mn-on-accent)] disabled:cursor-progress disabled:opacity-60" :disabled="isRunning(`remove-proxy-${pkg}`)" type="button" title="移除" @click="requestRemoveApp(pkg, 'proxy')"><X :size="14" /></button>
-          </span>
-          <em v-if="!state.appPolicy.proxy.length" class="text-sm not-italic text-[var(--mn-ink-muted)]">暂无应用</em>
+          <RemovableTag
+            v-for="pkg in state.appPolicy.proxy"
+            :key="pkg"
+            :disabled="isRunning(`remove-proxy-${pkg}`)"
+            title="移除"
+            @remove="requestRemoveApp(pkg, 'proxy')"
+          >{{ pkg }}</RemovableTag>
+          <em v-if="!state.appPolicy.proxy.length" class="mn-empty">暂无应用</em>
         </div>
       </Card>
       <Card>
         <h3 class="mb-2 text-base font-semibold">Direct（TUN 内直连）</h3>
         <div class="flex max-h-80 flex-wrap gap-2 overflow-auto">
-          <span v-for="pkg in state.appPolicy.direct" :key="pkg" class="inline-flex max-w-full items-center gap-1 rounded-full border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] px-2 py-1 text-xs break-all">
-            {{ pkg }}
-            <button class="grid size-6 place-items-center rounded-full bg-[var(--mn-cactus)] text-[var(--mn-on-accent)] disabled:cursor-progress disabled:opacity-60" :disabled="isRunning(`remove-direct-${pkg}`)" type="button" title="移除" @click="requestRemoveApp(pkg, 'direct')"><X :size="14" /></button>
-          </span>
-          <em v-if="!state.appPolicy.direct.length" class="text-sm not-italic text-[var(--mn-ink-muted)]">暂无应用</em>
+          <RemovableTag
+            v-for="pkg in state.appPolicy.direct"
+            :key="pkg"
+            :disabled="isRunning(`remove-direct-${pkg}`)"
+            title="移除"
+            @remove="requestRemoveApp(pkg, 'direct')"
+          >{{ pkg }}</RemovableTag>
+          <em v-if="!state.appPolicy.direct.length" class="mn-empty">暂无应用</em>
         </div>
       </Card>
       <Card>
         <h3 class="mb-2 text-base font-semibold">Bypass TUN</h3>
         <div class="flex max-h-80 flex-wrap gap-2 overflow-auto">
-          <span v-for="pkg in state.appPolicy.bypass" :key="pkg" class="inline-flex max-w-full items-center gap-1 rounded-full border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] px-2 py-1 text-xs break-all">
-            {{ pkg }}
-            <button class="grid size-6 place-items-center rounded-full bg-[var(--mn-cactus)] text-[var(--mn-on-accent)] disabled:cursor-progress disabled:opacity-60" :disabled="isRunning(`remove-bypass-${pkg}`)" type="button" title="移入回收站" @click="requestRemoveApp(pkg, 'bypass')"><X :size="14" /></button>
-          </span>
-          <em v-if="!state.appPolicy.bypass.length" class="text-sm not-italic text-[var(--mn-ink-muted)]">暂无应用</em>
+          <RemovableTag
+            v-for="pkg in state.appPolicy.bypass"
+            :key="pkg"
+            :disabled="isRunning(`remove-bypass-${pkg}`)"
+            title="移入回收站"
+            @remove="requestRemoveApp(pkg, 'bypass')"
+          >{{ pkg }}</RemovableTag>
+          <em v-if="!state.appPolicy.bypass.length" class="mn-empty">暂无应用</em>
         </div>
       </Card>
     </div>
@@ -634,13 +634,19 @@ onMounted(() => {
         <Trash2 class="shrink-0 text-[var(--mn-ink-muted)]" :size="18" />
       </div>
       <div class="flex max-h-56 flex-wrap gap-2 overflow-auto">
-        <span v-for="pkg in recycledBypass" :key="pkg" class="inline-flex max-w-full items-center gap-1 rounded-full border border-dashed border-[color-mix(in_srgb,var(--mn-ink)_14%,transparent)] bg-[var(--mn-ivory)] px-2 py-1 text-xs text-[var(--mn-ink-soft)] break-all">
+        <RemovableTag
+          v-for="pkg in recycledBypass"
+          :key="pkg"
+          variant="dashed"
+          remove-variant="restore"
+          :disabled="isRunning(`restore-bypass-${pkg}`)"
+          title="加回 Bypass"
+          @remove="requestRestoreBypass(pkg)"
+        >
           {{ pkg }}
-          <button class="grid size-6 place-items-center rounded-full bg-[color-mix(in_srgb,var(--mn-cactus)_40%,var(--mn-carrier))] text-[var(--mn-success)] disabled:cursor-progress disabled:opacity-60" :disabled="isRunning(`restore-bypass-${pkg}`)" type="button" title="加回 Bypass" @click="requestRestoreBypass(pkg)">
-            <RotateCcw :size="14" />
-          </button>
-        </span>
-        <em v-if="!recycledBypass.length" class="text-sm not-italic text-[var(--mn-ink-muted)]">回收站为空</em>
+          <template #icon><RotateCcw :size="14" /></template>
+        </RemovableTag>
+        <em v-if="!recycledBypass.length" class="mn-empty">回收站为空</em>
       </div>
     </Card>
   </div>

--- a/webui/src/components/pages/BlocklistPage.vue
+++ b/webui/src/components/pages/BlocklistPage.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
-import { Copy, DownloadCloud, Github, ListFilter, Plus, RefreshCw, Search, X } from "lucide-vue-next";
+import { Copy, DownloadCloud, Github, ListFilter, Plus, RefreshCw } from "lucide-vue-next";
 import { computed, ref } from "vue";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
+import ConfirmPanel from "@/components/ui/ConfirmPanel.vue";
 import Input from "@/components/ui/Input.vue";
+import InsightChip from "@/components/ui/InsightChip.vue";
 import PageHeader from "@/components/ui/PageHeader.vue";
+import RemovableTag from "@/components/ui/RemovableTag.vue";
+import SearchField from "@/components/ui/SearchField.vue";
 import { useActionLock } from "@/composables/useActionLock";
 import { useMagicNet } from "@/composables/useMagicNet";
 import { copyText, execFailed, redactedCliPreview } from "@/utils";
@@ -333,19 +337,17 @@ async function confirmBlockAction(): Promise<void> {
       </div>
     </PageHeader>
 
-    <Card v-if="pendingBlockAction" class="grid gap-3 mn-panel-warn">
-      <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <div class="min-w-0">
-          <span class="text-[11px] font-bold uppercase tracking-wide text-[var(--mn-warning)]">Confirm blocklist</span>
-          <p class="mt-1 text-sm leading-6 text-[var(--mn-warning)]">{{ pendingBlockAction.message }}</p>
-          <code class="mt-2 block break-all rounded-md bg-[var(--mn-ivory)]/60 px-3 py-2 text-xs text-[var(--mn-ink)]">{{ pendingBlockAction.command }}</code>
-        </div>
-        <div class="flex shrink-0 gap-2">
-          <Button variant="secondary" :loading="isRunning(pendingBlockAction.key)" @click="confirmBlockAction">确认</Button>
-          <Button variant="outline" @click="cancelBlockAction">取消</Button>
-        </div>
-      </div>
-    </Card>
+    <ConfirmPanel
+      v-if="pendingBlockAction"
+      title="Confirm blocklist"
+      :detail="pendingBlockAction.message"
+      :command="pendingBlockAction.command"
+      :loading="isRunning(pendingBlockAction.key)"
+      confirm-label="确认"
+      confirm-variant="secondary"
+      @cancel="cancelBlockAction"
+      @confirm="confirmBlockAction"
+    />
 
     <Card class="grid gap-3">
       <div class="flex flex-wrap items-center justify-between gap-2">
@@ -365,20 +367,14 @@ async function confirmBlockAction(): Promise<void> {
           {{ blockSummary.status === 'active' ? '完整启用' : blockSummary.status === 'partial' ? '部分启用' : blockSummary.status === 'empty' ? '无有效规则' : '已关闭' }}
         </span>
       </div>
-      <div class="grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-5">
-        <span
+      <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+        <InsightChip
           v-for="item in blockSummary.insights"
           :key="item.label"
-          class="rounded border px-2 py-1"
-          :class="{
-            'mn-chip-ok': item.tone === 'success',
-            'mn-chip-warn': item.tone === 'warning',
-            'border-[color-mix(in_srgb,var(--mn-coral)_70%,transparent)] text-[var(--mn-danger)]': item.tone === 'danger',
-            'border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] text-[var(--mn-ink-muted)]': item.tone === 'neutral',
-          }"
-        >
-          {{ item.label }}: <b class="font-medium">{{ item.value }}</b>
-        </span>
+          :label="item.label"
+          :value="item.value"
+          :tone="item.tone"
+        />
       </div>
       <div class="grid gap-2 sm:grid-cols-2">
         <Button :variant="state.blocklist.enabled ? 'default' : 'outline'" :loading="isRunning('toggle-block')" @click="requestToggleBlocklist">
@@ -392,32 +388,35 @@ async function confirmBlockAction(): Promise<void> {
         <Input v-model="state.blocklist.newDomain" placeholder="malware.example.com" spellcheck="false" />
         <Button variant="secondary" :loading="isRunning(`add-domain-${state.blocklist.newDomain.trim()}`)" @click="requestAddDomain"><Plus :size="16" />添加</Button>
       </div>
-      <div class="relative">
-        <Search class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[var(--mn-ink-faint)]" :size="16" />
-        <Input v-model="blockQuery" class="pl-9" placeholder="过滤本地阻断、社区规则和广告放行白名单" spellcheck="false" />
-      </div>
+      <SearchField v-model="blockQuery" placeholder="过滤本地阻断、社区规则和广告放行白名单" />
     </Card>
 
     <div class="grid gap-3 md:grid-cols-2">
       <Card>
         <h3 class="mb-2 inline-flex items-center gap-2 text-base font-semibold"><ListFilter :size="16" />阻断</h3>
         <div class="flex max-h-80 flex-wrap gap-2 overflow-auto">
-          <span v-for="domain in visibleManualDomains" :key="domain" class="inline-flex max-w-full items-center gap-1 rounded-full border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] px-2 py-1 text-xs break-all">
-            {{ domain }}
-            <button class="grid size-6 place-items-center rounded-full bg-[var(--mn-cactus)] text-[var(--mn-on-accent)] disabled:cursor-progress disabled:opacity-60" :disabled="isRunning(`remove-domain-${domain}`)" type="button" @click="requestRemoveDomain(domain)"><X :size="14" /></button>
-          </span>
-          <em v-if="!visibleManualDomains.length" class="text-sm not-italic text-[var(--mn-ink-muted)]">{{ state.blocklist.manual.length ? '没有匹配项' : '暂无域名' }}</em>
+          <RemovableTag
+            v-for="domain in visibleManualDomains"
+            :key="domain"
+            :disabled="isRunning(`remove-domain-${domain}`)"
+            :remove-label="`移除 ${domain}`"
+            @remove="requestRemoveDomain(domain)"
+          >{{ domain }}</RemovableTag>
+          <em v-if="!visibleManualDomains.length" class="mn-empty">{{ state.blocklist.manual.length ? '没有匹配项' : '暂无域名' }}</em>
         </div>
       </Card>
 
       <Card>
         <h3 class="mb-2 text-base font-semibold">社区库缓存</h3>
         <div class="flex max-h-[26rem] flex-wrap gap-2 overflow-auto">
-          <span v-for="rule in visibleCommunityEntries.slice(0, 120)" :key="rule" class="inline-flex max-w-full items-center gap-1 rounded-full border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] px-2 py-1 text-xs break-all">
-            {{ rule }}
-            <button class="grid size-6 place-items-center rounded-full bg-[var(--mn-cactus)] text-[var(--mn-on-accent)] disabled:cursor-progress disabled:opacity-60" :disabled="isRunning(`allow-${rule}`)" type="button" title="排除这条社区规则" @click="requestAllowRule(rule)"><X :size="14" /></button>
-          </span>
-          <em v-if="!visibleCommunityEntries.length" class="text-sm not-italic text-[var(--mn-ink-muted)]">{{ communityEntries.length ? '没有匹配项' : '未读取到社区规则' }}</em>
+          <RemovableTag
+            v-for="rule in visibleCommunityEntries.slice(0, 120)"
+            :key="rule"
+            :disabled="isRunning(`allow-${rule}`)"
+            title="排除这条社区规则"
+            @remove="requestAllowRule(rule)"
+          >{{ rule }}</RemovableTag>
+          <em v-if="!visibleCommunityEntries.length" class="mn-empty">{{ communityEntries.length ? '没有匹配项' : '未读取到社区规则' }}</em>
         </div>
       </Card>
 
@@ -429,11 +428,16 @@ async function confirmBlockAction(): Promise<void> {
           <Button variant="secondary" :loading="isRunning(`allow-${allowRuleInput.trim()}`)" @click="requestAddAllowRule"><Plus :size="16" />加入白名单</Button>
         </div>
         <div class="flex max-h-[26rem] flex-wrap gap-2 overflow-auto">
-          <span v-for="rule in visibleAllowRules" :key="rule" class="inline-flex max-w-full items-center gap-1 rounded-full border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] px-2 py-1 text-xs break-all">
-            {{ rule }}
-            <button class="grid size-6 place-items-center rounded-full bg-[color-mix(in_srgb,var(--mn-coral)_55%,var(--mn-carrier))] text-[var(--mn-danger)] hover:bg-[color-mix(in_srgb,var(--mn-coral)_70%,var(--mn-carrier))] disabled:cursor-progress disabled:opacity-60" :disabled="isRunning(`unallow-${rule}`)" type="button" :title="`从广告放行白名单删除 ${rule}`" :aria-label="`从广告放行白名单删除 ${rule}`" @click="requestRemoveAllowRule(rule)"><X :size="14" /></button>
-          </span>
-          <em v-if="!visibleAllowRules.length" class="text-sm not-italic text-[var(--mn-ink-muted)]">{{ state.blocklist.allowRules.length ? '没有匹配项' : '暂无白名单规则' }}</em>
+          <RemovableTag
+            v-for="rule in visibleAllowRules"
+            :key="rule"
+            remove-variant="danger"
+            :disabled="isRunning(`unallow-${rule}`)"
+            :title="`从广告放行白名单删除 ${rule}`"
+            :remove-label="`从广告放行白名单删除 ${rule}`"
+            @remove="requestRemoveAllowRule(rule)"
+          >{{ rule }}</RemovableTag>
+          <em v-if="!visibleAllowRules.length" class="mn-empty">{{ state.blocklist.allowRules.length ? '没有匹配项' : '暂无白名单规则' }}</em>
         </div>
       </Card>
     </div>

--- a/webui/src/components/pages/ConfigPage.vue
+++ b/webui/src/components/pages/ConfigPage.vue
@@ -3,6 +3,7 @@ import { Braces, Copy, DownloadCloud, FileUp, Github, ListTree, RefreshCw, Save 
 import { computed, ref } from "vue";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
+import InsightChip from "@/components/ui/InsightChip.vue";
 import PageHeader from "@/components/ui/PageHeader.vue";
 import ConfigCodeEditor from "@/components/ConfigCodeEditor.vue";
 import { useActionLock } from "@/composables/useActionLock";
@@ -294,20 +295,14 @@ async function openConfigIssue(): Promise<void> {
           </div>
           <Button variant="outline" :disabled="!configAudit.items.length" @click="copyConfigAudit"><Copy :size="16" />{{ auditCopied ? '已复制审计' : '复制审计' }}</Button>
         </div>
-        <div class="grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-4">
-          <span
+        <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+          <InsightChip
             v-for="item in configAudit.items"
             :key="item.label"
-            class="rounded border px-2 py-1"
-            :class="{
-              'mn-chip-ok': item.tone === 'success',
-              'mn-chip-warn': item.tone === 'warning',
-              'border-[color-mix(in_srgb,var(--mn-coral)_70%,transparent)] text-[var(--mn-danger)]': item.tone === 'danger',
-              'border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] text-[var(--mn-ink-muted)]': item.tone === 'neutral',
-            }"
-          >
-            {{ item.label }}: <b class="font-medium">{{ item.value }}</b>
-          </span>
+            :label="item.label"
+            :value="item.value"
+            :tone="item.tone"
+          />
         </div>
         <p class="break-words text-xs text-[var(--mn-ink-muted)]">
           出站 tag：{{ configAudit.outboundTags.length ? configAudit.outboundTags.join(", ") : "无" }}

--- a/webui/src/components/pages/ConnectionsPanel.vue
+++ b/webui/src/components/pages/ConnectionsPanel.vue
@@ -3,7 +3,9 @@ import { computed, onMounted, ref } from "vue";
 import { Copy, RefreshCw, Search, Unplug } from "lucide-vue-next";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
+import ConfirmPanel from "@/components/ui/ConfirmPanel.vue";
 import Input from "@/components/ui/Input.vue";
+import { statusToneClasses } from "@/lib/statusTone";
 import { connectionBuckets, connectionFlowSummary, connectionMatchesQuery, parseConnectionSnapshot, type ConnectionTarget } from "@/composables/parsers";
 import { useActionLock } from "@/composables/useActionLock";
 import { useMagicNet } from "@/composables/useMagicNet";
@@ -229,13 +231,8 @@ onMounted(() => {
       <div
         v-for="item in insights"
         :key="item.label"
-        class="rounded-md border p-3"
-        :class="{
-          'mn-tone-ok': item.tone === 'success',
-          'mn-tone-warn': item.tone === 'warning',
-          'border-[color-mix(in_srgb,var(--mn-coral)_70%,transparent)] bg-[color-mix(in_srgb,var(--mn-coral)_55%,var(--mn-carrier))]': item.tone === 'danger',
-          'border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)]': item.tone === 'neutral',
-        }"
+        class="mn-stat-tile"
+        :class="statusToneClasses(item.tone)"
       >
         <p class="text-xs text-[var(--mn-ink-muted)]">{{ item.label }}</p>
         <p class="mt-1 text-base font-semibold text-[var(--mn-ink)]">{{ item.value }}</p>
@@ -243,15 +240,16 @@ onMounted(() => {
       </div>
     </div>
 
-    <div v-if="pendingAction" class="mn-panel-warn rounded-md p-3">
-      <p class="text-sm font-semibold text-[var(--mn-warning)]">{{ pendingAction.title }}</p>
-      <p class="mt-1 text-sm leading-6 text-[var(--mn-warning)]/80">{{ pendingAction.detail }}</p>
-      <code class="mt-2 block break-words rounded bg-[var(--mn-carrier-deep)]/50 p-2 text-xs text-[var(--mn-ink-soft)]">{{ pendingAction.command }}</code>
-      <div class="mt-3 grid gap-2 sm:grid-cols-2">
-        <Button size="sm" variant="secondary" :loading="isRunning(pendingAction.key)" @click="confirmAction">确认执行</Button>
-        <Button size="sm" variant="outline" @click="cancelAction">取消</Button>
-      </div>
-    </div>
+    <ConfirmPanel
+      v-if="pendingAction"
+      :title="pendingAction.title"
+      :detail="pendingAction.detail"
+      :command="pendingAction.command"
+      :loading="isRunning(pendingAction.key)"
+      confirm-variant="secondary"
+      @cancel="cancelAction"
+      @confirm="confirmAction"
+    />
 
     <div class="grid gap-2 sm:grid-cols-[8rem_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)]">
       <label class="grid gap-1 text-xs text-[var(--mn-ink-muted)]">

--- a/webui/src/components/pages/ControlPage.vue
+++ b/webui/src/components/pages/ControlPage.vue
@@ -10,7 +10,6 @@ import {
   Save,
   Share2,
   ShieldCheck,
-  Trash2,
   Unplug,
   Wifi,
   Zap,
@@ -19,8 +18,14 @@ import { computed, nextTick, onMounted, ref } from "vue";
 import Badge from "@/components/ui/Badge.vue";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
+import CardHeading from "@/components/ui/CardHeading.vue";
+import ConfirmPanel from "@/components/ui/ConfirmPanel.vue";
+import Eyebrow from "@/components/ui/Eyebrow.vue";
 import Input from "@/components/ui/Input.vue";
 import PageHeader from "@/components/ui/PageHeader.vue";
+import RemovableTag from "@/components/ui/RemovableTag.vue";
+import StatTile from "@/components/ui/StatTile.vue";
+import StatusDot from "@/components/ui/StatusDot.vue";
 import {
   applyConfigAction,
   applyTransparentModeAction,
@@ -379,8 +384,8 @@ onMounted(() => {
         :class="controlInsightTone(runtimeInsight.status)"
       >
         <div class="flex items-start justify-between gap-3">
-          <span class="text-[10px] font-semibold uppercase tracking-[0.22em] opacity-60">运行状态</span>
-          <span class="size-2.5 rounded-full bg-current opacity-70 " />
+          <Eyebrow tone="inherit" class="opacity-60">运行状态</Eyebrow>
+          <StatusDot tone="current" />
         </div>
         <div class="my-auto max-w-xl">
           <h3 class="break-words text-2xl font-semibold tracking-[-0.035em] md:text-3xl">
@@ -412,18 +417,9 @@ onMounted(() => {
       </Card>
 
       <Card class="grid gap-3 !p-4 md:col-span-5 md:!p-6">
-        <div class="flex items-start justify-between gap-3">
-          <div class="min-w-0">
-            <span
-              class="text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-muted)]"
-              >sing-box</span
-            >
-            <h3 class="mt-2 break-words text-2xl font-semibold tracking-[-0.035em]">
-              {{ singBoxStatus.label }}
-            </h3>
-          </div>
+        <CardHeading overline="sing-box" :title="singBoxStatus.label">
           <span :class="['mt-1 size-3 rounded-full', singBoxStatus.dotClass]" />
-        </div>
+        </CardHeading>
         <p class="text-sm leading-6 text-[var(--mn-ink-muted)]">
           MagicNet 当前只运行 sing-box 核心。
         </p>
@@ -443,10 +439,7 @@ onMounted(() => {
       </Card>
 
       <Card class="!p-4 md:col-span-5 md:!p-6">
-        <span
-          class="text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-muted)]"
-          >快捷操作</span
-        >
+        <Eyebrow>快捷操作</Eyebrow>
         <div class="mt-3 grid grid-cols-2 gap-2 md:mt-4 md:grid-cols-1 xl:grid-cols-2">
           <Button
             variant="secondary"
@@ -484,12 +477,11 @@ onMounted(() => {
       </Card>
 
       <Card class="!p-4 md:col-span-4 md:!p-6">
-        <span
-          class="text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-muted)]"
-          >sing-box WebUI</span
-        >
-        <h3 class="mt-3 text-xl font-semibold tracking-[-0.03em]">核心控制入口</h3>
-        <p class="mt-2 text-sm leading-6 text-[var(--mn-ink-muted)]">进入 zashboard 管理节点与代理组，或直接检查 API 连通性。</p>
+        <CardHeading
+          overline="sing-box WebUI"
+          title="核心控制入口"
+          description="进入 zashboard 管理节点与代理组，或直接检查 API 连通性。"
+        />
         <div class="mt-5 grid gap-2">
           <Button
             variant="outline"
@@ -513,21 +505,13 @@ onMounted(() => {
       </Card>
 
       <Card class="grid gap-4 !p-4 md:col-span-8 md:gap-5 md:!p-6">
-        <div class="flex flex-wrap items-start justify-between gap-2">
-          <div>
-            <span
-              class="text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-muted)]"
-              >透明代理模式</span
-            >
-            <h3 class="mt-2 text-2xl font-semibold tracking-[-0.035em]">TUN</h3>
-            <p class="mt-2 text-sm leading-6 text-[var(--mn-ink-muted)]">
-              MagicNet 统一使用 sing-box TUN 透明代理路径。
-            </p>
-          </div>
-          <div class="flex flex-wrap gap-2">
-            <Badge tone="neutral">TUN</Badge>
-          </div>
-        </div>
+        <CardHeading
+          overline="透明代理模式"
+          title="TUN"
+          description="MagicNet 统一使用 sing-box TUN 透明代理路径。"
+        >
+          <Badge tone="neutral">TUN</Badge>
+        </CardHeading>
         <Button
           variant="secondary"
           :disabled="runtimeBusy"
@@ -609,35 +593,28 @@ onMounted(() => {
       </Card>
 
       <Card class="grid gap-4 !p-4 md:col-span-12 md:gap-5 md:!p-6">
-        <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-          <div>
-            <span
-              class="text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-faint)]"
-              >Wi-Fi 模式策略</span
-            >
-            <h3 class="mt-2 flex items-center gap-2 text-2xl font-semibold tracking-[-0.035em]">
-              <Wifi :size="22" />按 Wi-Fi 自动切换
-            </h3>
-            <p class="mt-2 max-w-2xl text-sm leading-6 text-[var(--mn-ink-muted)]">
-              黑名单命中 SSID 或 BSSID 时切换为 Direct，离开 Wi-Fi 后自动恢复 Rule。白名单模式会让名单内 Wi-Fi 使用 Rule，其他 Wi-Fi 使用 Direct。
-            </p>
-          </div>
-          <div class="flex flex-wrap items-center gap-2">
-            <Badge :tone="state.wifiPolicy.connected ? 'success' : 'neutral'">
-              {{ state.wifiPolicy.connected ? state.wifiPolicy.ssid || "Wi-Fi 已连接" : "未连接 Wi-Fi" }}
-            </Badge>
-            <Badge :tone="state.wifiPolicy.enabled ? 'success' : 'warning'">
-              {{ state.wifiPolicy.enabled ? "已启用" : "已停用" }}
-            </Badge>
-            <Button
-              :loading="isRunning('wifi-toggle')"
-              :disabled="runtimeBusy"
-              @click="toggleWifiPolicy"
-            >
-              <Power :size="17" />{{ state.wifiPolicy.enabled ? "停用" : "启用" }}
-            </Button>
-          </div>
-        </div>
+        <CardHeading
+          overline="Wi-Fi 模式策略"
+          overline-tone="faint"
+          description="黑名单命中 SSID 或 BSSID 时切换为 Direct，离开 Wi-Fi 后自动恢复 Rule。白名单模式会让名单内 Wi-Fi 使用 Rule，其他 Wi-Fi 使用 Direct。"
+        >
+          <template #title>
+            <span class="inline-flex items-center gap-2"><Wifi :size="22" />按 Wi-Fi 自动切换</span>
+          </template>
+          <Badge :tone="state.wifiPolicy.connected ? 'success' : 'neutral'">
+            {{ state.wifiPolicy.connected ? state.wifiPolicy.ssid || "Wi-Fi 已连接" : "未连接 Wi-Fi" }}
+          </Badge>
+          <Badge :tone="state.wifiPolicy.enabled ? 'success' : 'warning'">
+            {{ state.wifiPolicy.enabled ? "已启用" : "已停用" }}
+          </Badge>
+          <Button
+            :loading="isRunning('wifi-toggle')"
+            :disabled="runtimeBusy"
+            @click="toggleWifiPolicy"
+          >
+            <Power :size="17" />{{ state.wifiPolicy.enabled ? "停用" : "启用" }}
+          </Button>
+        </CardHeading>
 
         <div class="grid gap-3 md:grid-cols-2">
           <button
@@ -661,21 +638,10 @@ onMounted(() => {
           </button>
         </div>
 
-        <div class="grid gap-3 rounded-[1.4rem] bg-black/20 p-4 md:grid-cols-3">
-          <div>
-            <span class="text-xs text-[var(--mn-ink-faint)]">当前 BSSID</span>
-            <p class="mt-1 break-all text-sm text-[var(--mn-ink-soft)]">{{ state.wifiPolicy.bssid || "—" }}</p>
-          </div>
-          <div>
-            <span class="text-xs text-[var(--mn-ink-faint)]">匹配结果</span>
-            <p class="mt-1 text-sm text-[var(--mn-ink-soft)]">{{ state.wifiPolicy.matched ? "已命中名单" : "未命中" }}</p>
-          </div>
-          <div>
-            <span class="text-xs text-[var(--mn-ink-faint)]">代理模式</span>
-            <p class="mt-1 text-sm text-[var(--mn-ink-soft)]">
-              {{ state.wifiPolicy.currentMode }} → {{ state.wifiPolicy.desiredMode }}
-            </p>
-          </div>
+        <div class="grid gap-3 md:grid-cols-3">
+          <StatTile label="当前 BSSID" :value="state.wifiPolicy.bssid || '—'" />
+          <StatTile label="匹配结果" :value="state.wifiPolicy.matched ? '已命中名单' : '未命中'" />
+          <StatTile label="代理模式" :value="`${state.wifiPolicy.currentMode} → ${state.wifiPolicy.desiredMode}`" />
         </div>
 
         <div class="grid gap-5 lg:grid-cols-2">
@@ -693,23 +659,15 @@ onMounted(() => {
               ><Plus :size="17" />SSID</Button>
             </div>
             <div class="flex flex-wrap gap-2">
-              <span
-                v-if="!state.wifiPolicy.ssids.length"
-                class="text-xs text-[var(--mn-ink-faint)]"
-              >还没有 SSID 条目</span>
-              <span
+              <span v-if="!state.wifiPolicy.ssids.length" class="mn-empty text-xs">还没有 SSID 条目</span>
+              <RemovableTag
                 v-for="ssid in state.wifiPolicy.ssids"
                 :key="ssid"
-                class="inline-flex items-center gap-2 rounded-full bg-[color-mix(in_srgb,var(--mn-ink)_6%,transparent)] px-3 py-1.5 text-xs text-[var(--mn-ink-soft)]"
-              >
-                {{ ssid }}
-                <button
-                  type="button"
-                  class="text-[var(--mn-ink-faint)] hover:text-[var(--mn-danger)]"
-                  :aria-label="`移除 SSID ${ssid}`"
-                  @click="removeWifiEntry('ssid', ssid)"
-                ><Trash2 :size="14" /></button>
-              </span>
+                variant="soft"
+                remove-variant="ghost"
+                :remove-label="`移除 SSID ${ssid}`"
+                @remove="removeWifiEntry('ssid', ssid)"
+              >{{ ssid }}</RemovableTag>
             </div>
           </div>
 
@@ -727,23 +685,16 @@ onMounted(() => {
               ><Plus :size="17" />BSSID</Button>
             </div>
             <div class="flex flex-wrap gap-2">
-              <span
-                v-if="!state.wifiPolicy.bssids.length"
-                class="text-xs text-[var(--mn-ink-faint)]"
-              >还没有 BSSID 条目</span>
-              <span
+              <span v-if="!state.wifiPolicy.bssids.length" class="mn-empty text-xs">还没有 BSSID 条目</span>
+              <RemovableTag
                 v-for="bssid in state.wifiPolicy.bssids"
                 :key="bssid"
-                class="inline-flex items-center gap-2 rounded-full bg-[color-mix(in_srgb,var(--mn-ink)_6%,transparent)] px-3 py-1.5 font-mono text-xs text-[var(--mn-ink-soft)]"
-              >
-                {{ bssid }}
-                <button
-                  type="button"
-                  class="text-[var(--mn-ink-faint)] hover:text-[var(--mn-danger)]"
-                  :aria-label="`移除 BSSID ${bssid}`"
-                  @click="removeWifiEntry('bssid', bssid)"
-                ><Trash2 :size="14" /></button>
-              </span>
+                class="font-mono"
+                variant="soft"
+                remove-variant="ghost"
+                :remove-label="`移除 BSSID ${bssid}`"
+                @remove="removeWifiEntry('bssid', bssid)"
+              >{{ bssid }}</RemovableTag>
             </div>
           </div>
         </div>
@@ -751,40 +702,31 @@ onMounted(() => {
     </div>
 
     <div v-if="pendingDangerAction" ref="dangerConfirmCard" tabindex="-1">
-      <Card class="grid gap-3 !bg-[color-mix(in_srgb,var(--mn-oat)_55%,var(--mn-carrier))] text-[var(--mn-warning)] shadow-[inset_0_0_0_1px_rgba(251,191,36,0.25),inset_0_0_0_7px_rgba(251,191,36,0.025)]">
-        <div
-          class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between"
-        >
-          <div class="min-w-0">
-            <span
-              class="text-[11px] font-bold uppercase tracking-wide text-[var(--mn-warning)]"
-              >确认操作</span
-            >
-            <p class="mt-1 text-sm leading-6 text-[var(--mn-warning)]">
-              {{ pendingDangerMessage }}
-            </p>
-            <code
-              class="mt-3 block break-all rounded-[1.15rem] bg-[var(--mn-carrier-deep)]/30 px-4 py-3 text-xs text-[var(--mn-ink)] shadow-[inset_0_0_0_1px_var(--mn-border)]"
-              >{{ pendingDangerAction.args }}</code
-            >
-          </div>
-          <div class="flex shrink-0 gap-2">
-            <Button
-              data-danger-cancel
-              variant="outline"
-              @click="cancelDangerAction"
-              >取消</Button
-            >
-            <Button
-              variant="secondary"
-              :disabled="runtimeBusy"
-              :loading="isRunning(pendingDangerAction.key)"
-              @click="confirmDangerAction"
-              >确认</Button
-            >
-          </div>
-        </div>
-      </Card>
+      <ConfirmPanel
+        title="确认操作"
+        :detail="pendingDangerMessage"
+        :command="pendingDangerAction.args"
+        :loading="isRunning(pendingDangerAction.key)"
+        confirm-label="确认"
+        confirm-variant="secondary"
+        :auto-focus="false"
+      >
+        <template #actions>
+          <Button
+            data-danger-cancel
+            variant="outline"
+            @click="cancelDangerAction"
+            >取消</Button
+          >
+          <Button
+            variant="secondary"
+            :disabled="runtimeBusy"
+            :loading="isRunning(pendingDangerAction.key)"
+            @click="confirmDangerAction"
+            >确认</Button
+          >
+        </template>
+      </ConfirmPanel>
     </div>
   </div>
 </template>

--- a/webui/src/components/pages/DiagnosticsPage.vue
+++ b/webui/src/components/pages/DiagnosticsPage.vue
@@ -5,6 +5,7 @@ import Badge from "@/components/ui/Badge.vue";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
 import PageHeader from "@/components/ui/PageHeader.vue";
+import { statusToneClasses } from "@/lib/statusTone";
 import { sanitizeDiagnosticText } from "@/composables/issueDrafts";
 import { useActionLock } from "@/composables/useActionLock";
 import { useMagicNet } from "@/composables/useMagicNet";
@@ -228,12 +229,7 @@ async function askAi(url: string, name: string): Promise<void> {
           </Button>
         </div>
       </div>
-      <div class="rounded-md border p-3 text-sm leading-6" :class="{
-        'border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] text-[var(--mn-ink-soft)]': apiProbeSummary.level === 'idle',
-        'mn-tone-ok': apiProbeSummary.level === 'ok',
-        'mn-tone-warn': apiProbeSummary.level === 'warning',
-        'border-[color-mix(in_srgb,var(--mn-coral)_70%,transparent)] bg-[color-mix(in_srgb,var(--mn-coral)_55%,var(--mn-carrier))] text-[var(--mn-danger)]': apiProbeSummary.level === 'danger',
-      }">
+      <div class="rounded-md p-3 text-sm leading-6" :class="statusToneClasses(apiProbeSummary.level)">
         <p class="font-semibold">{{ apiProbeSummary.label }}</p>
         <p class="mt-1 text-xs opacity-80">
           {{ apiProbeSummary.detail }} · 总耗时 {{ apiProbeSummary.totalMillis }}ms

--- a/webui/src/components/pages/DnsToolsCard.vue
+++ b/webui/src/components/pages/DnsToolsCard.vue
@@ -4,6 +4,7 @@ import { Cloud, Copy, RadioTower, RefreshCw } from "lucide-vue-next";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
 import Input from "@/components/ui/Input.vue";
+import InsightChip from "@/components/ui/InsightChip.vue";
 import { useActionLock } from "@/composables/useActionLock";
 import { useMagicNet } from "@/composables/useMagicNet";
 import { copyText, execFailed } from "@/utils";
@@ -136,20 +137,14 @@ function normalizeDomain(value: string): string {
       @confirm="confirmDnsAction"
     />
     <div v-if="pendingDnsPlan" class="grid gap-2 rounded-md mn-panel-warn p-3">
-      <div class="grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-5">
-        <span
+      <div class="flex flex-wrap gap-2">
+        <InsightChip
           v-for="item in pendingDnsPlan.items"
           :key="item.label"
-          class="rounded border px-2 py-1"
-          :class="{
-            'mn-chip-ok': item.tone === 'success',
-            'mn-chip-warn': item.tone === 'warning',
-            'border-[color-mix(in_srgb,var(--mn-coral)_70%,transparent)] text-[var(--mn-danger)]': item.tone === 'danger',
-            'mn-chip-neutral': item.tone === 'neutral',
-          }"
-        >
-          {{ item.label }}: <b class="font-medium">{{ item.value }}</b>
-        </span>
+          :label="item.label"
+          :value="item.value"
+          :tone="item.tone"
+        />
       </div>
       <p v-if="pendingDnsPlan.warnings.length" class="text-xs leading-5 text-[var(--mn-warning)]/80">
         {{ pendingDnsPlan.warnings.join("；") }}

--- a/webui/src/components/pages/NodeDelayPanel.vue
+++ b/webui/src/components/pages/NodeDelayPanel.vue
@@ -3,6 +3,8 @@ import { computed, onMounted, ref } from "vue";
 import { Copy, Gauge, RefreshCw, Zap } from "lucide-vue-next";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
+import ConfirmPanel from "@/components/ui/ConfirmPanel.vue";
+import StatTile from "@/components/ui/StatTile.vue";
 import { buildNodeDelayStats, formatNodeDelayReport, nodeDelayHealthText, nodeDelayQualityLabel, parseCurrentNode, parseNodeTestAll, sanitizeNodeText, type NodeDelayEntry } from "@/composables/nodeDelayParsers";
 import { useActionLock } from "@/composables/useActionLock";
 import { useMagicNet } from "@/composables/useMagicNet";
@@ -148,17 +150,17 @@ onMounted(() => {
       </div>
     </div>
 
-    <div v-if="pendingAction" class="mn-panel-warn rounded-md p-3">
-      <p class="text-sm font-semibold text-[var(--mn-warning)]">切换到最快节点</p>
-      <p class="mt-1 text-sm leading-6 text-[var(--mn-warning)]/80">
-        将把 proxy selector 切换到 {{ sanitizeNodeText(pendingAction.node.node) }}，当前连接可能重新选择出站。
-      </p>
-      <code class="mt-2 block rounded bg-[var(--mn-carrier-deep)]/50 p-2 text-xs text-[var(--mn-ink-soft)]">node use &lt;fastest-node&gt;</code>
-      <div class="mt-3 grid gap-2 sm:grid-cols-2">
-        <Button size="sm" variant="secondary" :loading="isRunning('node-use-fastest')" @click="confirmAction">确认切换</Button>
-        <Button size="sm" variant="outline" @click="cancelAction">取消</Button>
-      </div>
-    </div>
+    <ConfirmPanel
+      v-if="pendingAction"
+      title="切换到最快节点"
+      :detail="`将把 proxy selector 切换到 ${sanitizeNodeText(pendingAction.node.node)}，当前连接可能重新选择出站。`"
+      command="node use <fastest-node>"
+      :loading="isRunning('node-use-fastest')"
+      confirm-label="确认切换"
+      confirm-variant="secondary"
+      @cancel="cancelAction"
+      @confirm="confirmAction"
+    />
 
     <div v-if="entries.length" class="rounded-md border border-[color-mix(in_srgb,var(--mn-heather)_55%,transparent)] bg-[color-mix(in_srgb,var(--mn-heather)_40%,var(--mn-carrier))] p-3">
       <p class="text-sm font-semibold text-[var(--mn-info)]">测速健康摘要</p>
@@ -174,26 +176,11 @@ onMounted(() => {
     </div>
 
     <div class="grid gap-2 sm:grid-cols-5">
-      <div class="rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[color-mix(in_srgb,var(--mn-ink)_5%,transparent)] p-3">
-        <p class="text-xs text-[var(--mn-ink-muted)]">已测</p>
-        <p class="text-lg font-semibold text-[var(--mn-ink)]">{{ stats.tested }}</p>
-      </div>
-      <div class="rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[color-mix(in_srgb,var(--mn-ink)_5%,transparent)] p-3">
-        <p class="text-xs text-[var(--mn-ink-muted)]">可用</p>
-        <p class="text-lg font-semibold text-[var(--mn-ink)]">{{ stats.usable }}</p>
-      </div>
-      <div class="rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[color-mix(in_srgb,var(--mn-ink)_5%,transparent)] p-3">
-        <p class="text-xs text-[var(--mn-ink-muted)]">失败</p>
-        <p class="text-lg font-semibold text-[var(--mn-ink)]">{{ stats.failed }}</p>
-      </div>
-      <div class="rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[color-mix(in_srgb,var(--mn-ink)_5%,transparent)] p-3">
-        <p class="text-xs text-[var(--mn-ink-muted)]">平均</p>
-        <p class="text-lg font-semibold text-[var(--mn-ink)]">{{ delayLabel(stats.averageMillis) }}</p>
-      </div>
-      <div class="rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[color-mix(in_srgb,var(--mn-ink)_5%,transparent)] p-3">
-        <p class="text-xs text-[var(--mn-ink-muted)]">中位/解析可用率</p>
-        <p class="text-lg font-semibold text-[var(--mn-ink)]">{{ delayLabel(stats.medianMillis) }} · {{ stats.usablePercent }}%</p>
-      </div>
+      <StatTile label="已测" :value="stats.tested" />
+      <StatTile label="可用" :value="stats.usable" />
+      <StatTile label="失败" :value="stats.failed" />
+      <StatTile label="平均" :value="delayLabel(stats.averageMillis)" />
+      <StatTile label="中位/解析可用率" :value="`${delayLabel(stats.medianMillis)} · ${stats.usablePercent}%`" />
     </div>
 
     <div v-if="stats.fastest || stats.slowest" class="grid gap-2 sm:grid-cols-2">

--- a/webui/src/components/pages/ProxyChainPage.vue
+++ b/webui/src/components/pages/ProxyChainPage.vue
@@ -4,7 +4,9 @@ import { GitBranch, RefreshCw, Save, ShieldCheck, Trash2 } from "lucide-vue-next
 import Badge from "@/components/ui/Badge.vue";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
+import CardHeading from "@/components/ui/CardHeading.vue";
 import PageHeader from "@/components/ui/PageHeader.vue";
+import StatTile from "@/components/ui/StatTile.vue";
 import { useActionLock } from "@/composables/useActionLock";
 import { useMagicNet } from "@/composables/useMagicNet";
 import { sanitizeNodeText } from "@/composables/nodeDelayParsers";
@@ -193,21 +195,16 @@ onMounted(() => {
     </PageHeader>
 
     <Card class="grid gap-4 !p-4 md:!p-6">
-      <div class="flex flex-wrap items-start justify-between gap-3">
-        <div class="min-w-0">
-          <span class="text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-muted)]">当前配置</span>
-          <h2 class="mt-2 flex items-center gap-2 text-2xl font-semibold tracking-[-0.035em]">
-            <GitBranch :size="23" />两跳链路
-          </h2>
-          <p class="mt-2 max-w-3xl text-sm leading-6 text-[var(--mn-ink-muted)]">
-            页面只保存节点 tag；节点凭据继续由 sing-box 订阅配置管理。链路默认关闭，保存后会重新应用运行配置。
-          </p>
-        </div>
-        <div class="flex flex-wrap gap-2">
-          <Badge :tone="status.enabled ? 'success' : 'neutral'">策略：{{ status.enabled ? "启用" : "停用" }}</Badge>
-          <Badge tone="neutral">{{ status.mode === "auto" ? "自动出口" : "手动出口" }}</Badge>
-        </div>
-      </div>
+      <CardHeading
+        overline="当前配置"
+        description="页面只保存节点 tag；节点凭据继续由 sing-box 订阅配置管理。链路默认关闭，保存后会重新应用运行配置。"
+      >
+        <template #title>
+          <span class="inline-flex items-center gap-2"><GitBranch :size="23" />两跳链路</span>
+        </template>
+        <Badge :tone="status.enabled ? 'success' : 'neutral'">策略：{{ status.enabled ? "启用" : "停用" }}</Badge>
+        <Badge tone="neutral">{{ status.mode === "auto" ? "自动出口" : "手动出口" }}</Badge>
+      </CardHeading>
 
       <label class="flex cursor-pointer items-start gap-3 rounded-[1.15rem] bg-[color-mix(in_srgb,var(--mn-ink)_5%,transparent)] p-4">
         <input
@@ -224,39 +221,24 @@ onMounted(() => {
         </span>
       </label>
 
-      <div class="grid gap-3 rounded-[1.15rem] bg-[var(--mn-ivory)] p-4 sm:grid-cols-2 lg:grid-cols-4">
-        <div>
-          <span class="text-xs text-[var(--mn-ink-faint)]">策略状态</span>
-          <p class="mt-1 text-sm font-semibold">{{ status.enabled ? "已启用" : "已停用" }}</p>
-        </div>
-        <div>
-          <span class="text-xs text-[var(--mn-ink-faint)]">运行 API</span>
-          <p class="mt-1 text-sm font-semibold">{{ status.runtime.available ? "可用" : "不可用" }}</p>
-        </div>
-        <div>
-          <span class="text-xs text-[var(--mn-ink-faint)]">proxy 当前出口</span>
-          <p class="mt-1 truncate text-sm font-mono" :title="status.runtime.proxy">{{ status.runtime.proxy || "—" }}</p>
-        </div>
-        <div>
-          <span class="text-xs text-[var(--mn-ink-faint)]">当前链路出口</span>
-          <p class="mt-1 truncate text-sm font-mono" :title="status.runtime.exit">{{ status.runtime.exit || "—" }}</p>
-        </div>
+      <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <StatTile label="策略状态" :value="status.enabled ? '已启用' : '已停用'" />
+        <StatTile label="运行 API" :value="status.runtime.available ? '可用' : '不可用'" />
+        <StatTile label="proxy 当前出口" :value="status.runtime.proxy || '—'" mono />
+        <StatTile label="当前链路出口" :value="status.runtime.exit || '—'" mono />
       </div>
     </Card>
 
     <Card class="grid gap-5 !p-4 md:!p-6">
-      <div class="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <span class="text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-muted)]">链路角色</span>
-          <h2 class="mt-2 text-2xl font-semibold tracking-[-0.035em]">选择两跳节点</h2>
-          <p class="mt-2 text-sm leading-6 text-[var(--mn-ink-muted)]">
-            节点来自当前 sing-box 订阅缓存；订阅更新后请点击刷新重新读取。
-          </p>
-        </div>
+      <CardHeading
+        overline="链路角色"
+        title="选择两跳节点"
+        description="节点来自当前 sing-box 订阅缓存；订阅更新后请点击刷新重新读取。"
+      >
         <Badge :tone="nodeLoadFailed ? 'warning' : 'neutral'">
           {{ nodeLoadFailed ? "节点读取失败" : `${nodes.length} 个可用节点` }}
         </Badge>
-      </div>
+      </CardHeading>
 
       <div class="grid gap-4 lg:grid-cols-2">
         <label class="grid gap-2 text-sm font-medium">
@@ -341,11 +323,12 @@ onMounted(() => {
     </Card>
 
     <Card class="grid gap-4 !p-4 md:!p-6">
-      <div>
-        <span class="text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-muted)]">应用预览</span>
-        <h2 class="mt-2 text-xl font-semibold tracking-[-0.03em]">确认配置变更</h2>
-        <p class="mt-2 text-sm leading-6 text-[var(--mn-ink-muted)]">每次保存会按顺序执行 CLI 配置操作；如果中途失败，页面会重新读取已落盘状态。</p>
-      </div>
+      <CardHeading
+        size="md"
+        overline="应用预览"
+        title="确认配置变更"
+        description="每次保存会按顺序执行 CLI 配置操作；如果中途失败，页面会重新读取已落盘状态。"
+      />
       <div v-if="pendingPlan" class="grid gap-3 rounded-[1.15rem] bg-[color-mix(in_srgb,var(--mn-oat)_45%,var(--mn-carrier))] p-4" role="alert">
         <div class="flex items-start gap-3">
           <ShieldCheck class="mt-0.5 shrink-0 text-[var(--mn-warning)]" :size="18" />
@@ -365,20 +348,20 @@ onMounted(() => {
     </Card>
 
     <Card class="grid gap-3 !p-4 md:!p-6">
-      <div>
-        <span class="text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--mn-ink-muted)]">运行观察</span>
-        <h2 class="mt-2 text-xl font-semibold tracking-[-0.03em]">链路选择器状态</h2>
-      </div>
+      <CardHeading size="md" overline="运行观察" title="链路选择器状态" />
       <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <div v-for="item in [
-          ['proxy', status.runtime.proxy],
-          ['chain', status.runtime.chain],
-          ['chain-hop1', status.runtime.hop1],
-          ['chain-exit', status.runtime.exit],
-        ]" :key="item[0]" class="min-w-0 rounded-[1.05rem] bg-[var(--mn-ivory)] p-3">
-          <span class="text-xs text-[var(--mn-ink-faint)]">{{ item[0] }}</span>
-          <p class="mt-1 truncate font-mono text-sm text-[var(--mn-ink-soft)]" :title="item[1]">{{ item[1] || "—" }}</p>
-        </div>
+        <StatTile
+          v-for="item in [
+            ['proxy', status.runtime.proxy],
+            ['chain', status.runtime.chain],
+            ['chain-hop1', status.runtime.hop1],
+            ['chain-exit', status.runtime.exit],
+          ]"
+          :key="item[0]"
+          :label="item[0]"
+          :value="item[1] || '—'"
+          mono
+        />
       </div>
       <p class="text-xs leading-5 text-[var(--mn-ink-muted)]">
         这里显示的是设备当前 sing-box API 选择器状态；策略已启用但 API 不可用时，需要先检查 sing-box 和 <code>magicnet0</code>。

--- a/webui/src/components/pages/ProxyGroupsPanel.vue
+++ b/webui/src/components/pages/ProxyGroupsPanel.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from "vue";
-import { Copy, RefreshCw, Route, Search } from "lucide-vue-next";
+import { Copy, RefreshCw, Route } from "lucide-vue-next";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
-import Input from "@/components/ui/Input.vue";
+import ConfirmPanel from "@/components/ui/ConfirmPanel.vue";
+import InsightChip from "@/components/ui/InsightChip.vue";
+import SearchField from "@/components/ui/SearchField.vue";
 import { buildNodeDelayStats, nodeDelayQualityLabel, parseNodeTestAll, sanitizeNodeText, type NodeDelayEntry } from "@/composables/nodeDelayParsers";
 import { parseProxyGroupsSnapshot, sanitizeProxyName, type ProxyGroupSummary } from "@/composables/proxyGroupParsers";
 import { useActionLock } from "@/composables/useActionLock";
@@ -187,45 +189,41 @@ onMounted(() => {
     </div>
 
     <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
-      <label class="relative block">
-        <Search class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[var(--mn-ink-muted)]" :size="15" />
-        <Input v-model="groupQuery" class="pl-9" placeholder="搜索代理组或节点" spellcheck="false" />
-      </label>
+      <SearchField v-model="groupQuery" placeholder="搜索代理组或节点" />
       <span class="text-sm text-[var(--mn-ink-muted)]">
         {{ filteredGroups.length }} / {{ snapshot?.groups.length || 0 }} 组
       </span>
     </div>
 
-    <div v-if="pendingAction" class="mn-panel-warn rounded-md p-3">
-      <p class="text-sm font-semibold text-[var(--mn-warning)]">切换代理节点</p>
-      <p class="mt-1 text-sm leading-6 text-[var(--mn-warning)]/80">
-        {{ sanitizeProxyName(pendingAction.group.name) }}：{{ sanitizeProxyName(pendingPlan?.summary || "") }}
-      </p>
-      <code class="mt-2 block rounded bg-[var(--mn-carrier-deep)]/50 p-2 text-xs text-[var(--mn-ink-soft)]">api select &lt;group&gt; &lt;node&gt;</code>
-      <div class="mt-3 grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-5">
-        <span
+    <ConfirmPanel
+      v-if="pendingAction"
+      title="切换代理节点"
+      :detail="`${sanitizeProxyName(pendingAction.group.name)}：${sanitizeProxyName(pendingPlan?.summary || '')}`"
+      command="api select <group> <node>"
+      :loading="isRunning('proxy-groups-select')"
+      confirm-label="确认切换"
+      confirm-variant="secondary"
+      @cancel="cancelAction"
+      @confirm="confirmAction"
+    >
+      <div class="mt-3 flex flex-wrap gap-2">
+        <InsightChip
           v-for="item in pendingPlan?.items || []"
           :key="item.label"
-          class="rounded border px-2 py-1"
-          :class="{
-            'mn-chip-ok': item.tone === 'success',
-            'mn-chip-warn': item.tone === 'warning',
-            'border-[color-mix(in_srgb,var(--mn-coral)_70%,transparent)] text-[var(--mn-danger)]': item.tone === 'danger',
-            'mn-chip-neutral': item.tone === 'neutral',
-          }"
-        >
-          {{ item.label }}: <b class="font-medium">{{ sanitizeProxyName(item.value) }}</b>
-        </span>
+          :label="item.label"
+          :value="sanitizeProxyName(item.value)"
+          :tone="item.tone"
+        />
       </div>
       <p v-if="pendingPlan?.warnings.length" class="mt-2 text-xs leading-5 text-[var(--mn-warning)]/80">
         {{ pendingPlan.warnings.join("；") }}
       </p>
-      <div class="mt-3 grid gap-2 sm:grid-cols-3">
-        <Button size="sm" variant="secondary" :loading="isRunning('proxy-groups-select')" @click="confirmAction">确认切换</Button>
-        <Button size="sm" variant="outline" @click="copySelectionPlan">{{ selectionPlanCopied ? "已复制计划" : "复制计划" }}</Button>
+      <template #actions>
         <Button size="sm" variant="outline" @click="cancelAction">取消</Button>
-      </div>
-    </div>
+        <Button size="sm" variant="outline" @click="copySelectionPlan">{{ selectionPlanCopied ? "已复制计划" : "复制计划" }}</Button>
+        <Button size="sm" variant="secondary" :loading="isRunning('proxy-groups-select')" @click="confirmAction">确认切换</Button>
+      </template>
+    </ConfirmPanel>
 
     <div v-if="visibleGroups.length" class="grid gap-3">
       <div v-for="group in visibleGroups" :key="group.name" class="rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] p-3">

--- a/webui/src/components/pages/ToolActionConfirmCard.vue
+++ b/webui/src/components/pages/ToolActionConfirmCard.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
-import Button from "@/components/ui/Button.vue";
-import Card from "@/components/ui/Card.vue";
+import ConfirmPanel from "@/components/ui/ConfirmPanel.vue";
 import type { PendingToolAction } from "./toolActions";
 
 defineProps<{
@@ -13,36 +11,15 @@ defineEmits<{
   cancel: [];
   confirm: [];
 }>();
-
-const card = ref<HTMLElement | null>(null);
-
-onMounted(() => {
-  card.value?.scrollIntoView({ block: "nearest", behavior: "smooth" });
-  card.value?.querySelector<HTMLButtonElement>("button:last-of-type")?.focus();
-});
 </script>
 
 <template>
-  <div ref="card" tabindex="-1">
-    <Card class="mn-panel-warn">
-      <div class="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
-        <div class="min-w-0">
-          <h3 class="text-sm font-semibold text-[var(--mn-warning)]">
-            {{ action.title }}
-          </h3>
-          <p class="mt-1 text-sm leading-6 text-[var(--mn-warning)]/75">
-            {{ action.detail }}
-          </p>
-          <code
-            class="mt-2 block break-all rounded-md bg-[var(--mn-carrier-deep)]/50 px-3 py-2 text-xs text-[var(--mn-ink-soft)]"
-            >{{ action.command }}</code
-          >
-        </div>
-        <div class="flex flex-wrap gap-2">
-          <Button variant="outline" @click="$emit('cancel')">取消</Button>
-          <Button :loading="loading" @click="$emit('confirm')">确认执行</Button>
-        </div>
-      </div>
-    </Card>
-  </div>
+  <ConfirmPanel
+    :title="action.title"
+    :detail="action.detail"
+    :command="action.command"
+    :loading="loading"
+    @cancel="$emit('cancel')"
+    @confirm="$emit('confirm')"
+  />
 </template>

--- a/webui/src/components/pages/WarpRouteRulesPanel.vue
+++ b/webui/src/components/pages/WarpRouteRulesPanel.vue
@@ -2,7 +2,10 @@
 import { computed, onMounted, ref } from "vue";
 import { Copy, RefreshCw, X } from "lucide-vue-next";
 import Button from "@/components/ui/Button.vue";
+import ConfirmPanel from "@/components/ui/ConfirmPanel.vue";
 import Input from "@/components/ui/Input.vue";
+import InsightChip from "@/components/ui/InsightChip.vue";
+import StatTile from "@/components/ui/StatTile.vue";
 import { parseRouteRuleSummary } from "@/composables/parsers";
 import { useActionLock } from "@/composables/useActionLock";
 import { useMagicNet } from "@/composables/useMagicNet";
@@ -155,56 +158,43 @@ onMounted(() => {
 
 <template>
   <div class="grid gap-3">
-    <div v-if="pendingAction" class="mn-panel-warn rounded-md p-3">
-      <p class="text-sm font-semibold text-[var(--mn-warning)]">{{ pendingAction.title }}</p>
-      <p class="mt-1 text-sm leading-6 text-[var(--mn-warning)]/80">{{ pendingAction.detail }}</p>
-      <code class="mt-2 block break-words rounded bg-[var(--mn-carrier-deep)]/50 p-2 text-xs text-[var(--mn-ink-soft)]">{{ pendingAction.command }}</code>
-      <div v-if="pendingPlan" class="mt-3 grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-5">
-        <span
+    <ConfirmPanel
+      v-if="pendingAction"
+      :title="pendingAction.title"
+      :detail="pendingAction.detail"
+      :command="pendingAction.command"
+      :loading="isRunning(pendingAction.key)"
+      @cancel="cancelAction"
+      @confirm="confirmAction"
+    >
+      <div v-if="pendingPlan" class="mt-3 flex flex-wrap gap-2">
+        <InsightChip
           v-for="item in pendingPlan.items"
           :key="item.label"
-          class="rounded border px-2 py-1"
-          :class="{
-            'mn-chip-ok': item.tone === 'success',
-            'mn-chip-warn': item.tone === 'warning',
-            'border-[color-mix(in_srgb,var(--mn-coral)_70%,transparent)] text-[var(--mn-danger)]': item.tone === 'danger',
-            'mn-chip-neutral': item.tone === 'neutral',
-          }"
-        >
-          {{ item.label }}: <b class="font-medium">{{ item.value }}</b>
-        </span>
+          :label="item.label"
+          :value="item.value"
+          :tone="item.tone"
+        />
       </div>
       <p v-if="pendingPlan?.warnings.length" class="mt-2 text-xs leading-5 text-[var(--mn-warning)]/80">
         {{ pendingPlan.warnings.join("；") }}
       </p>
-      <div class="mt-3 grid gap-2 sm:grid-cols-3">
+      <template #actions>
         <Button variant="outline" :disabled="isRunning(pendingAction.key)" @click="cancelAction">取消</Button>
         <Button variant="outline" @click="copyRouteChangePlan"><Copy :size="15" />{{ planCopied ? '已复制计划' : '复制计划' }}</Button>
         <Button :loading="isRunning(pendingAction.key)" @click="confirmAction">确认执行</Button>
-      </div>
-    </div>
+      </template>
+    </ConfirmPanel>
     <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
       <Input v-model="domain" placeholder="example.com" spellcheck="false" />
       <Button variant="secondary" :disabled="!state.warp.enabled" :loading="isRunning('warp-route')" @click="requestAddWarpRoute">域名走 WARP</Button>
     </div>
     <Input v-model="routeQuery" placeholder="过滤 WARP 域名，例如 google / openai" spellcheck="false" />
     <div class="grid gap-2 sm:grid-cols-4">
-      <div class="rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[color-mix(in_srgb,var(--mn-ink)_5%,transparent)] p-3">
-        <p class="text-xs text-[var(--mn-ink-muted)]">Proxy</p>
-        <p class="text-lg font-semibold text-[var(--mn-ink)]">{{ summary.proxy.length }}</p>
-      </div>
-      <div class="rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[color-mix(in_srgb,var(--mn-ink)_5%,transparent)] p-3">
-        <p class="text-xs text-[var(--mn-ink-muted)]">Direct</p>
-        <p class="text-lg font-semibold text-[var(--mn-ink)]">{{ summary.direct.length }}</p>
-      </div>
-      <div class="rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[color-mix(in_srgb,var(--mn-ink)_5%,transparent)] p-3">
-        <p class="text-xs text-[var(--mn-ink-muted)]">Block</p>
-        <p class="text-lg font-semibold text-[var(--mn-ink)]">{{ summary.block.length }}</p>
-      </div>
-      <div class="rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[color-mix(in_srgb,var(--mn-ink)_5%,transparent)] p-3">
-        <p class="text-xs text-[var(--mn-ink-muted)]">WARP</p>
-        <p class="text-lg font-semibold text-[var(--mn-ink)]">{{ summary.warp.length }}</p>
-      </div>
+      <StatTile label="Proxy" :value="summary.proxy.length" />
+      <StatTile label="Direct" :value="summary.direct.length" />
+      <StatTile label="Block" :value="summary.block.length" />
+      <StatTile label="WARP" :value="summary.warp.length" />
     </div>
     <div v-if="summary.warp.length" class="rounded-md border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] p-3 text-xs leading-6 text-[var(--mn-ink-soft)]">
       <p class="mb-1 text-[var(--mn-ink-muted)]">WARP 域名 · {{ visibleWarpDomains.length }} / {{ summary.warp.length }}</p>

--- a/webui/src/components/ui/Badge.vue
+++ b/webui/src/components/ui/Badge.vue
@@ -3,7 +3,7 @@ import { computed } from "vue";
 import { cn } from "@/lib/utils";
 
 const props = withDefaults(defineProps<{
-  tone?: "neutral" | "success" | "warning" | "danger";
+  tone?: "neutral" | "success" | "warning" | "danger" | "info";
   class?: string;
 }>(), {
   tone: "neutral"
@@ -14,6 +14,7 @@ const toneClass = computed(() => ({
   success: "mn-fill-ok",
   warning: "mn-fill-warn",
   danger: "mn-fill-danger",
+  info: "mn-fill-info",
 }[props.tone]));
 
 const classes = computed(() => cn("inline-flex min-h-7 items-center rounded-full px-3 text-[11px] font-semibold tracking-[0.015em] shadow-[inset_0_1px_0_color-mix(in_srgb,#fff_18%,transparent)]", toneClass.value, props.class));

--- a/webui/src/components/ui/CardHeading.vue
+++ b/webui/src/components/ui/CardHeading.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { cn } from "@/lib/utils";
+import Eyebrow from "@/components/ui/Eyebrow.vue";
+
+const props = withDefaults(
+  defineProps<{
+    overline?: string;
+    title?: string;
+    description?: string;
+    size?: "md" | "lg";
+    overlineTone?: "muted" | "faint" | "clay" | "inherit";
+    class?: string;
+  }>(),
+  {
+    size: "lg",
+    overlineTone: "muted",
+  },
+);
+
+const titleClass = computed(() =>
+  cn(
+    "mn-card-title break-words text-[var(--mn-ink)]",
+    props.size === "lg"
+      ? "mt-2 text-2xl md:text-[1.65rem]"
+      : "mt-2 text-xl tracking-[-0.03em]",
+  ),
+);
+</script>
+
+<template>
+  <div :class="cn('flex flex-wrap items-start justify-between gap-3', props.class)">
+    <div class="min-w-0">
+      <Eyebrow v-if="overline || $slots.overline" :tone="overlineTone">
+        <slot name="overline">{{ overline }}</slot>
+      </Eyebrow>
+      <h3 v-if="title || $slots.title" :class="titleClass">
+        <slot name="title">{{ title }}</slot>
+      </h3>
+      <p
+        v-if="description || $slots.description"
+        class="mt-2 max-w-3xl text-sm leading-6 text-[var(--mn-ink-muted)]"
+      >
+        <slot name="description">{{ description }}</slot>
+      </p>
+    </div>
+    <div v-if="$slots.default" class="flex shrink-0 flex-wrap items-center gap-2">
+      <slot />
+    </div>
+  </div>
+</template>

--- a/webui/src/components/ui/ConfirmPanel.vue
+++ b/webui/src/components/ui/ConfirmPanel.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import Button from "@/components/ui/Button.vue";
+import Card from "@/components/ui/Card.vue";
+
+const props = withDefaults(
+  defineProps<{
+    title: string;
+    detail?: string;
+    command?: string;
+    loading?: boolean;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    autoFocus?: boolean;
+    confirmVariant?: "default" | "secondary";
+  }>(),
+  {
+    loading: false,
+    confirmLabel: "确认执行",
+    cancelLabel: "取消",
+    autoFocus: true,
+    confirmVariant: "default",
+  },
+);
+
+defineEmits<{
+  cancel: [];
+  confirm: [];
+}>();
+
+const card = ref<HTMLElement | null>(null);
+
+onMounted(() => {
+  if (!props.autoFocus) return;
+  const reduceMotion =
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+  card.value?.scrollIntoView({
+    block: "nearest",
+    behavior: reduceMotion ? "auto" : "smooth",
+  });
+  card.value?.querySelector<HTMLButtonElement>("button:last-of-type")?.focus();
+});
+</script>
+
+<template>
+  <div ref="card" tabindex="-1">
+    <Card class="mn-panel-warn">
+      <div class="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
+        <div class="min-w-0">
+          <h3 class="text-sm font-semibold text-[var(--mn-warning)]">{{ title }}</h3>
+          <p v-if="detail" class="mt-1 text-sm leading-6 text-[var(--mn-warning)]/75">
+            {{ detail }}
+          </p>
+          <code v-if="command" class="mn-confirm-code mt-2">{{ command }}</code>
+          <slot />
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <slot name="actions">
+            <Button variant="outline" @click="$emit('cancel')">{{ cancelLabel }}</Button>
+            <Button :variant="confirmVariant" :loading="loading" @click="$emit('confirm')">
+              {{ confirmLabel }}
+            </Button>
+          </slot>
+        </div>
+      </div>
+    </Card>
+  </div>
+</template>

--- a/webui/src/components/ui/Eyebrow.vue
+++ b/webui/src/components/ui/Eyebrow.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { cn } from "@/lib/utils";
+
+const props = withDefaults(
+  defineProps<{
+    tone?: "muted" | "faint" | "clay" | "inherit";
+    class?: string;
+  }>(),
+  { tone: "muted" },
+);
+
+const classes = computed(() =>
+  cn(
+    "mn-eyebrow",
+    {
+      muted: "mn-eyebrow-muted",
+      faint: "mn-eyebrow-faint",
+      clay: "mn-eyebrow-clay",
+      inherit: "",
+    }[props.tone],
+    props.class,
+  ),
+);
+</script>
+
+<template>
+  <span :class="classes"><slot /></span>
+</template>

--- a/webui/src/components/ui/Field.vue
+++ b/webui/src/components/ui/Field.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+defineProps<{
+  label: string;
+  hint?: string;
+  hintId?: string;
+  required?: boolean;
+  forId?: string;
+}>();
+</script>
+
+<template>
+  <label :for="forId" class="grid gap-1.5">
+    <span class="text-sm font-semibold text-[var(--mn-ink)]">
+      {{ label }}
+      <span v-if="required" class="text-[var(--mn-clay-ink)]">*</span>
+    </span>
+    <slot />
+    <p v-if="hint" :id="hintId" class="text-xs leading-5 text-[var(--mn-ink-muted)]">{{ hint }}</p>
+  </label>
+</template>

--- a/webui/src/components/ui/InsightChip.vue
+++ b/webui/src/components/ui/InsightChip.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { statusChipClasses } from "@/lib/statusTone";
+import { cn } from "@/lib/utils";
+
+const props = withDefaults(
+  defineProps<{
+    label?: string;
+    value?: string | number;
+    tone?: string;
+    class?: string;
+  }>(),
+  { tone: "neutral" },
+);
+
+const classes = computed(() =>
+  cn("mn-insight-chip text-xs", statusChipClasses(props.tone), props.class),
+);
+</script>
+
+<template>
+  <span :class="classes">
+    <slot>
+      <template v-if="label != null">
+        {{ label }}<template v-if="value != null">: <b class="font-medium">{{ value }}</b></template>
+      </template>
+    </slot>
+  </span>
+</template>

--- a/webui/src/components/ui/RemovableTag.vue
+++ b/webui/src/components/ui/RemovableTag.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { X } from "lucide-vue-next";
+import { computed } from "vue";
+import { cn } from "@/lib/utils";
+
+const props = withDefaults(
+  defineProps<{
+    disabled?: boolean;
+    title?: string;
+    removeLabel?: string;
+    variant?: "default" | "soft" | "dashed";
+    removeVariant?: "default" | "danger" | "restore" | "ghost";
+    class?: string;
+  }>(),
+  {
+    variant: "default",
+    removeVariant: "default",
+  },
+);
+
+const emit = defineEmits<{
+  remove: [event: MouseEvent];
+}>();
+
+const tagClass = computed(() =>
+  cn(
+    "mn-tag",
+    {
+      default: "",
+      soft: "mn-tag-soft",
+      dashed: "mn-tag-dashed",
+    }[props.variant],
+    props.class,
+  ),
+);
+
+const removeClass = computed(() =>
+  cn("mn-tag-remove", {
+    default: "",
+    danger: "mn-tag-remove-danger",
+    restore: "mn-tag-remove-restore",
+    ghost: "mn-tag-remove-ghost",
+  }[props.removeVariant]),
+);
+</script>
+
+<template>
+  <span :class="tagClass">
+    <span class="min-w-0 break-all"><slot /></span>
+    <button
+      :class="removeClass"
+      :disabled="disabled"
+      :title="title"
+      :aria-label="removeLabel || title || '移除'"
+      type="button"
+      @click="emit('remove', $event)"
+    >
+      <slot name="icon">
+        <X :size="14" />
+      </slot>
+    </button>
+  </span>
+</template>

--- a/webui/src/components/ui/SearchField.vue
+++ b/webui/src/components/ui/SearchField.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { Search } from "lucide-vue-next";
+import { computed } from "vue";
+import Input from "@/components/ui/Input.vue";
+import { cn } from "@/lib/utils";
+
+defineOptions({ inheritAttrs: false });
+
+const props = defineProps<{
+  placeholder?: string;
+  class?: string;
+}>();
+
+const model = defineModel<string>();
+const wrapClass = computed(() => cn("relative min-w-0 flex-1", props.class));
+</script>
+
+<template>
+  <div :class="wrapClass">
+    <Search
+      class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[var(--mn-ink-faint)]"
+      :size="16"
+    />
+    <Input
+      v-model="model"
+      class="pl-9"
+      :placeholder="placeholder"
+      spellcheck="false"
+      v-bind="$attrs"
+    />
+  </div>
+</template>

--- a/webui/src/components/ui/StatTile.vue
+++ b/webui/src/components/ui/StatTile.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { cn } from "@/lib/utils";
+
+const props = defineProps<{
+  label: string;
+  value?: string | number;
+  hint?: string;
+  mono?: boolean;
+  class?: string;
+}>();
+
+const classes = computed(() => cn("mn-stat-tile", props.class));
+</script>
+
+<template>
+  <div :class="classes">
+    <p class="text-xs text-[var(--mn-ink-faint)]">{{ label }}</p>
+    <p :class="['mt-1 break-all text-base font-semibold text-[var(--mn-ink)]', mono ? 'font-mono' : '']">
+      <slot>{{ value ?? "—" }}</slot>
+    </p>
+    <p v-if="hint || $slots.hint" class="mt-1 truncate text-xs text-[var(--mn-ink-muted)]">
+      <slot name="hint">{{ hint }}</slot>
+    </p>
+  </div>
+</template>

--- a/webui/src/components/ui/StatusDot.vue
+++ b/webui/src/components/ui/StatusDot.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { cn } from "@/lib/utils";
+
+const props = withDefaults(
+  defineProps<{
+    tone?: "ok" | "stop" | "unknown" | "current";
+    class?: string;
+  }>(),
+  { tone: "unknown" },
+);
+
+const classes = computed(() =>
+  cn(
+    "size-2.5 shrink-0 rounded-full",
+    {
+      ok: "mn-status-dot-ok",
+      stop: "mn-status-dot-stop",
+      unknown: "mn-status-dot-unknown",
+      current: "bg-current opacity-70",
+    }[props.tone],
+    props.class,
+  ),
+);
+</script>
+
+<template>
+  <span :class="classes" aria-hidden="true" />
+</template>

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -414,6 +414,153 @@ textarea {
   box-shadow: inset 0 0 0 1px var(--mn-border);
 }
 
+.mn-eyebrow {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.mn-eyebrow-muted {
+  color: var(--mn-ink-muted);
+}
+
+.mn-eyebrow-faint {
+  color: var(--mn-ink-faint);
+}
+
+.mn-eyebrow-clay {
+  color: var(--mn-clay-ink);
+}
+
+.mn-card-title {
+  font-weight: 600;
+  letter-spacing: -0.035em;
+}
+
+.mn-insight-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 0.5rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.mn-tag {
+  display: inline-flex;
+  max-width: 100%;
+  align-items: center;
+  gap: 0.25rem;
+  overflow-wrap: anywhere;
+  border-radius: 9999px;
+  border: 1px solid color-mix(in srgb, var(--mn-ink) 12%, transparent);
+  background: var(--mn-ivory);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  line-height: 1.25;
+}
+
+.mn-tag-soft {
+  border-color: transparent;
+  background: color-mix(in srgb, var(--mn-ink) 6%, transparent);
+  color: var(--mn-ink-soft);
+}
+
+.mn-tag-dashed {
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--mn-ink) 14%, transparent);
+  color: var(--mn-ink-soft);
+}
+
+.mn-tag-remove {
+  display: grid;
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+  place-items: center;
+  border-radius: 9999px;
+  background: var(--mn-cactus);
+  color: var(--mn-on-accent);
+}
+
+.mn-tag-remove:hover {
+  filter: brightness(1.04);
+}
+
+.mn-tag-remove:disabled {
+  cursor: progress;
+  opacity: 0.6;
+}
+
+.mn-tag-remove-danger {
+  background: color-mix(in srgb, var(--mn-coral) 55%, var(--mn-carrier));
+  color: var(--mn-danger);
+}
+
+.mn-tag-remove-danger:hover {
+  background: color-mix(in srgb, var(--mn-coral) 70%, var(--mn-carrier));
+}
+
+.mn-tag-remove-restore {
+  background: color-mix(in srgb, var(--mn-cactus) 40%, var(--mn-carrier));
+  color: var(--mn-success);
+}
+
+.mn-tag-remove-ghost {
+  background: transparent;
+  color: var(--mn-ink-faint);
+}
+
+.mn-tag-remove-ghost:hover {
+  color: var(--mn-danger);
+}
+
+.mn-empty {
+  font-size: 0.875rem;
+  font-style: normal;
+  color: var(--mn-ink-muted);
+}
+
+.mn-stat-tile {
+  min-width: 0;
+  border-radius: var(--mn-radius-md);
+  background: color-mix(in srgb, var(--mn-ink) 5%, var(--mn-ivory));
+  box-shadow: inset 0 0 0 1px var(--mn-border);
+  padding: 0.75rem;
+}
+
+.mn-confirm-code {
+  display: block;
+  overflow-wrap: anywhere;
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--mn-carrier-deep) 50%, transparent);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
+  color: var(--mn-ink-soft);
+}
+
+.mn-choice {
+  border: 1px solid var(--mn-border);
+  background: var(--mn-carrier);
+}
+
+.mn-choice-active {
+  border-color: var(--mn-cactus);
+  background: color-mix(in srgb, var(--mn-cactus) 12%, var(--mn-ivory));
+}
+
+.mn-overlay {
+  background: color-mix(in srgb, var(--mn-ink) 40%, transparent);
+}
+
+.mn-segmented {
+  display: inline-flex;
+  width: fit-content;
+  border-radius: var(--mn-radius-md);
+  background: var(--mn-ivory);
+  padding: 0.25rem;
+  box-shadow: inset 0 0 0 1px var(--mn-border);
+}
+
 .mn-code {
   color: var(--mn-ink-soft);
 }

--- a/webui/ui-primitives.test.mjs
+++ b/webui/ui-primitives.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(fileURLToPath(import.meta.url));
+const src = join(root, "src");
+const read = (relativePath) => readFileSync(join(root, relativePath), "utf8");
+
+const primitives = [
+  "components/ui/Eyebrow.vue",
+  "components/ui/CardHeading.vue",
+  "components/ui/InsightChip.vue",
+  "components/ui/RemovableTag.vue",
+  "components/ui/SearchField.vue",
+  "components/ui/StatusDot.vue",
+  "components/ui/StatTile.vue",
+  "components/ui/ConfirmPanel.vue",
+  "components/ui/Field.vue",
+];
+
+for (const relativePath of primitives) {
+  assert.ok(existsSync(join(src, relativePath)), `missing shared primitive: ${relativePath}`);
+}
+
+const styles = read("src/styles.css");
+for (const token of [
+  ".mn-eyebrow",
+  ".mn-insight-chip",
+  ".mn-tag",
+  ".mn-empty",
+  ".mn-stat-tile",
+  ".mn-confirm-code",
+  ".mn-overlay",
+  ".mn-choice",
+  ".mn-segmented",
+]) {
+  assert.match(styles, new RegExp(token.replace(".", "\\.")), `styles.css must define ${token}`);
+}
+
+const insightChip = read("src/components/ui/InsightChip.vue");
+assert.match(insightChip, /statusChipClasses/, "InsightChip must use the shared statusChipClasses helper");
+
+const confirmCard = read("src/components/pages/ToolActionConfirmCard.vue");
+assert.match(confirmCard, /ConfirmPanel/, "tool confirms must reuse ConfirmPanel instead of a page-local card");
+
+const consumers = {
+  "src/App.vue": ["Eyebrow", "StatusDot"],
+  "src/components/pages/AppsPage.vue": ["ConfirmPanel", "InsightChip", "RemovableTag", "SearchField"],
+  "src/components/pages/BlocklistPage.vue": ["ConfirmPanel", "InsightChip", "RemovableTag", "SearchField"],
+  "src/components/pages/ControlPage.vue": ["CardHeading", "ConfirmPanel", "RemovableTag", "StatTile"],
+  "src/components/pages/ConfigPage.vue": ["InsightChip"],
+  "src/components/IssueReporterDialog.vue": ["Field", "Textarea"],
+};
+
+for (const [file, names] of Object.entries(consumers)) {
+  const body = read(file);
+  for (const name of names) {
+    assert.match(body, new RegExp(name), `${file} must reuse ${name}`);
+  }
+}
+
+assert.doesNotMatch(
+  read("src/components/pages/AppsPage.vue"),
+  /mn-chip-ok': item\.tone === 'success'/,
+  "AppsPage must not keep a page-local chip tone map",
+);
+assert.doesNotMatch(
+  read("src/components/pages/BlocklistPage.vue"),
+  /mn-chip-ok': item\.tone === 'success'/,
+  "BlocklistPage must not keep a page-local chip tone map",
+);
+
+console.log("ui primitives contract tests passed");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
把 WebUI 里各页各自手写的确认框、色标、可删标签、搜索框和卡片标题收成一套共享组件，减少重复样式和重复轮子，同时把视觉层级对齐到现有 design tokens。

## 改了什么

- 新增共享原语：`Eyebrow`、`CardHeading`、`InsightChip`、`RemovableTag`、`SearchField`、`StatusDot`、`StatTile`、`ConfirmPanel`、`Field`
- `InsightChip` 走已有的 `statusChipClasses`，不再在每个页面复制 `mn-chip-*` 映射
- `ToolActionConfirmCard` 以及控制、应用、黑名单、连接、测速、代理组、WARP 等确认区统一用 `ConfirmPanel`
- 对话框和表单改用 `mn-overlay`、`mn-choice`、`Textarea`/`Field`，去掉各页自己拼的 overlay / textarea 样式
- 在 `styles.css` 补上对应工具类，Badge 增加 `info` tone
- 顺手修了 CI clippy：`base64` 解码把 `chunks_exact(4)` 换成 `as_chunks::<4>()`

## 验证

- `npm test`（`node --experimental-strip-types --test *.test.mjs`）39 项全部通过
- `npm run typecheck` 通过
- `npm run build` 通过
- 既有设计合同、无障碍、引导和 Issue 对话框测试保持通过

无障碍焦点陷阱、新手引导文案和危险操作确认的 `data-danger-cancel` 行为未改。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46f4db1a-c91a-4f03-83bb-be6bc67bd320?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46f4db1a-c91a-4f03-83bb-be6bc67bd320&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Sourcery 总结

将重复的 WebUI 模式整合为共享基础组件，并使页面视觉效果与现有设计系统保持一致。

新功能：
- 引入用于标题、状态指示器、洞察标签、可移除标签、搜索字段、统计信息、确认面板和表单字段的共享 WebUI 基础组件。

增强功能：
- 使用共享设计令牌，统一 WebUI 页面中的确认流程、叠加层、选项、表单控件、标签、统计信息和状态样式。
- 集中管理状态标签和色调样式，同时新增信息徽章支持。
- 在整合 UI 实现的同时，保留现有的无障碍焦点处理、引导行为以及危险操作取消语义。

测试：
- 添加契约测试，覆盖共享基础组件的存在性、必需的样式令牌、组件复用，以及页面本地状态映射的移除。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

将重复的 WebUI 模式整合为共享组件，并使页面视觉效果与设计系统保持一致。

新功能：
- 引入用于标题、状态指示器、洞察标签、可移除标签、搜索字段、统计信息、确认面板和表单字段的共享 WebUI 基础组件。

增强功能：
- 使用共享设计令牌，统一 WebUI 页面中的确认流程、覆盖层、选项、表单控件、标签、统计信息和状态样式。
- 集中管理状态色调映射，并新增信息徽章样式，同时保留现有的无障碍支持、引导流程和危险操作行为。

测试：
- 添加契约测试，涵盖共享基础组件的可用性、必需的样式令牌、组件复用，以及页面本地状态映射的移除。

杂项：
- 更新 base64 分块处理，改用固定大小的数组分块。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Consolidate repeated WebUI patterns into shared components and align page visuals with the design system.

New Features:
- Introduce shared WebUI primitives for headings, status indicators, insight chips, removable tags, search fields, statistics, confirmation panels, and form fields.

Enhancements:
- Standardize confirmation flows, overlays, choices, form controls, tags, statistics, and status styling across WebUI pages using shared design tokens.
- Centralize status tone mappings and add informational badge styling while preserving existing accessibility, onboarding, and dangerous-action behavior.

Tests:
- Add contract tests covering shared primitive availability, required style tokens, component reuse, and removal of page-local status mappings.

Chores:
- Update base64 chunk processing to use fixed-size array chunks.

</details>

</details>