### PR TITLE
fix: 加固下载路径并收敛重复辅助函数

### DIFF
--- a/crates/magicnet-cli/src/diagnostics.rs
+++ b/crates/magicnet-cli/src/diagnostics.rs
@@ -12,7 +12,9 @@ use serde_json::Value;
 
 use crate::diagnostics_dns::dns_leak_check;
 use crate::diagnostics_routing::routing_policy_check;
-use crate::{clean_lines, command_text_timeout, mcp, pid_summary, singbox_pid_summary, App};
+use crate::{
+    clean_module_lines, command_text_timeout, mcp, pid_summary, singbox_pid_summary, App,
+};
 
 pub(crate) fn health(app: &App) -> Result<(), String> {
     for (key, ok, detail) in health_items(app) {
@@ -623,7 +625,9 @@ fn subscription_evidence(app: &App) -> String {
             {
                 1
             } else {
-                clean_lines(app.moddir.join(".config/sing-box/subscription.url")).len()
+                clean_module_lines(app, Path::new(".config/sing-box/subscription.url"))
+                    .unwrap_or_default()
+                    .len()
             }
         ),
         format!("source_mode={source_mode}"),
@@ -1052,16 +1056,16 @@ fn cmdline_has_command(cmdline: &str, executable: &str, args: &[&str]) -> bool {
 }
 
 fn has_subscription(app: &App) -> bool {
-    sensitive_paths(app)
-        .into_iter()
-        .any(|path| !clean_lines(path).is_empty())
-}
-
-fn sensitive_paths(app: &App) -> Vec<PathBuf> {
-    vec![
-        app.moddir.join(".config/sing-box/subscription.url"),
-        app.moddir.join(".config/sing-box/subscription.local"),
+    [
+        ".config/sing-box/subscription.url",
+        ".config/sing-box/subscription.local",
     ]
+    .into_iter()
+    .any(|relative| {
+        clean_module_lines(app, Path::new(relative))
+            .map(|lines| !lines.is_empty())
+            .unwrap_or(false)
+    })
 }
 
 fn sysroute_snapshot() {

--- a/crates/magicnet-cli/src/main.rs
+++ b/crates/magicnet-cli/src/main.rs
@@ -71,8 +71,8 @@ pub(crate) use process::{
     SHORT_TIMEOUT,
 };
 pub(crate) use utils::{
-    clean_lines, clear_node_cache, command_text_timeout, first_clean_line, proc_start_time,
-    read_kv, replace_module_text_files_transactionally, run_bounded_command,
+    clean_module_lines, clear_node_cache, command_text_timeout, first_clean_module_line,
+    proc_start_time, read_kv, replace_module_text_files_transactionally, run_bounded_command,
     shell_inert_conf_value, write_kv, write_secret_file, write_text_file,
 };
 

--- a/crates/magicnet-cli/src/rules.rs
+++ b/crates/magicnet-cli/src/rules.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 
 use crate::service::restart_current_core;
 use crate::utils::{clean_module_lines, replace_module_text_files_transactionally};
-use crate::{clean_lines, run_magicnet_function, write_text_file, App};
+use crate::{run_magicnet_function, write_text_file, App};
 
 pub(crate) use block::block_cmd;
 
@@ -27,7 +27,12 @@ pub(crate) fn route_cmd(app: &App, args: &[String]) -> Result<(), String> {
 fn route_list(app: &App) {
     for target in ["proxy", "direct", "block", "warp"] {
         println!("{target} domain suffixes:");
-        print_lines(route_file(app, target).unwrap());
+        print_lines(
+            app,
+            Path::new(&format!(
+                ".config/magicnet/route-{target}-domain-suffix.list"
+            )),
+        );
     }
 }
 
@@ -289,7 +294,10 @@ fn valid_package_name(package: &str) -> bool {
 }
 
 pub(super) fn update_line(app: &App, path: PathBuf, item: &str, add: bool) -> Result<(), String> {
-    let mut lines: Vec<String> = clean_lines(path.clone())
+    let relative = path
+        .strip_prefix(&app.moddir)
+        .map_err(|_| "refusing to update a list outside the module root".to_string())?;
+    let mut lines: Vec<String> = clean_module_lines(app, relative)?
         .into_iter()
         .filter(|line| line != item)
         .collect();
@@ -405,8 +413,8 @@ fn print_app_list_lines(lines: &[String]) {
     }
 }
 
-pub(super) fn print_lines(path: PathBuf) {
-    for line in clean_lines(path) {
+pub(super) fn print_lines(app: &App, relative: &Path) {
+    for line in clean_module_lines(app, relative).unwrap_or_default() {
         println!("  {line}");
     }
 }

--- a/crates/magicnet-cli/src/rules/block.rs
+++ b/crates/magicnet-cli/src/rules/block.rs
@@ -1,14 +1,13 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::io::Read;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::path::Path;
 
 use crate::service::restart_current_core;
-use crate::subscriptions::validate_subscription_url;
-use crate::{clean_lines, read_kv, run_magicnet_function, shell_inert_conf_value, write_kv, App};
+use crate::subscriptions::{download_pinned_https_url, validate_subscription_url};
+use crate::utils::clean_module_lines;
+use crate::{read_kv, run_magicnet_function, shell_inert_conf_value, write_kv, App};
 
-use super::{conf_dir, normalize_allow_rule, normalize_block_rule, print_lines, update_line};
+use super::{conf_dir, normalize_allow_rule, normalize_block_rule, update_line};
 
 const BLOCK_CONF: &str = ".config/magicnet/block.conf";
 /// Keep a compromised community source from consuming more than 8 MiB of CLI memory.
@@ -18,7 +17,6 @@ const MAX_COMMUNITY_BLOCKLIST_LINES: usize = 250_000;
 const MAX_COMMUNITY_BLOCKLIST_RULES: usize = 100_000;
 
 pub(crate) fn block_cmd(app: &App, args: &[String]) -> Result<(), String> {
-    let dir = conf_dir(app);
     match args.first().map(String::as_str).unwrap_or("list") {
         "list" => {
             block_list(app);
@@ -31,13 +29,12 @@ pub(crate) fn block_cmd(app: &App, args: &[String]) -> Result<(), String> {
         "allow-rule" | "unallow-rule" => block_allow(app, args),
         "apply" => apply_and_restart(app),
         "update" => block_update(app),
-        "diff" => block_diff(dir),
+        "diff" => block_diff(app),
         _ => Err("Usage: cli block {list|enable|disable|community <on|off>|url <http-url>|update|add-domain <suffix>|remove-domain <suffix>|allow-rule <rule>|unallow-rule <rule>|diff|apply}".to_string()),
     }
 }
 
 fn block_list(app: &App) {
-    let dir = conf_dir(app);
     let conf = block_conf_values(app);
     println!(
         "enabled={}",
@@ -58,17 +55,17 @@ fn block_list(app: &App) {
             .unwrap_or(default_block_url())
     );
     println!("manual domain suffixes:");
-    print_lines(dir.join("block-domain-suffix.list"));
-    let allow = clean_lines(dir.join("block-allow-rules.list"));
+    print_module_lines(app, "block-domain-suffix.list");
+    let allow = module_list_lines(app, "block-allow-rules.list");
     println!("community rules:");
-    for line in clean_lines(dir.join("community-ban-rules.list"))
+    for line in module_list_lines(app, "community-ban-rules.list")
         .into_iter()
         .filter(|line| !allow.contains(line))
     {
         println!("  {line}");
     }
     println!("community domain suffixes:");
-    print_lines(dir.join("community-ban-domain-suffix.list"));
+    print_module_lines(app, "community-ban-domain-suffix.list");
     println!("local allow rules:");
     for line in allow {
         println!("  {line}");
@@ -224,48 +221,8 @@ fn block_update(app: &App) -> Result<(), String> {
 }
 
 fn download_blocklist(url: &str) -> Result<String, String> {
-    let max_bytes = MAX_COMMUNITY_BLOCKLIST_BYTES.to_string();
-    let mut child = Command::new("curl")
-        .args([
-            "-fsSL",
-            "--max-filesize",
-            &max_bytes,
-            "--connect-timeout",
-            "8",
-            "--max-time",
-            "30",
-            url,
-        ])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .map_err(|err| format!("run curl: {err}"))?;
-    let mut stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| "capture blocklist download failed".to_string())?;
-    let mut bytes = Vec::with_capacity(MAX_COMMUNITY_BLOCKLIST_BYTES.min(64 * 1024));
-    stdout
-        .by_ref()
-        .take((MAX_COMMUNITY_BLOCKLIST_BYTES + 1) as u64)
-        .read_to_end(&mut bytes)
-        .map_err(|err| format!("read blocklist download: {err}"))?;
-    if bytes.len() > MAX_COMMUNITY_BLOCKLIST_BYTES {
-        let _ = child.kill();
-        let _ = child.wait();
-        return Err(format!(
-            "community blocklist exceeds {MAX_COMMUNITY_BLOCKLIST_BYTES} byte limit"
-        ));
-    }
-    if child
-        .wait()
-        .map_err(|err| format!("wait for curl: {err}"))?
-        .success()
-    {
-        return String::from_utf8(bytes)
-            .map_err(|_| "community blocklist is not UTF-8".to_string());
-    }
-    Err(format!("download blocklist failed: {url}"))
+    let bytes = download_pinned_https_url(url, MAX_COMMUNITY_BLOCKLIST_BYTES, 8, 30)?;
+    String::from_utf8(bytes).map_err(|_| "community blocklist is not UTF-8".to_string())
 }
 
 fn apply_and_restart(app: &App) -> Result<(), String> {
@@ -329,14 +286,24 @@ fn lines_text(values: &[String]) -> String {
     values.iter().map(|value| format!("{value}\n")).collect()
 }
 
-fn block_diff(dir: PathBuf) -> Result<(), String> {
-    for domain in clean_lines(dir.join("block-domain-suffix.list")) {
+fn block_diff(app: &App) -> Result<(), String> {
+    for domain in module_list_lines(app, "block-domain-suffix.list") {
         println!("+ DOMAIN-SUFFIX,{domain}");
     }
-    for rule in clean_lines(dir.join("block-allow-rules.list")) {
+    for rule in module_list_lines(app, "block-allow-rules.list") {
         println!("- {rule}");
     }
     Ok(())
+}
+
+fn module_list_lines(app: &App, name: &str) -> Vec<String> {
+    clean_module_lines(app, &Path::new(".config/magicnet").join(name)).unwrap_or_default()
+}
+
+fn print_module_lines(app: &App, name: &str) {
+    for line in module_list_lines(app, name) {
+        println!("  {line}");
+    }
 }
 
 fn block_conf_values(app: &App) -> HashMap<String, String> {
@@ -411,7 +378,7 @@ mod tests {
     use super::*;
     use crate::test_support::temp_app;
 
-    fn write_block_conf_fixture(app: &App, text: &str) -> PathBuf {
+    fn write_block_conf_fixture(app: &App, text: &str) -> std::path::PathBuf {
         let path = conf_dir(app).join("block.conf");
         fs::create_dir_all(path.parent().expect("block config parent"))
             .expect("create block config parent");

--- a/crates/magicnet-cli/src/subscriptions.rs
+++ b/crates/magicnet-cli/src/subscriptions.rs
@@ -1,20 +1,21 @@
 use std::collections::HashSet;
 use std::ffi::{CString, OsStr, OsString};
 use std::fs::{self, File};
-use std::io::{self, Seek, SeekFrom, Write};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::net::{IpAddr, ToSocketAddrs};
 use std::os::fd::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
-    clean_lines, clear_node_cache, decode_base64, first_clean_line, run_magicnet_function,
-    run_subscription_source_update_from_inherited_fd, run_subscription_update_from_inherited_fd,
-    write_text_file, App,
+    clean_module_lines, clear_node_cache, decode_base64, first_clean_module_line,
+    run_magicnet_function, run_subscription_source_update_from_inherited_fd,
+    run_subscription_update_from_inherited_fd, write_text_file, App,
 };
 
 const MAX_SINGBOX_SUBSCRIPTION_URLS: usize = 5;
@@ -24,6 +25,7 @@ const MAX_SUBSCRIPTION_FILTER_BYTES: usize = 64;
 const MAX_LOCAL_SUBSCRIPTION_BYTES: usize = 8 * 1024 * 1024;
 const SUBSCRIPTION_USER_AGENT_PATH: &str = ".config/sing-box/subscription.user-agent";
 const SUBSCRIPTION_FILTER_PATH: &str = ".config/sing-box/subscription-filter.list";
+const SUBSCRIPTION_URL_PATH: &str = ".config/sing-box/subscription.url";
 const SELECTOR_REPLAY_WARNING: &str =
     "subscription committed, but saved selector choices could not be replayed";
 static SUBSCRIPTION_CANDIDATE_SEQUENCE: AtomicUsize = AtomicUsize::new(0);
@@ -472,7 +474,8 @@ fn normalized_subscription_text(text: &str) -> Result<String, String> {
 }
 
 pub fn sub_list(app: &App) {
-    for (idx, url) in clean_lines(app.moddir.join(".config/sing-box/subscription.url"))
+    for (idx, url) in clean_module_lines(app, Path::new(SUBSCRIPTION_URL_PATH))
+        .unwrap_or_default()
         .iter()
         .enumerate()
     {
@@ -480,7 +483,7 @@ pub fn sub_list(app: &App) {
     }
     println!(
         "sing-box={}",
-        first_clean_line(app.moddir.join(".config/sing-box/subscription.url"))
+        first_clean_module_line(app, Path::new(SUBSCRIPTION_URL_PATH))
     );
     println!("user-agent={}", subscription_user_agent(app));
     for (idx, value) in subscription_filters(app).iter().enumerate() {
@@ -489,7 +492,11 @@ pub fn sub_list(app: &App) {
 }
 
 pub fn sub_get(app: &App, target: &str) {
-    println!("{}", first_clean_line(sub_target_file(app, target)));
+    let _ = target;
+    println!(
+        "{}",
+        first_clean_module_line(app, Path::new(SUBSCRIPTION_URL_PATH))
+    );
 }
 
 pub fn sub_update(app: &App, args: &[String]) -> Result<(), String> {
@@ -635,6 +642,7 @@ pub(crate) fn validate_subscription_url(url: &str) -> Result<(), String> {
 
 struct SubscriptionAuthority<'a> {
     host: &'a str,
+    port: u16,
 }
 
 /// Parse only the authority needed for URL policy. DNS resolution and pinning
@@ -659,7 +667,7 @@ fn parse_subscription_authority(url: &str) -> Result<SubscriptionAuthority<'_>, 
         );
     }
 
-    let (host, _port) = if let Some(bracketed) = authority.strip_prefix('[') {
+    let (host, port) = if let Some(bracketed) = authority.strip_prefix('[') {
         let closing = bracketed
             .find(']')
             .ok_or_else(|| "Subscription URL has an invalid IPv6 authority".to_string())?;
@@ -684,7 +692,100 @@ fn parse_subscription_authority(url: &str) -> Result<SubscriptionAuthority<'_>, 
         (host, parse_subscription_port(port_suffix)?)
     };
 
-    Ok(SubscriptionAuthority { host })
+    Ok(SubscriptionAuthority { host, port })
+}
+
+/// Download an HTTPS URL with the same public-address and redirect policy as
+/// subscription fetches: resolve first, reject private targets, pin curl with
+/// `--resolve`, and refuse redirects that could re-target the request.
+pub(crate) fn download_pinned_https_url(
+    url: &str,
+    max_bytes: usize,
+    connect_timeout_secs: u64,
+    max_time_secs: u64,
+) -> Result<Vec<u8>, String> {
+    validate_subscription_url(url)?;
+    let authority = parse_subscription_authority(url)?;
+    let resolved = (authority.host, authority.port)
+        .to_socket_addrs()
+        .map_err(|_| "HTTPS hostname resolution failed".to_string())?
+        .map(|address| address.ip())
+        .collect::<HashSet<_>>();
+    validate_resolved_subscription_addresses(&resolved)?;
+
+    let mut addresses = resolved.into_iter().collect::<Vec<_>>();
+    addresses.sort_by_key(ToString::to_string);
+    let resolve_args = addresses
+        .into_iter()
+        .map(|address| {
+            let pinned = match address {
+                IpAddr::V6(v6) => format!("[{v6}]"),
+                IpAddr::V4(v4) => v4.to_string(),
+            };
+            format!("{}:{}:{pinned}", authority.host, authority.port)
+        })
+        .collect::<Vec<_>>();
+
+    let max_bytes_arg = max_bytes.to_string();
+    let connect_timeout = connect_timeout_secs.to_string();
+    let max_time = max_time_secs.to_string();
+    let mut command = Command::new("curl");
+    command.args([
+        "-fsS",
+        "--noproxy",
+        "*",
+        "--max-redirs",
+        "0",
+        "--proto",
+        "=https",
+        "--proto-redir",
+        "=https",
+        "--max-filesize",
+        &max_bytes_arg,
+        "--connect-timeout",
+        &connect_timeout,
+        "--max-time",
+        &max_time,
+    ]);
+    for resolve in &resolve_args {
+        command.args(["--resolve", resolve]);
+    }
+    command.arg(url);
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|err| format!("run curl: {err}"))?;
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "capture HTTPS download failed".to_string())?;
+    let mut bytes = Vec::with_capacity(max_bytes.min(64 * 1024));
+    stdout
+        .by_ref()
+        .take((max_bytes + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|err| format!("read HTTPS download: {err}"))?;
+    if bytes.len() > max_bytes {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(format!("HTTPS download exceeds {max_bytes} byte limit"));
+    }
+    let output = child
+        .wait_with_output()
+        .map_err(|err| format!("wait for curl: {err}"))?;
+    if !output.status.success() {
+        let detail = String::from_utf8_lossy(&output.stderr);
+        let detail = detail.trim();
+        return Err(if detail.is_empty() {
+            format!(
+                "curl exited with status {}",
+                output.status.code().unwrap_or(1)
+            )
+        } else {
+            format!("curl failed: {detail}")
+        });
+    }
+    Ok(bytes)
 }
 
 fn parse_subscription_port(suffix: &str) -> Result<u16, String> {

--- a/crates/magicnet-cli/src/utils.rs
+++ b/crates/magicnet-cli/src/utils.rs
@@ -151,10 +151,17 @@ fn receive_output(reader: Option<OutputReader>, name: &str) -> Vec<u8> {
     }
 }
 
+/// Soft reader that follows symlinks. Prefer [`clean_module_lines`] for
+/// module-owned state so symlink swaps cannot redirect privileged reads.
+#[allow(dead_code)]
 pub(crate) fn clean_lines(path: PathBuf) -> Vec<String> {
     fs::read_to_string(path)
+        .map(|text| filter_clean_lines(&text))
         .unwrap_or_default()
-        .lines()
+}
+
+fn filter_clean_lines(text: &str) -> Vec<String> {
+    text.lines()
         .map(str::trim)
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
         .map(ToOwned::to_owned)
@@ -175,16 +182,22 @@ pub(crate) fn clean_module_lines(app: &App, relative: &Path) -> Result<Vec<Strin
     if file.read_to_string(&mut text).is_err() {
         return Ok(Vec::new());
     }
-    Ok(text
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty() && !line.starts_with('#'))
-        .map(ToOwned::to_owned)
-        .collect())
+    Ok(filter_clean_lines(&text))
 }
 
+/// Soft reader for non-module paths. Prefer [`clean_module_lines`] /
+/// [`first_clean_module_line`] for anything under the module root.
+#[allow(dead_code)]
 pub(crate) fn first_clean_line(path: PathBuf) -> String {
     clean_lines(path).into_iter().next().unwrap_or_default()
+}
+
+pub(crate) fn first_clean_module_line(app: &App, relative: &Path) -> String {
+    clean_module_lines(app, relative)
+        .unwrap_or_default()
+        .into_iter()
+        .next()
+        .unwrap_or_default()
 }
 
 /// Writes an ordinary file below `app.moddir` without resolving any

--- a/crates/magicnet-cli/src/webui_api.rs
+++ b/crates/magicnet-cli/src/webui_api.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::io::Read;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -13,7 +13,7 @@ use crate::connection_control::{
 use crate::node_delay::encode_path_segment;
 use crate::selector_store;
 use crate::service::{apply_config, singbox_webui};
-use crate::subscriptions::validate_subscription_url;
+use crate::subscriptions::{download_pinned_https_url, validate_subscription_url};
 use crate::{run_magicnet_function, write_text_file, App};
 
 pub(crate) fn api_cmd(app: &App, args: &[String]) -> Result<(), String> {
@@ -517,81 +517,19 @@ fn download_panel_zip(url: &str, tmp: &std::path::Path) -> Result<(), String> {
     Ok(())
 }
 
-// The panel archive is unpacked as root. Keep curl's initial-URL and redirect
-// protocol policies adjacent so neither path can silently fall back to HTTP.
-const PANEL_DOWNLOAD_CURL_OPTIONS: [&str; 11] = [
-    "-fL",
-    "--proto",
-    "=https",
-    "--proto-redir",
-    "=https",
-    "--connect-timeout",
-    "15",
-    "--max-time",
-    "90",
-    "--max-filesize",
-    "33554432",
-];
-
 const PANEL_MAX_BYTES: usize = 32 * 1024 * 1024;
 
 fn curl_download(url: &str, tmp: &std::path::Path) -> Result<(), String> {
+    // Panel archives unpack as root. Reuse the subscription pinned-HTTPS
+    // downloader so redirects and private targets cannot re-aim the request.
     let result = (|| {
-        let mut child = Command::new("curl")
-            .args(PANEL_DOWNLOAD_CURL_OPTIONS)
-            .arg(url)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|err| format!("run curl: {err}"))?;
-        let mut stdout = child
-            .stdout
-            .take()
-            .ok_or_else(|| "capture curl response: stdout unavailable".to_string())?;
-        let body = match read_capped(&mut stdout, PANEL_MAX_BYTES) {
-            Ok(body) => body,
-            Err(err) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(err);
-            }
-        };
-        let output = child
-            .wait_with_output()
-            .map_err(|err| format!("wait for curl: {err}"))?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let detail = stderr.trim();
-            return Err(if detail.is_empty() {
-                format!(
-                    "curl exited with status {}",
-                    output.status.code().unwrap_or(1)
-                )
-            } else {
-                format!(
-                    "curl exited with status {}: {detail}",
-                    output.status.code().unwrap_or(1)
-                )
-            });
-        }
+        let body = download_pinned_https_url(url, PANEL_MAX_BYTES, 15, 90)?;
         fs::write(tmp, body).map_err(|err| format!("stage downloaded panel: {err}"))
     })();
     if result.is_err() {
         let _ = fs::remove_file(tmp);
     }
     result
-}
-
-fn read_capped(reader: &mut impl Read, max_bytes: usize) -> Result<Vec<u8>, String> {
-    let mut reader = reader.take(max_bytes as u64 + 1);
-    let mut body = Vec::new();
-    reader
-        .read_to_end(&mut body)
-        .map_err(|err| format!("read panel download: {err}"))?;
-    if body.len() > max_bytes {
-        return Err(format!("downloaded panel exceeds {max_bytes} byte limit"));
-    }
-    Ok(body)
 }
 
 fn validate_sha256(expected: &str) -> Result<(), String> {
@@ -855,33 +793,6 @@ mod tests {
     fn panel_download_size_limit_is_enforced() {
         assert!(ensure_panel_size(PANEL_MAX_BYTES).is_ok());
         assert!(ensure_panel_size(PANEL_MAX_BYTES + 1).is_err());
-    }
-
-    #[test]
-    fn oversized_stream_is_probed_once_past_the_limit_and_rejected() {
-        let mut reader = std::io::Cursor::new(b"12345".to_vec());
-        assert!(read_capped(&mut reader, 4).is_err());
-        assert_eq!(reader.position(), 5, "only the bounded probe may be read");
-    }
-
-    #[test]
-    fn panel_download_curl_requires_https_for_initial_and_redirect_urls() {
-        assert_eq!(
-            PANEL_DOWNLOAD_CURL_OPTIONS,
-            [
-                "-fL",
-                "--proto",
-                "=https",
-                "--proto-redir",
-                "=https",
-                "--connect-timeout",
-                "15",
-                "--max-time",
-                "90",
-                "--max-filesize",
-                "33554432",
-            ]
-        );
     }
 
     #[test]

--- a/crates/magicnet-cli/src/wifi.rs
+++ b/crates/magicnet-cli/src/wifi.rs
@@ -5,9 +5,9 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::diagnostics::supervisor_pid;
-use crate::utils::command_text_full_timeout;
+use crate::utils::{clean_module_lines, command_text_full_timeout};
 use crate::webui_api::{current_clash_mode, set_clash_mode};
-use crate::{clean_lines, read_kv, run_magicnet_function, write_kv, write_text_file, App};
+use crate::{read_kv, run_magicnet_function, write_kv, write_text_file, App};
 
 const DEFAULT_INTERVAL_SECONDS: u64 = 5;
 const MIN_INTERVAL_SECONDS: u64 = 3;
@@ -119,14 +119,6 @@ fn policy_config_path(app: &App) -> std::path::PathBuf {
     app.moddir.join(WIFI_POLICY_CONF)
 }
 
-fn ssid_list_path(app: &App) -> std::path::PathBuf {
-    app.moddir.join(WIFI_SSID_LIST)
-}
-
-fn bssid_list_path(app: &App) -> std::path::PathBuf {
-    app.moddir.join(WIFI_BSSID_LIST)
-}
-
 fn read_policy_config(app: &App) -> PolicyConfig {
     let values = read_kv(policy_config_path(app));
     let mode = values
@@ -226,11 +218,12 @@ enum ListAction {
 
 fn update_list(app: &App, kind: ListKind, value: &str, action: ListAction) -> Result<(), String> {
     let value = normalize_list_value(kind, value)?;
-    let (path, relative) = match kind {
-        ListKind::Ssid => (ssid_list_path(app), WIFI_SSID_LIST),
-        ListKind::Bssid => (bssid_list_path(app), WIFI_BSSID_LIST),
+    let relative = match kind {
+        ListKind::Ssid => WIFI_SSID_LIST,
+        ListKind::Bssid => WIFI_BSSID_LIST,
     };
-    let mut values = clean_lines(path)
+    let mut values = clean_module_lines(app, Path::new(relative))
+        .unwrap_or_default()
         .into_iter()
         .map(|item| match kind {
             ListKind::Ssid => item,
@@ -307,8 +300,9 @@ fn apply_network(
     network: &WifiNetwork,
     verbose: bool,
 ) -> Result<bool, String> {
-    let ssids = clean_lines(ssid_list_path(app));
-    let bssids = clean_lines(bssid_list_path(app))
+    let ssids = clean_module_lines(app, Path::new(WIFI_SSID_LIST)).unwrap_or_default();
+    let bssids = clean_module_lines(app, Path::new(WIFI_BSSID_LIST))
+        .unwrap_or_default()
         .into_iter()
         .filter_map(|value| normalize_bssid(&value))
         .collect::<Vec<_>>();
@@ -604,8 +598,9 @@ fn write_last_state(
 fn print_status(app: &App) {
     let config = read_policy_config(app);
     let network = detect_wifi();
-    let ssids = clean_lines(ssid_list_path(app));
-    let bssids = clean_lines(bssid_list_path(app))
+    let ssids = clean_module_lines(app, Path::new(WIFI_SSID_LIST)).unwrap_or_default();
+    let bssids = clean_module_lines(app, Path::new(WIFI_BSSID_LIST))
+        .unwrap_or_default()
         .into_iter()
         .filter_map(|value| normalize_bssid(&value))
         .collect::<Vec<_>>();

--- a/scripts/test-block-conf-safety.sh
+++ b/scripts/test-block-conf-safety.sh
@@ -71,4 +71,21 @@ magicnet_block_load_conf
 assert_eq "$MAGICNET_BLOCK_ENABLED" '1' 'unknown field is rejected'
 assert_eq "$MAGICNET_BLOCK_URL" "$default_url" 'unknown field resets URL'
 
+printf '%s\n' \
+    'MAGICNET_BLOCK_ENABLED=0' \
+    'MAGICNET_BLOCK_COMMUNITY_ENABLED=0' \
+    'MAGICNET_BLOCK_URL=http://example.com/community.yaml' \
+    >"$conf"
+magicnet_block_load_conf
+assert_eq "$MAGICNET_BLOCK_ENABLED" '1' 'plaintext URL is rejected'
+assert_eq "$MAGICNET_BLOCK_URL" "$default_url" 'plaintext URL resets to default'
+
+printf '%s\n' \
+    'MAGICNET_BLOCK_ENABLED=0' \
+    'MAGICNET_BLOCK_COMMUNITY_ENABLED=0' \
+    'MAGICNET_BLOCK_URL=https://127.0.0.1/community.yaml' \
+    >"$conf"
+magicnet_block_load_conf
+assert_eq "$MAGICNET_BLOCK_URL" "$default_url" 'loopback URL is rejected'
+
 printf 'block.conf parser safety test passed\n'

--- a/src/MagicNet/lib/magicnet/blocklist.sh
+++ b/src/MagicNet/lib/magicnet/blocklist.sh
@@ -23,13 +23,44 @@ magicnet_block_allow_file() {
 }
 
 magicnet_block_conf_url_is_safe() {
+    # Align with CLI validate_subscription_url + shell_inert_conf_value:
+    # HTTPS only, no credentials, inert charset, and no private IP literals.
     case "$1" in
-        http://*|https://*) ;;
+        https://*) ;;
         *) return 1 ;;
     esac
     case "$1" in
-        ''|*[!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._:/?=%+@,-]*) return 1 ;;
+        *@*) return 1 ;;
     esac
+    case "$1" in
+        ''|*[!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._:/?=%+,-]*) return 1 ;;
+    esac
+    _block_url_host="${1#https://}"
+    _block_url_host="${_block_url_host%%/*}"
+    _block_url_host="${_block_url_host%%\?*}"
+    _block_url_host="${_block_url_host%%#*}"
+    case "$_block_url_host" in
+        \[*\]*)
+            _block_url_host="${_block_url_host#\[}"
+            _block_url_host="${_block_url_host%%\]*}"
+            case "$_block_url_host" in
+                ::1|::|0:0:0:0:0:0:0:1|0:0:0:0:0:0:0:0|fe80:*|fc*|fd*)
+                    unset _block_url_host
+                    return 1
+                    ;;
+            esac
+            ;;
+        *:*)
+            _block_url_host="${_block_url_host%:*}"
+            ;;
+    esac
+    case "$_block_url_host" in
+        localhost|localhost.*|127.*|0.0.0.0|10.*|192.168.*|169.254.*|172.1[6-9].*|172.2[0-9].*|172.3[0-1].*)
+            unset _block_url_host
+            return 1
+            ;;
+    esac
+    unset _block_url_host
     return 0
 }
 

--- a/src/MagicNet/lib/magicnet/chain.sh
+++ b/src/MagicNet/lib/magicnet/chain.sh
@@ -19,8 +19,7 @@ magicnet_singbox_chain_config_file() {
 }
 
 magicnet_singbox_chain_jq() {
-    [ -x "${MODDIR}/bin/jq" ] || return 1
-    printf '%s\n' "${MODDIR}/bin/jq"
+    magicnet_jq
 }
 
 magicnet_singbox_chain_apply() {

--- a/src/MagicNet/lib/magicnet/common.sh
+++ b/src/MagicNet/lib/magicnet/common.sh
@@ -27,7 +27,14 @@ magicnet_module_disabled() {
 }
 
 magicnet_json_escape() {
-    LC_ALL=C printf '%s' "$1" | sed 's/[[:cntrl:]]//g; s/\\/\\\\/g; s/"/\\"/g'
+    # Normalize line breaks before stripping remaining controls so subscription
+    # tags and route domains cannot inject raw newlines into generated JSON.
+    LC_ALL=C printf '%s' "$1" | tr '\r\n\t' '   ' | sed 's/[[:cntrl:]]//g; s/\\/\\\\/g; s/"/\\"/g'
+}
+
+magicnet_jq() {
+    [ -x "${MODDIR}/bin/jq" ] || return 1
+    printf '%s\n' "${MODDIR}/bin/jq"
 }
 
 # Persisted *.conf files are data. Never source them into the privileged
@@ -91,7 +98,7 @@ magicnet_first_http_url() {
             line = $0
             sub(/[[:space:]]*#.*$/, "", line)
             gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
-            if (line ~ /^https?:\/\/[^[:space:]]+$/) {
+            if (line ~ /^https:\/\/[^[:space:]@]+$/) {
                 print line
                 found = 1
                 exit 0
@@ -106,8 +113,16 @@ magicnet_singbox_has_subscription() {
         magicnet_first_http_url "${MODDIR}/.config/sing-box/subscription.url" >/dev/null 2>&1
 }
 
+magicnet_subscription_schedule_file() {
+    printf '%s\n' "${MODDIR}/.config/magicnet/subscription-refresh-hours"
+}
+
 magicnet_singbox_config_has_nodes() {
-    _config="${MODDIR}/.config/sing-box/config.json"
+    if command -v magicnet_singbox_subscription_config_file >/dev/null 2>&1; then
+        _config=$(magicnet_singbox_subscription_config_file)
+    else
+        _config="${MAGICNET_SUB_CONFIG_FILE:-${MODDIR}/.config/sing-box/config.json}"
+    fi
     [ -f "$_config" ] || {
         unset _config
         return 1
@@ -262,14 +277,47 @@ magicnet_preferred_core() {
     printf '%s\n' "sing-box"
 }
 
+# Read /proc/<pid>/stat starttime. Optional second argument overrides the proc
+# root (tests inject a fixture tree via MAGICNET_SUB_REFRESH_PROC_ROOT).
+magicnet_proc_start() {
+    _proc_pid="$1"
+    _proc_root="${2:-${MAGICNET_PROC_ROOT:-/proc}}"
+    case "$_proc_pid" in
+        '' | *[!0-9]*)
+            unset _proc_pid _proc_root
+            return 1
+            ;;
+    esac
+    case "$_proc_root" in
+        /*) ;;
+        *)
+            unset _proc_pid _proc_root
+            return 1
+            ;;
+    esac
+    _proc_stat="${_proc_root}/${_proc_pid}/stat"
+    [ -r "$_proc_stat" ] || {
+        unset _proc_pid _proc_root _proc_stat
+        return 1
+    }
+    _proc_start="$(awk '{ line = $0; sub(/^.*\) /, "", line); count = split(line, field, /[[:space:]]+/); if (count >= 20) print field[20] }' \
+        "$_proc_stat" 2>/dev/null || true)"
+    case "$_proc_start" in
+        '' | *[!0-9]*)
+            unset _proc_pid _proc_root _proc_stat _proc_start
+            return 1
+            ;;
+    esac
+    printf '%s\n' "$_proc_start"
+    unset _proc_pid _proc_root _proc_stat _proc_start
+}
+
 magicnet_config_lock_dir() {
     printf '%s\n' "$MODDIR/.state/config.lock"
 }
 
 magicnet_config_lock_proc_start() {
-    case "$1" in '' | *[!0-9]*) return 1 ;; esac
-    awk '{ line = $0; sub(/^.*\) /, "", line); count = split(line, field, /[[:space:]]+/); if (count >= 20) print field[20] }' \
-        "/proc/$1/stat" 2>/dev/null || true
+    magicnet_proc_start "$1"
 }
 
 magicnet_config_lock_proc_live() {

--- a/src/MagicNet/lib/magicnet/network.sh
+++ b/src/MagicNet/lib/magicnet/network.sh
@@ -368,10 +368,6 @@ magicnet_dns_leak_guard_state_file() {
     printf '%s\n' "${MODDIR}/.state/dns-leak-guard.ifaces"
 }
 
-magicnet_dns_leak_guard_supported_for_mode() {
-    return 0
-}
-
 magicnet_dns_leak_guard_delete_rule() (
     _dns_guard_delete_cmd="$1"
     shift
@@ -639,8 +635,4 @@ magicnet_after_kernel_start_deferred_unlocked() {
     fi
     unset _deferred_failures _deferred_failure_names
     return 0
-}
-
-magicnet_after_kernel_start_deferred() {
-    magicnet_after_kernel_start_deferred_unlocked
 }

--- a/src/MagicNet/lib/magicnet/routes.sh
+++ b/src/MagicNet/lib/magicnet/routes.sh
@@ -43,8 +43,7 @@ magicnet_hotspot_source_cidrs() {
 }
 
 magicnet_hotspot_jq() {
-    [ -x "${MODDIR}/bin/jq" ] || return 1
-    printf '%s\n' "${MODDIR}/bin/jq"
+    magicnet_jq
 }
 
 magicnet_hotspot_source_cidrs_json() {

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/common.sh
@@ -2,11 +2,15 @@
 #
 # Import common Clash-style subscription nodes into the bundled sing-box config.
 
-magicnet_json_escape() {
-    printf '%s' "$1" |
-        tr '\r\n\t' '   ' |
-        sed 's/[[:cntrl:]]//g; s/\\/\\\\/g; s/"/\\"/g'
-}
+# Prefer the module-runtime JSON escaper when already loaded; keep a compatible
+# definition for isolated subscription smoke tests that only source this file.
+if ! command -v magicnet_json_escape >/dev/null 2>&1; then
+    magicnet_json_escape() {
+        printf '%s' "$1" |
+            tr '\r\n\t' '   ' |
+            sed 's/[[:cntrl:]]//g; s/\\/\\\\/g; s/"/\\"/g'
+    }
+fi
 
 # Extract a JSON string value while preserving its JSON escapes. This is the
 # jq-free path used on Android; preserving escapes lets generated JSON carry
@@ -452,9 +456,28 @@ magicnet_singbox_subscription_status_file() {
     printf '%s\n' "${MODDIR}/.state/sing-box/subscription-status"
 }
 
-magicnet_subscription_schedule_file() {
-    printf '%s\n' "${MODDIR}/.config/magicnet/subscription-refresh-hours"
-}
+if ! command -v magicnet_subscription_schedule_file >/dev/null 2>&1; then
+    magicnet_subscription_schedule_file() {
+        printf '%s\n' "${MODDIR}/.config/magicnet/subscription-refresh-hours"
+    }
+fi
+
+# Keep the strict node-presence check available when the subscription library is
+# loaded without the full module runtime.
+if ! command -v magicnet_singbox_config_has_nodes >/dev/null 2>&1; then
+    magicnet_singbox_config_has_nodes() {
+        _config="${MAGICNET_SUB_CONFIG_FILE:-${MODDIR}/.config/sing-box/config.json}"
+        [ -f "$_config" ] || {
+            unset _config
+            return 1
+        }
+        grep -Eq '"type"[[:space:]]*:[[:space:]]*"(vless|hysteria2|trojan|vmess|shadowsocks|wireguard|tuic|anytls|socks)"' "$_config" &&
+            magicnet_singbox_ai_selectors_canonical "$_config"
+        _rc=$?
+        unset _config
+        return "$_rc"
+    }
+fi
 
 magicnet_singbox_subscription_fingerprint() {
     _fingerprint_value="$1"

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
@@ -939,12 +939,7 @@ magicnet_singbox_restart_if_running() {
 magicnet_singbox_api_has_nodes() {
     _api=$(curl -sS --max-time 5 http://127.0.0.1:9090/proxies 2>/dev/null || curl -sS --max-time 5 http://127.0.0.1:9090/providers/proxies 2>/dev/null || true)
     [ -n "$_api" ] || return 1
-    printf '%s' "$_api" | grep -Eq '"type":"(VLESS|Hysteria2|Trojan|VMess|Shadowsocks|AnyTLS|TUIC|Socks|SOCKS|Selector)"'
-}
-
-magicnet_singbox_config_has_nodes() {
-    _config_file=$(magicnet_singbox_subscription_config_file)
-    grep -Eq '"type"[[:space:]]*:[[:space:]]*"(vless|hysteria2|trojan|vmess|shadowsocks|anytls|tuic|socks)"' "$_config_file"
+    printf '%s' "$_api" | grep -Eq '"type":"(VLESS|Hysteria2|Trojan|VMess|Shadowsocks|AnyTLS|TUIC|Socks|SOCKS|Selector|WireGuard)"'
 }
 
 magicnet_singbox_google_works() {

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
@@ -1,6 +1,23 @@
 magicnet_singbox_proc_start() {
+    # Path form kept for update-lock fixtures that only source this file.
+    _proc_stat_path="$1"
+    case "$_proc_stat_path" in
+        */[0-9]*/stat)
+            _proc_pid="${_proc_stat_path%/stat}"
+            _proc_pid="${_proc_pid##*/}"
+            _proc_root="${_proc_stat_path%/"$_proc_pid"/stat}"
+            if command -v magicnet_proc_start >/dev/null 2>&1; then
+                magicnet_proc_start "$_proc_pid" "$_proc_root"
+                _proc_rc=$?
+                unset _proc_stat_path _proc_pid _proc_root
+                return "$_proc_rc"
+            fi
+            unset _proc_pid _proc_root
+            ;;
+    esac
     awk '{ line = $0; sub(/^.*\) /, "", line); count = split(line, field, /[[:space:]]+/); if (count >= 20) print field[20] }' \
-        "$1" 2>/dev/null || true
+        "$_proc_stat_path" 2>/dev/null || true
+    unset _proc_stat_path
 }
 
 # Read-only lock probe for status/reporting paths.

--- a/src/MagicNet/lib/magicnet/supervisors.sh
+++ b/src/MagicNet/lib/magicnet/supervisors.sh
@@ -444,18 +444,6 @@ magicnet_wifi_policy_stop() {
     unset _wifi_policy_pid_file _wifi_policy_pid
 }
 
-magicnet_wifi_policy_status() {
-    _wifi_policy_pid_file="$(magicnet_wifi_policy_pid_file)"
-    _wifi_policy_pid="$(sed -n '1p' "$_wifi_policy_pid_file" 2>/dev/null || true)"
-    if magicnet_wifi_policy_pid_matches "$_wifi_policy_pid"; then
-        printf '%s\n' "$_wifi_policy_pid"
-        unset _wifi_policy_pid_file _wifi_policy_pid
-        return 0
-    fi
-    unset _wifi_policy_pid_file _wifi_policy_pid
-    return 1
-}
-
 magicnet_subscription_refresh_name() {
     printf '%s\n' "magicnet-subscription-refresh"
 }
@@ -477,35 +465,7 @@ magicnet_subscription_refresh_loop_file() {
 }
 
 magicnet_subscription_refresh_proc_start() {
-    _refresh_proc_pid="$1"
-    _refresh_proc_root="${MAGICNET_SUB_REFRESH_PROC_ROOT:-/proc}"
-    case "$_refresh_proc_pid" in
-        '' | *[!0-9]*)
-            unset _refresh_proc_pid _refresh_proc_root
-            return 1
-            ;;
-    esac
-    case "$_refresh_proc_root" in
-        /*) ;;
-        *)
-            unset _refresh_proc_pid _refresh_proc_root
-            return 1
-            ;;
-    esac
-    _refresh_proc_stat="${_refresh_proc_root}/${_refresh_proc_pid}/stat"
-    [ -r "$_refresh_proc_stat" ] || {
-        unset _refresh_proc_pid _refresh_proc_root _refresh_proc_stat
-        return 1
-    }
-    _refresh_proc_start="$(awk '{ line = $0; sub(/^.*\) /, "", line); count = split(line, field, /[[:space:]]+/); if (count >= 20) print field[20] }' \
-        "$_refresh_proc_stat" 2>/dev/null || true)"
-    case "$_refresh_proc_start" in '' | *[!0-9]*)
-        unset _refresh_proc_pid _refresh_proc_root _refresh_proc_stat _refresh_proc_start
-        return 1
-        ;;
-    esac
-    printf '%s\n' "$_refresh_proc_start"
-    unset _refresh_proc_pid _refresh_proc_root _refresh_proc_stat _refresh_proc_start
+    magicnet_proc_start "$1" "${MAGICNET_SUB_REFRESH_PROC_ROOT:-/proc}"
 }
 
 magicnet_subscription_refresh_proc_command_matches() {
@@ -773,10 +733,6 @@ magicnet_subscription_refresh_owner_state() {
     unset _refresh_state_owner _refresh_state_record
     unset _refresh_owner_record _refresh_owner_pid _refresh_owner_rest _refresh_owner_start _refresh_owner_identity
     return "$_refresh_state_rc"
-}
-
-magicnet_subscription_schedule_file() {
-    printf '%s\n' "${MODDIR}/.config/magicnet/subscription-refresh-hours"
 }
 
 magicnet_subscription_schedule_interval() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

排查并修复了若干高优先级安全与正确性问题，同时收敛 shell/CLI 中重复的辅助实现。

### Security
- Community blocklist 与 WebUI panel 下载改为复用 `download_pinned_https_url`：HTTPS-only、禁止重定向、DNS 解析后拒绝私网地址，并用 `--resolve` 钉住目标（对齐订阅拉取策略，堵住 `-L` 重定向 SSRF）。
- Shell `magicnet_block_conf_url_is_safe` 对齐 CLI：仅 HTTPS、拒绝凭证与明显私网字面量。
- 模块列表/订阅/Wi-Fi 等读取路径从会跟随符号链接的 `clean_lines` 迁到 `clean_module_lines`（`O_NOFOLLOW` 边界）。

### Dedup / quality
- 统一 `magicnet_json_escape`（含 CR/LF/TAB 规范化），避免订阅库覆盖模块运行时后策略分叉。
- 删除较弱的 `magicnet_singbox_config_has_nodes` 重定义；保留严格实现并尊重 `MAGICNET_SUB_CONFIG_FILE`。
- 新增共享 `magicnet_proc_start` / `magicnet_jq`；锁与 supervisor 刷新、hotspot/chain jq 走同一入口。
- 订阅存在性检查改为仅识别 `https://` URL。
- 去掉未使用的 `magicnet_wifi_policy_status`、`magicnet_dns_leak_guard_supported_for_mode`、空壳 deferred wrapper。

### Tests
- `cargo test -p magicnet-cli`：345 + integration 通过
- 相关 shell 回归通过；已补 rustfmt，修复 Code Quality / rust 格式检查失败

### Follow-ups（未改，避免过大 diff）
- kamfw `panel_*` 重定义、MCP files TOCTOU、CLI/MCP base64 与 bounded process 抽公共 crate、mkdir 锁栈参数化。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccb97e50-c639-4b53-a0d0-8ac25bbe3130?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccb97e50-c639-4b53-a0d0-8ac25bbe3130&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Sourcery 摘要

增强下载和模块状态处理，防范 SSRF 和符号链接攻击，同时整合重复的 Shell 和 CLI 辅助函数。

错误修复：
- 加强社区黑名单和 WebUI 面板下载的安全性，仅允许固定的 HTTPS 连接，禁止重定向或指向私有地址。
- 防止读取模块自有列表和订阅内容时跟随符号链接，并在 Shell 运行时拒绝不安全的黑名单 URL。
- 将订阅检测限制为 HTTPS URL，并在检查 sing-box 节点时保留已配置的订阅文件。

改进：
- 整合 Shell 和 CLI 代码中的 JSON 转义、jq 查找、进程启动时间检测和订阅辅助函数实现。
- 移除未使用的策略函数和延迟包装函数，并简化共享的模块列表处理。

测试：
- 扩展区块配置安全性测试，覆盖明文 URL 和回环地址，同时保留现有的 CLI 和 Shell 安全性测试覆盖范围。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden download and module-state handling against SSRF and symlink attacks while consolidating duplicated shell and CLI helpers.

Bug Fixes:
- Harden community blocklist and WebUI panel downloads to allow only pinned HTTPS connections without redirects or private-address targets.
- Prevent module-owned list and subscription reads from following symlinks, and reject unsafe blocklist URLs in the shell runtime.
- Restrict subscription detection to HTTPS URLs and preserve the configured subscription file when checking sing-box nodes.

Enhancements:
- Consolidate JSON escaping, jq lookup, process start-time detection, and subscription helper implementations across the shell and CLI code.
- Remove unused policy and deferred-wrapper functions and simplify shared module-list handling.

Tests:
- Extend block configuration safety coverage for plaintext and loopback URLs while retaining the existing CLI and shell safety test coverage.

</details>