### PR TITLE
fix: preserve route-rule precedence

### DIFF
--- a/scripts/test-block-apply-safety.sh
+++ b/scripts/test-block-apply-safety.sh
@@ -69,14 +69,16 @@ magicnet_singbox_insert_route_rules \
 jq -e . "$route_hint" >/dev/null
 rm -f "$route_hint"
 
-# Managed ad rules must follow sniffing, ICMP handling, and per-app proxy
-# policy. Placing them before these precedence rules can evaluate domains
-# before sniffing and bypass the selected application route.
+# Managed ad rules must follow custom routes, sniffing, ICMP handling, and
+# per-app proxy policy. Placing them before these precedence rules can override
+# an explicit custom route, evaluate domains before sniffing, or bypass the
+# selected application route.
 cat >"$MODDIR/.config/sing-box/config.json" <<'EOF'
 {"outbounds":[
   {"type":"direct","tag":"direct"},
   {"type":"selector","tag":"final","outbounds":["direct"],"default":"direct"}
 ],"route":{"rules":[
+  {"domain_suffix":["__magicnet_route__","custom.example"],"outbound":"proxy-rule"},
   {"action":"sniff"},
   {"protocol":"icmp","outbound":"block"},
   {"package_name":["__magicnet_app_proxy__","com.example.proxy"],"outbound":"proxy"},
@@ -90,12 +92,13 @@ magicnet_singbox_insert_route_rules \
   "$MODDIR/.config/sing-box/config.json" "$route_hint" "$route_rules" block
 jq -e '
   [.route.rules[]
-    | if .action == "sniff" then "sniff"
+    | if ((.domain_suffix // []) | index("__magicnet_route__")) != null then "route"
+      elif .action == "sniff" then "sniff"
       elif .protocol == "icmp" then "icmp"
       elif ((.package_name // []) | index("__magicnet_app_proxy__")) != null then "app"
       elif ((.domain // []) | index("__magicnet_block__")) != null then "block"
       else "final"
-      end] == ["sniff", "icmp", "app", "block", "final"]
+      end] == ["route", "sniff", "icmp", "app", "block", "final"]
 ' "$route_hint" >/dev/null
 rm -f "$route_hint"
 

--- a/scripts/test-block-apply-safety.sh
+++ b/scripts/test-block-apply-safety.sh
@@ -69,6 +69,36 @@ magicnet_singbox_insert_route_rules \
 jq -e . "$route_hint" >/dev/null
 rm -f "$route_hint"
 
+# Managed ad rules must follow sniffing, ICMP handling, and per-app proxy
+# policy. Placing them before these precedence rules can evaluate domains
+# before sniffing and bypass the selected application route.
+cat >"$MODDIR/.config/sing-box/config.json" <<'EOF'
+{"outbounds":[
+  {"type":"direct","tag":"direct"},
+  {"type":"selector","tag":"final","outbounds":["direct"],"default":"direct"}
+],"route":{"rules":[
+  {"action":"sniff"},
+  {"protocol":"icmp","outbound":"block"},
+  {"package_name":["__magicnet_app_proxy__","com.example.proxy"],"outbound":"proxy"},
+  {"outbound":"final"}
+]}}
+EOF
+cat >"$route_rules" <<'EOF'
+  {"domain":["__magicnet_block__"],"outbound":"ad-block"},
+EOF
+magicnet_singbox_insert_route_rules \
+  "$MODDIR/.config/sing-box/config.json" "$route_hint" "$route_rules" block
+jq -e '
+  [.route.rules[]
+    | if .action == "sniff" then "sniff"
+      elif .protocol == "icmp" then "icmp"
+      elif ((.package_name // []) | index("__magicnet_app_proxy__")) != null then "app"
+      elif ((.domain // []) | index("__magicnet_block__")) != null then "block"
+      else "final"
+      end] == ["sniff", "icmp", "app", "block", "final"]
+' "$route_hint" >/dev/null
+rm -f "$route_hint"
+
 magicnet_block_apply_singbox
 jq -e '
   ([.outbounds[] | select(.tag == "ad-block")] | length == 1)

--- a/src/MagicNet/lib/magicnet/singbox_route_rules.sh
+++ b/src/MagicNet/lib/magicnet/singbox_route_rules.sh
@@ -49,11 +49,14 @@ magicnet_singbox_insert_route_rules() (
           else
             has_value("domain_suffix"; "__magicnet_route__")
           end;
-        def is_boundary:
+        def is_block_precedence_rule:
+          has("action")
+            or ((has_value("protocol"; "icmp")) and ((.outbound? // "") == "block"))
+            or has_value("package_name"; "__magicnet_app_proxy__")
+            or has_value("domain"; "__magicnet_app_proxy__");
+        def is_insertion_point:
           if $mode == "block" then
-            has("action")
-              or ((has_value("protocol"; "icmp")) and ((.outbound? // "") == "block"))
-              or has_value("domain"; "__magicnet_app_proxy__")
+            (is_block_precedence_rule | not)
           else
             (.action? // "") == "sniff"
           end;
@@ -63,7 +66,7 @@ magicnet_singbox_insert_route_rules() (
           ($managed[0] // []) as $new
           | (.route.rules | map(select(is_managed | not))) as $clean
           | ([range(0; ($clean | length)) as $index
-              | select($clean[$index] | is_boundary)
+              | select($clean[$index] | is_insertion_point)
               | $index][0] // ($clean | length)) as $position
           | .route.rules = (
               $clean[0:$position] + $new + $clean[$position:]

--- a/src/MagicNet/lib/magicnet/singbox_route_rules.sh
+++ b/src/MagicNet/lib/magicnet/singbox_route_rules.sh
@@ -50,7 +50,8 @@ magicnet_singbox_insert_route_rules() (
             has_value("domain_suffix"; "__magicnet_route__")
           end;
         def is_block_precedence_rule:
-          has("action")
+          has_value("domain_suffix"; "__magicnet_route__")
+            or has("action")
             or ((has_value("protocol"; "icmp")) and ((.outbound? // "") == "block"))
             or has_value("package_name"; "__magicnet_app_proxy__")
             or has_value("domain"; "__magicnet_app_proxy__");


### PR DESCRIPTION
## Summary

- insert managed ad rules after sniff, ICMP-block, and per-app proxy rules
- recognize the real `package_name: ["__magicnet_app_proxy__", ...]` marker used by application routing
- add a structural ordering regression test

## Why

The jq route-rule rewrite selected the first precedence rule as the insertion point, placing ad rules before it. That can evaluate domain rules before sniffing and let ad policy run before the configured per-app proxy route.

The previous line-oriented implementation intentionally skipped these precedence rules and inserted immediately before the first ordinary routing rule.

## Validation

- `test-block-apply-safety.sh`
- `test-ad-routing.sh`
- `test-app-routing-policy.sh`
- `test-route-apply-safety.sh`
- `test-singbox-route-apply-safety.sh`
- `test-action-routing.sh`
- `test-policy-architecture.sh`
- `git diff --check`

## Sourcery 摘要

在插入托管广告路由规则时，保留路由规则的优先级顺序。

错误修复：
- 通过将托管广告规则插入到嗅探、ICMP 阻止和应用代理策略之后，保留路由规则的优先级顺序。

增强功能：
- 在确定路由规则优先级顺序时，识别应用路由软件包标记。

测试：
- 添加结构回归测试，涵盖优先级顺序和托管广告规则的排列。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

插入托管广告规则时保留路由规则的优先级。

错误修复：
- 通过将托管广告规则插入到自定义路由、嗅探、ICMP 阻止规则和按应用代理规则之后，保留路由规则的优先级。

增强功能：
- 确定插入位置时识别应用路由软件包标记。

测试：
- 添加结构回归测试，涵盖托管广告规则所需的顺序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve route-rule precedence when inserting managed ad rules.

Bug Fixes:
- Preserve route-rule precedence by inserting managed ad rules after custom routes, sniffing, ICMP blocking, and per-app proxy rules.

Enhancements:
- Recognize the application-routing package marker when determining the insertion position.

Tests:
- Add a structural regression test covering the required ordering of managed ad rules.

</details>

</details>