### PR TITLE
fix: load subscription API validation standalone

### DIFF
--- a/scripts/singbox-subscription-protocol-smoke.sh
+++ b/scripts/singbox-subscription-protocol-smoke.sh
@@ -24,6 +24,19 @@ trap cleanup EXIT
 
 # shellcheck disable=SC2034
 MODDIR="$MODULE_ROOT"
+
+# The isolated bootstrap provides command discovery only as a fallback. Tests
+# and embedding callers may inject a narrower resolver before sourcing it.
+(
+    magicnet_cmd_exists() { [[ "$1" == fixture-command ]]; }
+    # shellcheck disable=SC1090
+    . "$MODULE_ROOT/lib/magicnet/subscribe_bootstrap.sh"
+    magicnet_cmd_exists fixture-command \
+        || fail "subscription bootstrap replaced an injected command resolver"
+    ! magicnet_cmd_exists curl \
+        || fail "injected command resolver no longer controls discovery"
+)
+
 # shellcheck disable=SC1090
 . "$MODULE_ROOT/lib/magicnet_singbox_subscribe.sh"
 

--- a/scripts/singbox-subscription-protocol-smoke.sh
+++ b/scripts/singbox-subscription-protocol-smoke.sh
@@ -27,6 +27,15 @@ MODDIR="$MODULE_ROOT"
 # shellcheck disable=SC1090
 . "$MODULE_ROOT/lib/magicnet_singbox_subscribe.sh"
 
+type magicnet_singbox_api_has_nodes >/dev/null 2>&1 \
+    || fail "standalone subscription loader omitted sing-box API validation"
+curl() {
+    printf '%s\n' '{"proxies":{"fixture":{"type":"VLESS"}}}'
+}
+magicnet_singbox_api_has_nodes \
+    || fail "standalone sing-box API validation rejected a node response"
+unset -f curl
+
 magicnet_singbox_tag_is_reserved hotspot \
     || fail "jq-free reserved-tag fallback does not protect the hotspot selector"
 

--- a/src/MagicNet/lib/magicnet/common.sh
+++ b/src/MagicNet/lib/magicnet/common.sh
@@ -30,10 +30,6 @@ magicnet_warn() {
     warn "$1"
 }
 
-magicnet_cmd_exists() {
-    command -v "$1" >/dev/null 2>&1
-}
-
 magicnet_module_disabled() {
     [ -f "${MODDIR}/disable" ] || [ -f "${MODDIR}/remove" ]
 }
@@ -105,20 +101,6 @@ magicnet_first_http_url() {
 magicnet_singbox_has_subscription() {
     [ -s "${MODDIR}/.config/sing-box/subscription.local" ] ||
         magicnet_first_http_url "${MODDIR}/.config/sing-box/subscription.url" >/dev/null 2>&1
-}
-
-magicnet_singbox_api_has_nodes() {
-    magicnet_cmd_exists curl || return 1
-    _api=$(curl -sS --max-time 5 http://127.0.0.1:9090/proxies 2>/dev/null ||
-        curl -sS --max-time 5 http://127.0.0.1:9090/providers/proxies 2>/dev/null || true)
-    [ -n "$_api" ] || {
-        unset _api
-        return 1
-    }
-    printf '%s' "$_api" | grep -Eq '"type":"(VLESS|Hysteria2|Trojan|VMess|Shadowsocks|AnyTLS|TUIC|Socks|SOCKS|Selector|WireGuard)"'
-    _rc=$?
-    unset _api
-    return "$_rc"
 }
 
 magicnet_singbox_standalone_config_ready() {

--- a/src/MagicNet/lib/magicnet/subscribe_bootstrap.sh
+++ b/src/MagicNet/lib/magicnet/subscribe_bootstrap.sh
@@ -2,6 +2,24 @@
 #
 # Kamfw-free helpers for isolated sing-box subscription loads.
 
+magicnet_cmd_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+magicnet_singbox_api_has_nodes() {
+    magicnet_cmd_exists curl || return 1
+    _api=$(curl -sS --max-time 5 http://127.0.0.1:9090/proxies 2>/dev/null ||
+        curl -sS --max-time 5 http://127.0.0.1:9090/providers/proxies 2>/dev/null || true)
+    [ -n "$_api" ] || {
+        unset _api
+        return 1
+    }
+    printf '%s' "$_api" | grep -Eq '"type":"(VLESS|Hysteria2|Trojan|VMess|Shadowsocks|AnyTLS|TUIC|Socks|SOCKS|Selector|WireGuard)"'
+    _rc=$?
+    unset _api
+    return "$_rc"
+}
+
 magicnet_singbox_config_file() {
     printf '%s\n' "${MAGICNET_SUB_CONFIG_FILE:-${MODDIR}/.config/sing-box/config.json}"
 }

--- a/src/MagicNet/lib/magicnet/subscribe_bootstrap.sh
+++ b/src/MagicNet/lib/magicnet/subscribe_bootstrap.sh
@@ -2,7 +2,7 @@
 #
 # Kamfw-free helpers for isolated sing-box subscription loads.
 
-magicnet_cmd_exists() {
+type magicnet_cmd_exists >/dev/null 2>&1 || magicnet_cmd_exists() {
     command -v "$1" >/dev/null 2>&1
 }
 


### PR DESCRIPTION
## Summary

- make `magicnet_cmd_exists` and `magicnet_singbox_api_has_nodes` available through the Kamfw-free subscription bootstrap
- remove duplicate definitions from the full runtime loader
- verify the standalone subscription loader can inspect a live sing-box API response

## Why

`magicnet_singbox_subscribe.sh` loads `subscribe_bootstrap.sh` directly, not the top-level runtime `common.sh`. Its readiness path calls `magicnet_singbox_api_has_nodes` when sing-box is running, so isolated subscription updates could hit a missing command and skip API validation.

## Validation

- `singbox-subscription-protocol-smoke.sh`
- `test-subscription-activation-order.sh`
- `test-subscription-transaction-atomicity.sh`
- `test-subscription-transaction-journal-safety.sh`
- `test-subscription-update-lock-safety.sh`
- `git diff --check`

Two broader local scripts (`test-subscription-fetch-policy.sh` and `test-subscription-lifecycle.sh`) also fail unchanged on the clean base in this host environment; GitHub Actions remains the authoritative full validation.

## Sourcery 总结

确保独立订阅更新能够在不加载完整运行时的情况下，验证实时 sing-box API 响应。

Bug 修复：
- 服务运行时，使独立订阅加载执行 sing-box API 节点验证。

增强功能：
- 在订阅引导过程中集中管理命令存在性和 sing-box API 验证辅助函数，同时移除重复的完整运行时定义。

测试：
- 扩展订阅协议冒烟测试，针对具有代表性的 sing-box 响应验证独立 API 验证功能。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

使隔离的 sing-box 订阅加载能够可靠地验证服务是否就绪，而无需完整的运行时加载器。

错误修复：
- 启用独立订阅更新，以便在服务运行时验证实时 sing-box API 响应。

增强功能：
- 在订阅引导流程中集中处理命令发现和 sing-box API 节点验证，同时移除重复的运行时定义。

测试：
- 扩展订阅协议冒烟测试，覆盖注入的命令解析以及具有代表性的 sing-box API 响应。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make isolated sing-box subscription loading reliably validate service readiness without requiring the full runtime loader.

Bug Fixes:
- Enable standalone subscription updates to validate live sing-box API responses when the service is running.

Enhancements:
- Centralize command discovery and sing-box API node validation in the subscription bootstrap while removing duplicate runtime definitions.

Tests:
- Extend the subscription protocol smoke test to cover injected command resolution and representative sing-box API responses.

</details>

</details>