### PR TITLE
fix: prevent ipv4_only TUN from claiming IPv6 routes

### DIFF
--- a/scripts/orchestrator-mode-smoke.sh
+++ b/scripts/orchestrator-mode-smoke.sh
@@ -286,7 +286,7 @@ assert_mode() {
     fi
 
     if [ "$expect_tun" = "yes" ]; then
-        jq -e '.inbounds[] | select(.type == "tun" and .tag == "tun-in" and .interface_name == "magicnet0" and .stack == "mixed" and .mtu == 1400 and .udp_timeout == "5m")' "$config" >/dev/null
+        jq -e '.inbounds[] | select(.type == "tun" and .tag == "tun-in" and .interface_name == "magicnet0" and .address == ["172.19.0.1/30"] and .stack == "mixed" and .mtu == 1400 and .udp_timeout == "5m")' "$config" >/dev/null
         assert_tun_exclusions "$config" "$mode/$managed_variant second apply"
         jq -e '.route.rules[] | select(.action == "sniff" and (.inbound == ["mixed-in", "tun-in"]))' "$config" >/dev/null
     else
@@ -337,10 +337,10 @@ assert_dual_stack_policy() {
         and ([.inbounds[]? | select(
           .type == "tun"
           and .tag == "tun-in"
+          and .address == ["172.19.0.1/30", "fdfe:dcba:9876::1/126"]
           and .stack == "mixed"
           and .mtu == $mtu
           and .udp_timeout == $timeout
-          and any(.address[]?; contains(":"))
         )] | length) == 1
     ' "$config" >/dev/null; then
         echo "orchestrator smoke failed: invalid $strategy/$mtu/$udp_timeout policy output" >&2

--- a/src/MagicNet/lib/magicnet/transparent.sh
+++ b/src/MagicNet/lib/magicnet/transparent.sh
@@ -34,10 +34,11 @@ magicnet_singbox_apply_transparent_mode() {
             "type": "tun",
             "tag": "tun-in",
             "interface_name": "magicnet0",
-            "address": [
-              "172.19.0.1/30",
-              "fdfe:dcba:9876::1/126"
-            ],
+            "address": (if $dns_strategy == "ipv4_only" then
+              ["172.19.0.1/30"]
+            else
+              ["172.19.0.1/30", "fdfe:dcba:9876::1/126"]
+            end),
             "auto_route": true,
             "auto_redirect": true,
             "strict_route": true,


### PR DESCRIPTION
## Summary

- generate an IPv4-only `magicnet0` address list when `MAGICNET_IPV6_MODE=ipv4_only`
- keep the existing dual-stack TUN addresses for `prefer_ipv4` and `prefer_ipv6`
- strengthen the orchestrator smoke test to assert the exact address list for both policy families

## Root cause

The network policy changed the DNS strategy and inserted a managed IPv6 reject rule, but the TUN inbound still declared `fdfe:dcba:9876::1/126`. With `auto_route` enabled, sing-box therefore continued to install an IPv6 route in table 2022, so direct IPv6 connections were still captured by `magicnet0` before the guard could reject them.

## Validation

- `bash scripts/orchestrator-mode-smoke.sh src/MagicNet/lib/magicnet/transparent.sh` (sing-box 1.13.19)
- `sh -n src/MagicNet/lib/magicnet/transparent.sh`
- `bash -n scripts/orchestrator-mode-smoke.sh`
- `git diff --check`

Fixes #133

## Sourcery 摘要

确保仅 IPv4 的透明模式不会捕获 IPv6 流量，同时保留其他策略模式下双栈 TUN 的行为。

Bug 修复：
- 通过在仅 IPv4 模式启用时省略 IPv6 TUN 地址，防止仅 IPv4 的 TUN 配置声明拥有 IPv6 路由。

测试：
- 强化编排器冒烟测试，以验证仅 IPv4 和双栈策略模式下确切的 TUN 地址列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure IPv4-only transparent mode does not capture IPv6 traffic while preserving dual-stack TUN behavior for other policy modes.

Bug Fixes:
- Prevent IPv4-only TUN configurations from claiming IPv6 routes by omitting the IPv6 TUN address when IPv4-only mode is active.

Tests:
- Strengthen orchestrator smoke tests to verify the exact TUN address list for IPv4-only and dual-stack policy modes.

</details>