### PR TITLE
fix: validate subscription runtime inputs

### DIFF
--- a/scripts/test-config-lock-safety.sh
+++ b/scripts/test-config-lock-safety.sh
@@ -17,7 +17,10 @@ printf '%s\n' 'https://example.invalid/sub/user@example.com' >"$subscription_fil
 test "$(magicnet_first_http_url "$subscription_file")" = \
     'https://example.invalid/sub/user@example.com'
 printf '%s\n' 'https://user@example.invalid/sub' >"$subscription_file"
-! magicnet_first_http_url "$subscription_file" >/dev/null
+if magicnet_first_http_url "$subscription_file" >/dev/null; then
+    printf '%s\n' 'subscription credentials were accepted in the URL authority' >&2
+    exit 1
+fi
 
 # A stale signal trap from another PID must not remove the current owner.
 printf '%s\n' '999999:1' >"$MODDIR/.state/config.lock/pid"

--- a/scripts/test-config-lock-safety.sh
+++ b/scripts/test-config-lock-safety.sh
@@ -10,6 +10,15 @@ mkdir -p "$MODDIR/.state/config.lock"
 import() { :; }
 . "$ROOT/src/MagicNet/lib/magicnet/common.sh"
 
+# URL credentials are forbidden only in the authority. A literal @ in the
+# path/query/fragment is valid and must not hide a persisted subscription.
+subscription_file="$fixture/subscription.url"
+printf '%s\n' 'https://example.invalid/sub/user@example.com' >"$subscription_file"
+test "$(magicnet_first_http_url "$subscription_file")" = \
+    'https://example.invalid/sub/user@example.com'
+printf '%s\n' 'https://user@example.invalid/sub' >"$subscription_file"
+! magicnet_first_http_url "$subscription_file" >/dev/null
+
 # A stale signal trap from another PID must not remove the current owner.
 printf '%s\n' '999999:1' >"$MODDIR/.state/config.lock/pid"
 magicnet_config_lock_release
@@ -66,5 +75,16 @@ unset -f printf
     printf '%s\n' 'failed config lock acquisition leaked its directory' >&2
     exit 1
 }
+
+# Invalid inherited subscription timeouts must fall back to the bounded
+# default before reaching the config lock's numeric comparisons.
+magicnet_with_config_lock() {
+    test "$MAGICNET_CONFIG_LOCK_TIMEOUT" = "$expected_timeout"
+}
+expected_timeout=17
+MAGICNET_SUB_CONFIG_LOCK_TIMEOUT=17 magicnet_with_sub_config_lock :
+expected_timeout=45
+MAGICNET_SUB_CONFIG_LOCK_TIMEOUT=not-a-number magicnet_with_sub_config_lock :
+unset -f magicnet_with_config_lock
 
 printf '%s\n' 'config lock safety test passed'

--- a/scripts/test-config-lock-safety.sh
+++ b/scripts/test-config-lock-safety.sh
@@ -88,6 +88,8 @@ expected_timeout=17
 MAGICNET_SUB_CONFIG_LOCK_TIMEOUT=17 magicnet_with_sub_config_lock :
 expected_timeout=45
 MAGICNET_SUB_CONFIG_LOCK_TIMEOUT=not-a-number magicnet_with_sub_config_lock :
+MAGICNET_SUB_CONFIG_LOCK_TIMEOUT=999999999999999999999999999999 \
+    magicnet_with_sub_config_lock :
 unset -f magicnet_with_config_lock
 
 printf '%s\n' 'config lock safety test passed'

--- a/src/MagicNet/lib/magicnet/common.sh
+++ b/src/MagicNet/lib/magicnet/common.sh
@@ -88,7 +88,11 @@ magicnet_first_http_url() {
             line = $0
             sub(/[[:space:]]*#.*$/, "", line)
             gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
-            if (line ~ /^https:\/\/[^[:space:]@]+$/) {
+            if (line ~ /^https:\/\/[^[:space:]]+$/) {
+                remainder = substr(line, 9)
+                authority = remainder
+                sub(/[\/?#].*$/, "", authority)
+                if (authority == "" || authority ~ /@/) next
                 print line
                 found = 1
                 exit 0
@@ -208,7 +212,11 @@ magicnet_prepare_singbox_nodes_unlocked() {
 
 magicnet_with_sub_config_lock() {
     _old_lock_timeout="${MAGICNET_CONFIG_LOCK_TIMEOUT:-}"
-    MAGICNET_CONFIG_LOCK_TIMEOUT="${MAGICNET_SUB_CONFIG_LOCK_TIMEOUT:-45}"
+    _sub_lock_timeout="${MAGICNET_SUB_CONFIG_LOCK_TIMEOUT:-45}"
+    case "$_sub_lock_timeout" in
+        '' | *[!0-9]*) _sub_lock_timeout=45 ;;
+    esac
+    MAGICNET_CONFIG_LOCK_TIMEOUT="$_sub_lock_timeout"
     magicnet_with_config_lock "$@"
     _sub_lock_rc=$?
     if [ -n "$_old_lock_timeout" ]; then
@@ -216,7 +224,7 @@ magicnet_with_sub_config_lock() {
     else
         unset MAGICNET_CONFIG_LOCK_TIMEOUT
     fi
-    unset _old_lock_timeout
+    unset _old_lock_timeout _sub_lock_timeout
     return "$_sub_lock_rc"
 }
 

--- a/src/MagicNet/lib/magicnet/common.sh
+++ b/src/MagicNet/lib/magicnet/common.sh
@@ -216,6 +216,9 @@ magicnet_with_sub_config_lock() {
     case "$_sub_lock_timeout" in
         '' | *[!0-9]*) _sub_lock_timeout=45 ;;
     esac
+    if ! [ "$_sub_lock_timeout" -le 86400 ] 2>/dev/null; then
+        _sub_lock_timeout=45
+    fi
     MAGICNET_CONFIG_LOCK_TIMEOUT="$_sub_lock_timeout"
     magicnet_with_config_lock "$@"
     _sub_lock_rc=$?


### PR DESCRIPTION
## Summary

- reject `@` only inside the HTTPS authority when detecting a persisted subscription URL
- allow valid `@` characters in URL paths, queries, and fragments
- normalize a nonnumeric `MAGICNET_SUB_CONFIG_LOCK_TIMEOUT` to the bounded 45-second default
- add focused regression coverage to the existing config-lock safety test

## Why

The CLI already parses credentials only from the URL authority, but startup used a broader regex that rejected `@` anywhere. A saved URL such as `https://example.invalid/sub/user@example.com` could therefore be accepted by the CLI and then ignored during startup.

The shared subscription lock wrapper also forwarded an inherited nonnumeric timeout directly into numeric comparisons, which could prevent the lock wait from enforcing its intended bound.

## Validation

- focused URL-authority and lock-timeout regression checks
- `test-config-lock-safety.sh` reaches both new assertions (the unchanged base test remains timing-sensitive on this host when run without tracing)
- `git diff --check`

## Sourcery 总结

在进入运行时安全检查之前，验证持久化的订阅 URL 和继承的配置锁超时值。

错误修复：
- 将持久化订阅 URL 凭据拒绝限制在 HTTPS authority 部分，以继续支持路径、查询参数和片段中的有效 `@` 字符。
- 将非数字的订阅配置锁超时值规范化为有界的 45 秒默认值。

测试：
- 增加 URL authority 验证和无效订阅锁超时处理的回归测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在运行时安全检查之前，验证持久化的订阅 URL 和继承的配置锁定超时时间。

错误修复：
- 将持久化订阅 URL 凭据拒绝限制在 HTTPS authority 中，同时允许路径、查询参数和片段中使用有效的 `@` 字符。
- 将继承的订阅配置锁定超时时间中的非数字值规范化为有界的 45 秒默认值。

测试：
- 添加针对 URL authority 验证以及无效订阅锁定超时时间处理的回归测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

加强对持久化订阅 URL 和配置锁超时的运行时验证。

错误修复：
- 仅在 HTTPS 权限部分验证持久化订阅 URL 中的凭据，从而允许路径、查询参数和片段中存在有效的 `@` 字符。
- 将无效或超出范围的继承订阅锁超时规范化为有界的 45 秒默认值。

测试：
- 增加对订阅 URL 权限验证以及无效或过大锁超时处理的回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden runtime validation for persisted subscription URLs and configuration lock timeouts.

Bug Fixes:
- Validate persisted subscription URLs for credentials only in the HTTPS authority, allowing valid `@` characters in paths, queries, and fragments.
- Normalize invalid or out-of-range inherited subscription lock timeouts to the bounded 45-second default.

Tests:
- Add regression coverage for subscription URL authority validation and invalid or oversized lock timeout handling.

</details>

</details>

</details>