### PR TITLE
fix: parse standalone-dash Clash proxy entries

### DIFF
--- a/scripts/singbox-subscription-protocol-smoke.sh
+++ b/scripts/singbox-subscription-protocol-smoke.sh
@@ -65,6 +65,40 @@ assert_extracted_links "$tmp_dir/leading-links.txt" leading-plain
 base64 <"$links_fixture" >"$tmp_dir/mixed-links.base64"
 assert_extracted_links "$tmp_dir/mixed-links.base64" base64
 
+# Clash/Mihomo permits a sequence item indicator on its own line before the
+# node mapping. Keep both that block style and the usual inline style working.
+clash_sequence_fixture="$tmp_dir/clash-sequence-styles.yaml"
+cat >"$clash_sequence_fixture" <<'YAML'
+proxies:
+  - name: inline-vmess
+    type: vmess
+    server: inline.invalid
+    port: 443
+    uuid: 00000000-0000-4000-8000-000000000101
+  -
+    name: block-vmess
+    type: vmess
+    server: block.invalid
+    port: 8443
+    uuid: 00000000-0000-4000-8000-000000000102
+proxy-groups:
+  - name: ignored-group
+YAML
+clash_nodes_dir="$tmp_dir/clash-sequence-nodes"
+clash_node_count="$(magicnet_singbox_extract_clash_nodes "$clash_sequence_fixture" "$clash_nodes_dir")"
+[[ "$clash_node_count" == "2" ]] \
+    || fail "Clash sequence extraction returned $clash_node_count nodes, expected 2"
+inline_clash_json="$(magicnet_singbox_emit_node_json "$clash_nodes_dir/node-1.yaml")" \
+    || fail "inline Clash sequence item did not emit a node"
+block_clash_json="$(magicnet_singbox_emit_node_json "$clash_nodes_dir/node-2.yaml")" \
+    || fail "block-style Clash sequence item did not emit a node"
+printf '%s\n' "$inline_clash_json" | jq -e \
+    '.tag == "inline-vmess" and .server == "inline.invalid" and .server_port == 443' >/dev/null \
+    || fail "inline Clash sequence item was parsed incorrectly: $inline_clash_json"
+printf '%s\n' "$block_clash_json" | jq -e \
+    '.tag == "block-vmess" and .server == "block.invalid" and .server_port == 8443' >/dev/null \
+    || fail "block-style Clash sequence item was parsed incorrectly: $block_clash_json"
+
 # Proxylink uses -singbox for a full sing-box JSON document. Keep this path
 # isolated from the bundled ARM binary by observing the production wrapper's
 # arguments with a test double.

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/parse.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/parse.sh
@@ -16,7 +16,7 @@ magicnet_singbox_extract_clash_nodes() {
                 in_proxies = 0
             }
         }
-        in_proxies && /^[[:space:]]*-[[:space:]]+/ {
+        in_proxies && /^[[:space:]]*-[[:space:]]*/ {
             idx++
             file = outdir "/node-" (start + idx) ".yaml"
             line = $0


### PR DESCRIPTION
## Summary

- accept Clash/Mihomo `proxies` entries whose sequence indicator is a standalone `-`
- preserve support for the existing inline `- name: ...` form
- add a regression fixture that extracts and converts both styles while ensuring parsing stops before `proxy-groups`

Closes #135

## Verification

- `bash scripts/singbox-subscription-protocol-smoke.sh` ✅
- `bash -n src/MagicNet/lib/magicnet/singbox_subscribe/parse.sh scripts/singbox-subscription-protocol-smoke.sh` ✅
- `shellcheck src/MagicNet/lib/magicnet/singbox_subscribe/parse.sh scripts/singbox-subscription-protocol-smoke.sh` ✅
- `bash scripts/test-repository-hygiene.sh` ✅

`cargo` is unavailable in the execution environment, so `scripts/kam-test.sh quick` and `scripts/fake-magisk-smoke.sh` could not start locally; CI should run the Rust-backed checks.

## Sourcery 摘要

修复 Clash/Mihomo 代理解析对独立序列项指示符的支持。

错误修复：
- 解析使用独立序列项短横线的 Clash/Mihomo 代理条目，同时保留对内联条目的支持。

测试：
- 添加回归测试，验证两种 Clash 代理条目样式都能被提取和转换，同时排除 proxy-groups 下的条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Clash/Mihomo proxy parsing for standalone sequence-item indicators.

Bug Fixes:
- Parse Clash/Mihomo proxy entries that use a standalone sequence-item dash while retaining support for inline entries.

Tests:
- Add regression coverage verifying both Clash proxy entry styles are extracted and converted, while entries under proxy-groups are excluded.

</details>