### PR TITLE
fix: capture root DNS queries in transparent mode

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -72,7 +72,7 @@ WebUI 可查看延迟、手动选择节点或切回自动组。选择结果会�
 
 - `Proxy`：应用进入 `magicnet0`，并强制使用代理规则。
 - `Direct`：应用仍进入 TUN，但使用 `direct` 出站；验证“不要走 MagicNet 代理”通常选它。
-- `Bypass TUN`：应用完全离开 MagicNet。模块按所有 Android 用户解析包 UID，并让这些 UID 同时绕过 TUN 与 DNS 捕获，适合外部 VPN 或明确的共存需求。
+- `Bypass TUN`：应用完全离开 MagicNet。模块按所有 Android 用户解析包 UID，并让这些 UID 同时绕过 TUN 与 DNS 捕获，适合外部 VPN 或明确的共存需求。部分设备的 `netd` 会以 UID 0 代发系统 DNS；存在 Bypass UID 时，DNS 捕获链会保守保留 UID 0 直通，以维持这项边界。
 
 ```bash
 su -c '/data/adb/modules/MagicNet/cli app add com.example.app proxy'

--- a/scripts/test-app-routing-policy.sh
+++ b/scripts/test-app-routing-policy.sh
@@ -340,6 +340,7 @@ EOF
   }
   magicnet_cmd_exists() { command -v "$1" >/dev/null 2>&1; }
   magicnet_dns_profile() { printf '%s\n' default; }
+  magicnet_dns_capture_singbox_udp_marked() { return 0; }
   magicnet_log() { :; }
   magicnet_warn() { printf '%s\n' "$*" >&2; }
 

--- a/scripts/test-app-routing-policy.sh
+++ b/scripts/test-app-routing-policy.sh
@@ -346,10 +346,17 @@ EOF
   magicnet_enable_dns_capture
 
   for family in iptables ip6tables; do
+    mark_line=$(grep -nF "$family -t nat -A magicnet-dns-output -m mark --mark 1073741824/1073741824 -j RETURN" "$dns_capture_log" | cut -d: -f1 | head -n 1)
+    root_line=$(grep -nF "$family -t nat -A magicnet-dns-output -m owner --uid-owner 0 -j RETURN" "$dns_capture_log" | cut -d: -f1 | head -n 1)
+    redirect_line=$(sed -n "/$family -t nat -A magicnet-dns-output -p udp --dport 53 -j REDIRECT --to-ports 1053/=" "$dns_capture_log")
+    if [ -z "$mark_line" ] || [ -z "$root_line" ] || [ -z "$redirect_line" ] || [ "$mark_line" -ge "$redirect_line" ] || [ "$root_line" -ge "$redirect_line" ]; then
+      printf '%s\n' "$family DNS bypass rules must return before DNS capture redirect" >&2
+      cat "$dns_capture_log" >&2
+      exit 1
+    fi
     for uid in 11001 1011001; do
       bypass_line=$(sed -n "/$family -t nat -A magicnet-dns-output -m owner --uid-owner $uid -j RETURN/=" "$dns_capture_log")
-      redirect_line=$(sed -n "/$family -t nat -A magicnet-dns-output -p udp --dport 53 -j REDIRECT --to-ports 1053/=" "$dns_capture_log")
-      if [ -z "$bypass_line" ] || [ -z "$redirect_line" ] || [ "$bypass_line" -ge "$redirect_line" ]; then
+      if [ -z "$bypass_line" ] || [ "$bypass_line" -ge "$redirect_line" ]; then
         printf '%s\n' "$family app-bypass UID $uid must return before DNS capture redirect" >&2
         cat "$dns_capture_log" >&2
         exit 1
@@ -357,8 +364,8 @@ EOF
     done
   done
 
-  if grep -q -- '--uid-owner 0 -j RETURN' "$dns_capture_log"; then
-    printf '%s\n' 'root UID must remain subject to DNS capture' >&2
+  if [ "$(grep -c -- '-A magicnet-dns-output -m owner --uid-owner 0 -j RETURN' "$dns_capture_log")" -ne 2 ]; then
+    printf '%s\n' 'root UID must bypass DNS capture when Bypass TUN UIDs are configured' >&2
     cat "$dns_capture_log" >&2
     exit 1
   fi
@@ -369,6 +376,15 @@ EOF
   fi
   if grep -q -- '--uid-owner invalid' "$dns_capture_log"; then
     printf '%s\n' 'invalid app-bypass UID reached iptables' >&2
+    cat "$dns_capture_log" >&2
+    exit 1
+  fi
+
+  printf '%s\n' 0 >"$MODDIR/.state/app-policy/exclude-uids.list"
+  : >"$dns_capture_log"
+  magicnet_enable_dns_capture
+  if grep -q -- '-m owner --uid-owner 0 -j RETURN' "$dns_capture_log"; then
+    printf '%s\n' 'root UID must be captured when no Bypass TUN UID is configured' >&2
     cat "$dns_capture_log" >&2
     exit 1
   fi

--- a/scripts/test-app-routing-policy.sh
+++ b/scripts/test-app-routing-policy.sh
@@ -314,6 +314,7 @@ assert_dns_capture_bypass_uids() (
   export MODDIR
   mkdir -p "$MODDIR/.state/app-policy"
   cat >"$MODDIR/.state/app-policy/exclude-uids.list" <<'EOF'
+0
 11001
 1011001
 11001
@@ -356,6 +357,11 @@ EOF
     done
   done
 
+  if grep -q -- '--uid-owner 0 -j RETURN' "$dns_capture_log"; then
+    printf '%s\n' 'root UID must remain subject to DNS capture' >&2
+    cat "$dns_capture_log" >&2
+    exit 1
+  fi
   if [ "$(grep -c -- '--uid-owner 11001 -j RETURN' "$dns_capture_log")" -ne 4 ]; then
     printf '%s\n' 'duplicate app-bypass UIDs must produce one check and one append per address family only' >&2
     cat "$dns_capture_log" >&2

--- a/scripts/test-dns-profile-safety.sh
+++ b/scripts/test-dns-profile-safety.sh
@@ -16,7 +16,8 @@ cat >"$MODDIR/.config/sing-box/config.json" <<'EOF'
     "servers": [
       {"type": "https", "tag": "bootstrap-local-dns", "server": "223.5.5.5"},
       {"type": "https", "tag": "cloudflare-backup-dns", "server": "1.0.0.1"},
-      {"type": "https", "tag": "doh-cloudflare", "server": "1.1.1.1", "detour": "proxy"}
+      {"type": "https", "tag": "doh-cloudflare", "server": "1.1.1.1", "detour": "proxy"},
+      {"type": "udp", "tag": "retained-udp", "server": "9.9.9.9"}
     ]
   }
 }
@@ -56,6 +57,7 @@ MAGICNET_DNS_PROFILE=default magicnet_dns_apply_singbox
 jq -e '
   .dns.final == "bootstrap-local-dns"
     and ([.dns.servers[] | select(.tag == "cloudflare-profile-dns" or .tag == "cloudflare-backup-dns")] | length) == 0
+    and ([.dns.servers[] | select(.tag == "retained-udp") | .routing_mark] == [1073741824])
 ' "$MODDIR/.config/sing-box/config.json" >/dev/null || {
     printf 'default DNS profile must restore direct bootstrap final and remove managed profile servers\n' >&2
     exit 1

--- a/src/MagicNet/README.md
+++ b/src/MagicNet/README.md
@@ -146,6 +146,7 @@ MagicNet 目前只支持 `tun` 透明模式，使用 `sing-box` `magicnet0` TUN 
 - 分应用策略分为三类：`Proxy` 强制走代理；`Direct` 仍进入 TUN，但强制走 `direct` 出站；`Bypass TUN` 则让应用完全离开 MagicNet。
 - WebUI 的“全局接管”对应黑名单语义：默认应用进入 TUN，`Bypass TUN` 名单走系统网络；“仅名单接管”对应白名单语义：只有 `Proxy` 和 `Direct` 名单进入 TUN。
 - Root 命令行模式会把包名解析为 Android UID，再通过 TUN 的 `include_uid` / `exclude_uid` 执行边界，避免包名过滤在重启后失效。共享同一 UID 的应用会一起生效。
+- Android `netd` 在部分设备上会把 Bypass 应用的系统 DNS 请求统一以 UID 0 发出；存在 Bypass UID 时，DNS 捕获链会保守保留 UID 0 的 `RETURN`，避免无法归属的请求重新进入 MagicNet。
 - `Bypass TUN` 不等于断网或阻止访问。应用离开 MagicNet 后会使用系统上游网络；如果上游网络或另一个 VPN 能访问 Google，加入 Bypass 后的 Chrome 仍然可以访问。
 - 要验证 Chrome 没有使用 MagicNet 代理，请在 WebUI“应用策略”中选择 `Direct`，或执行 `cli app add com.android.chrome direct`。只有多 VPN 共存或明确需要完全避开 MagicNet 时才选择 `Bypass TUN`。
 - 默认网络策略是双栈、DNS 优先 IPv4、`mixed` TUN 栈、MTU `1400` 和 UDP 会话超时 `5m`。

--- a/src/MagicNet/lib/magicnet/dns.sh
+++ b/src/MagicNet/lib/magicnet/dns.sh
@@ -66,7 +66,8 @@ magicnet_dns_apply_singbox() {
         return 1
     }
     _tmp="${_config}.magicnet-dns.new"
-    magicnet_jq_install_config "$_config" "$_tmp" "$_jq" --arg profile "$_profile" --arg bootstrap_server "$_bootstrap_server" -e '
+    magicnet_jq_install_config "$_config" "$_tmp" "$_jq" --arg profile "$_profile" --arg bootstrap_server "$_bootstrap_server" \
+        --argjson dns_capture_singbox_mark "${MAGICNET_DNS_CAPTURE_SINGBOX_MARK:-1073741824}" -e '
       def cf_udp($tag; $server):
         {"type":"udp","tag":$tag,"server":$server,"detour":"proxy"};
       def cf_tls($tag; $server):
@@ -92,6 +93,15 @@ magicnet_dns_apply_singbox() {
                  server_for($profile; "cloudflare-backup-dns"; "1.0.0.1")]
            end) + .
       )
+      # Direct UDP DNS servers are contacted by sing-box itself. Mark those
+      # sockets so the kernel DNS redirect can exempt them without exempting
+      # every UID-0 Android resolver query.
+      | .dns.servers |= map(
+          if (.type == "udp" and (.detour // "") == "") then
+            .routing_mark = $dns_capture_singbox_mark
+          else .
+          end
+        )
       | if $profile == "default" then .dns.final = "bootstrap-local-dns"
         else .dns.final = "cloudflare-profile-dns"
         end

--- a/src/MagicNet/lib/magicnet/dns.sh
+++ b/src/MagicNet/lib/magicnet/dns.sh
@@ -67,7 +67,7 @@ magicnet_dns_apply_singbox() {
     }
     _tmp="${_config}.magicnet-dns.new"
     magicnet_jq_install_config "$_config" "$_tmp" "$_jq" --arg profile "$_profile" --arg bootstrap_server "$_bootstrap_server" \
-        --argjson dns_capture_singbox_mark "${MAGICNET_DNS_CAPTURE_SINGBOX_MARK:-1073741824}" -e '
+        --argjson dns_capture_singbox_mark "$(magicnet_dns_capture_singbox_mark)" -e '
       def cf_udp($tag; $server):
         {"type":"udp","tag":$tag,"server":$server,"detour":"proxy"};
       def cf_tls($tag; $server):

--- a/src/MagicNet/lib/magicnet/network.sh
+++ b/src/MagicNet/lib/magicnet/network.sh
@@ -170,7 +170,9 @@ magicnet_dns_capture_bypass_uids() {
         unset _dns_bypass_uid_file
         return 0
     }
-    awk '/^[0-9]+$/ && !seen[$0]++ { print }' "$_dns_bypass_uid_file" 2>/dev/null
+    # UID 0 is excluded from the TUN boundary but must not bypass DNS
+    # capture: Android netd commonly sends system queries as root.
+    awk '/^[0-9]+$/ && ($0 + 0) != 0 && !seen[$0]++ { print }' "$_dns_bypass_uid_file" 2>/dev/null
     unset _dns_bypass_uid_file
 }
 

--- a/src/MagicNet/lib/magicnet/network.sh
+++ b/src/MagicNet/lib/magicnet/network.sh
@@ -170,10 +170,16 @@ magicnet_dns_capture_bypass_uids() {
         unset _dns_bypass_uid_file
         return 0
     }
-    # UID 0 is excluded from the TUN boundary but must not bypass DNS
-    # capture: Android netd commonly sends system queries as root.
-    awk '/^[0-9]+$/ && ($0 + 0) != 0 && !seen[$0]++ { print }' "$_dns_bypass_uid_file" 2>/dev/null
-    unset _dns_bypass_uid_file
+    # Android netd can emit a Bypass TUN app's DNS request as UID 0. Once
+    # netd proxies the lookup, xt_owner cannot recover the originating app;
+    # keep UID 0 outside capture whenever a real bypass UID is configured so
+    # the app and its DNS stay on the same non-MagicNet path.
+    _dns_bypass_uids="$(awk '/^[0-9]+$/ && ($0 + 0) != 0 && !seen[$0]++ { print }' "$_dns_bypass_uid_file" 2>/dev/null)"
+    if [ -n "$_dns_bypass_uids" ]; then
+        printf '%s\n' 0
+    fi
+    printf '%s\n' "$_dns_bypass_uids"
+    unset _dns_bypass_uid_file _dns_bypass_uids
 }
 
 magicnet_enable_dns_capture() {
@@ -201,6 +207,7 @@ magicnet_enable_dns_capture() {
 
     _dns_capture_port="$(magicnet_dns_capture_port)"
     _dns_capture_bypass_uids="$(magicnet_dns_capture_bypass_uids)"
+    _dns_capture_singbox_mark="${MAGICNET_DNS_CAPTURE_SINGBOX_MARK:-1073741824}"
     _dns_capture_rc=0
     _dns_capture_ipv6_unavailable=0
     if ! magicnet_iptables_cmd -t nat -N magicnet-dns-output >/dev/null 2>&1; then
@@ -213,6 +220,14 @@ magicnet_enable_dns_capture() {
         0) ;;
         1) magicnet_iptables_cmd -t nat -I OUTPUT 1 -j magicnet-dns-output >/dev/null 2>&1 || _dns_capture_rc=1 ;;
         *) _dns_capture_rc=1 ;;
+    esac
+    # Direct UDP DNS servers are marked in the sing-box config. Keep those
+    # resolver packets out of this chain without exempting all UID-0 traffic.
+    magicnet_iptables_ensure -t nat magicnet-dns-output -m mark --mark "$_dns_capture_singbox_mark/$_dns_capture_singbox_mark" -j RETURN || _dns_capture_rc=1
+    case " $_dns_capture_bypass_uids " in
+        *" 0 "*)
+            magicnet_log "DNS capture keeps UID 0 outside interception while Bypass TUN UIDs are configured"
+            ;;
     esac
     for _dns_capture_bypass_uid in $_dns_capture_bypass_uids; do
         magicnet_iptables_ensure -t nat magicnet-dns-output -m owner --uid-owner "$_dns_capture_bypass_uid" -j RETURN || _dns_capture_rc=1
@@ -245,6 +260,7 @@ magicnet_enable_dns_capture() {
                 1) magicnet_ip6tables_cmd -t nat -I OUTPUT 1 -j magicnet-dns-output >/dev/null 2>&1 || _dns_capture_rc=1 ;;
                 *) _dns_capture_rc=1 ;;
             esac
+            magicnet_ip6tables_nat_ensure magicnet-dns-output -m mark --mark "$_dns_capture_singbox_mark/$_dns_capture_singbox_mark" -j RETURN || _dns_capture_rc=1
             for _dns_capture_bypass_uid in $_dns_capture_bypass_uids; do
                 magicnet_ip6tables_nat_ensure magicnet-dns-output -m owner --uid-owner "$_dns_capture_bypass_uid" -j RETURN || _dns_capture_rc=1
             done
@@ -255,7 +271,7 @@ magicnet_enable_dns_capture() {
 
     if [ "$_dns_capture_rc" -ne 0 ]; then
         magicnet_disable_dns_capture >/dev/null 2>&1 || true
-        unset _dns_capture_port _dns_capture_bypass_uids _dns_capture_bypass_uid
+        unset _dns_capture_port _dns_capture_bypass_uids _dns_capture_bypass_uid _dns_capture_singbox_mark
         unset _dns_capture_rc _dns_capture_check_rc _dns_capture_ipv6_mode _dns_capture_ipv6_unavailable
         return 1
     fi
@@ -265,7 +281,7 @@ magicnet_enable_dns_capture() {
     else
         magicnet_log "DNS capture redirected port 53 to 127.0.0.1:${_dns_capture_port}"
     fi
-    unset _dns_capture_port _dns_capture_bypass_uids _dns_capture_bypass_uid
+    unset _dns_capture_port _dns_capture_bypass_uids _dns_capture_bypass_uid _dns_capture_singbox_mark
     unset _dns_capture_rc _dns_capture_check_rc _dns_capture_ipv6_mode _dns_capture_ipv6_unavailable
 }
 

--- a/src/MagicNet/lib/magicnet/network.sh
+++ b/src/MagicNet/lib/magicnet/network.sh
@@ -182,6 +182,22 @@ magicnet_dns_capture_bypass_uids() {
     unset _dns_bypass_uid_file _dns_bypass_uids
 }
 
+magicnet_dns_capture_singbox_udp_marked() {
+    _dns_marked_config="$(magicnet_singbox_config_file 2>/dev/null || printf '%s\n' "${MODDIR}/.config/sing-box/config.json")"
+    _dns_marked_jq="${MODDIR}/bin/jq"
+    [ -x "$_dns_marked_jq" ] || _dns_marked_jq="$(command -v jq 2>/dev/null || true)"
+    [ -f "$_dns_marked_config" ] && [ -n "$_dns_marked_jq" ] || {
+        unset _dns_marked_config _dns_marked_jq
+        return 1
+    }
+    "$_dns_marked_jq" -e --argjson dns_capture_singbox_mark "${MAGICNET_DNS_CAPTURE_SINGBOX_MARK:-1073741824}" \
+        'any((.dns.servers // [])[]?; .type == "udp" and .routing_mark == $dns_capture_singbox_mark)' \
+        "$_dns_marked_config" >/dev/null 2>&1
+    _dns_marked_rc=$?
+    unset _dns_marked_config _dns_marked_jq
+    return "$_dns_marked_rc"
+}
+
 magicnet_enable_dns_capture() {
     if ! magicnet_dns_capture_enabled; then
         if magicnet_disable_dns_capture; then
@@ -208,6 +224,8 @@ magicnet_enable_dns_capture() {
     _dns_capture_port="$(magicnet_dns_capture_port)"
     _dns_capture_bypass_uids="$(magicnet_dns_capture_bypass_uids)"
     _dns_capture_singbox_mark="${MAGICNET_DNS_CAPTURE_SINGBOX_MARK:-1073741824}"
+    _dns_capture_singbox_marked=0
+    magicnet_dns_capture_singbox_udp_marked && _dns_capture_singbox_marked=1
     _dns_capture_rc=0
     _dns_capture_ipv6_unavailable=0
     if ! magicnet_iptables_cmd -t nat -N magicnet-dns-output >/dev/null 2>&1; then
@@ -223,7 +241,9 @@ magicnet_enable_dns_capture() {
     esac
     # Direct UDP DNS servers are marked in the sing-box config. Keep those
     # resolver packets out of this chain without exempting all UID-0 traffic.
-    magicnet_iptables_ensure -t nat magicnet-dns-output -m mark --mark "$_dns_capture_singbox_mark/$_dns_capture_singbox_mark" -j RETURN || _dns_capture_rc=1
+    if [ "$_dns_capture_singbox_marked" -eq 1 ]; then
+        magicnet_iptables_ensure -t nat magicnet-dns-output -m mark --mark "$_dns_capture_singbox_mark/$_dns_capture_singbox_mark" -j RETURN || _dns_capture_rc=1
+    fi
     case " $_dns_capture_bypass_uids " in
         *" 0 "*)
             magicnet_log "DNS capture keeps UID 0 outside interception while Bypass TUN UIDs are configured"
@@ -260,7 +280,9 @@ magicnet_enable_dns_capture() {
                 1) magicnet_ip6tables_cmd -t nat -I OUTPUT 1 -j magicnet-dns-output >/dev/null 2>&1 || _dns_capture_rc=1 ;;
                 *) _dns_capture_rc=1 ;;
             esac
-            magicnet_ip6tables_nat_ensure magicnet-dns-output -m mark --mark "$_dns_capture_singbox_mark/$_dns_capture_singbox_mark" -j RETURN || _dns_capture_rc=1
+            if [ "$_dns_capture_singbox_marked" -eq 1 ]; then
+                magicnet_ip6tables_nat_ensure magicnet-dns-output -m mark --mark "$_dns_capture_singbox_mark/$_dns_capture_singbox_mark" -j RETURN || _dns_capture_rc=1
+            fi
             for _dns_capture_bypass_uid in $_dns_capture_bypass_uids; do
                 magicnet_ip6tables_nat_ensure magicnet-dns-output -m owner --uid-owner "$_dns_capture_bypass_uid" -j RETURN || _dns_capture_rc=1
             done
@@ -271,7 +293,7 @@ magicnet_enable_dns_capture() {
 
     if [ "$_dns_capture_rc" -ne 0 ]; then
         magicnet_disable_dns_capture >/dev/null 2>&1 || true
-        unset _dns_capture_port _dns_capture_bypass_uids _dns_capture_bypass_uid _dns_capture_singbox_mark
+        unset _dns_capture_port _dns_capture_bypass_uids _dns_capture_bypass_uid _dns_capture_singbox_mark _dns_capture_singbox_marked
         unset _dns_capture_rc _dns_capture_check_rc _dns_capture_ipv6_mode _dns_capture_ipv6_unavailable
         return 1
     fi
@@ -281,7 +303,7 @@ magicnet_enable_dns_capture() {
     else
         magicnet_log "DNS capture redirected port 53 to 127.0.0.1:${_dns_capture_port}"
     fi
-    unset _dns_capture_port _dns_capture_bypass_uids _dns_capture_bypass_uid _dns_capture_singbox_mark
+    unset _dns_capture_port _dns_capture_bypass_uids _dns_capture_bypass_uid _dns_capture_singbox_mark _dns_capture_singbox_marked
     unset _dns_capture_rc _dns_capture_check_rc _dns_capture_ipv6_mode _dns_capture_ipv6_unavailable
 }
 

--- a/src/MagicNet/lib/magicnet/network.sh
+++ b/src/MagicNet/lib/magicnet/network.sh
@@ -190,7 +190,7 @@ magicnet_dns_capture_singbox_udp_marked() {
         unset _dns_marked_config _dns_marked_jq
         return 1
     }
-    "$_dns_marked_jq" -e --argjson dns_capture_singbox_mark "${MAGICNET_DNS_CAPTURE_SINGBOX_MARK:-1073741824}" \
+    "$_dns_marked_jq" -e --argjson dns_capture_singbox_mark "$(magicnet_dns_capture_singbox_mark)" \
         'any((.dns.servers // [])[]?; .type == "udp" and .routing_mark == $dns_capture_singbox_mark)' \
         "$_dns_marked_config" >/dev/null 2>&1
     _dns_marked_rc=$?
@@ -223,7 +223,7 @@ magicnet_enable_dns_capture() {
 
     _dns_capture_port="$(magicnet_dns_capture_port)"
     _dns_capture_bypass_uids="$(magicnet_dns_capture_bypass_uids)"
-    _dns_capture_singbox_mark="${MAGICNET_DNS_CAPTURE_SINGBOX_MARK:-1073741824}"
+    _dns_capture_singbox_mark="$(magicnet_dns_capture_singbox_mark)"
     _dns_capture_singbox_marked=0
     magicnet_dns_capture_singbox_udp_marked && _dns_capture_singbox_marked=1
     _dns_capture_rc=0

--- a/src/MagicNet/lib/magicnet/primitives.sh
+++ b/src/MagicNet/lib/magicnet/primitives.sh
@@ -2,6 +2,11 @@
 #
 # Kamfw-free helpers shared by common.sh and isolated subscribe loads.
 
+# High-bit fwmark reserved for direct sing-box UDP DNS sockets. Android's
+# netd fwmark rules use the low bits, so this mark distinguishes resolver
+# traffic without changing the selected network route.
+MAGICNET_DNS_CAPTURE_SINGBOX_MARK=1073741824
+
 magicnet_lib_dir() {
     if [ -n "${MAGICNET_LIB_DIR:-}" ]; then
         printf '%s\n' "$MAGICNET_LIB_DIR"

--- a/src/MagicNet/lib/magicnet/primitives.sh
+++ b/src/MagicNet/lib/magicnet/primitives.sh
@@ -5,7 +5,9 @@
 # High-bit fwmark reserved for direct sing-box UDP DNS sockets. Android's
 # netd fwmark rules use the low bits, so this mark distinguishes resolver
 # traffic without changing the selected network route.
-MAGICNET_DNS_CAPTURE_SINGBOX_MARK=1073741824
+magicnet_dns_capture_singbox_mark() {
+    printf '%s\n' 1073741824
+}
 
 magicnet_lib_dir() {
     if [ -n "${MAGICNET_LIB_DIR:-}" ]; then


### PR DESCRIPTION
Fixes #137

## Summary

- Keep UID 0 outside DNS interception when Bypass TUN UIDs are configured, because some Android `netd` versions emit the app's DNS request as root and `xt_owner` cannot recover the original UID.
- Keep UID 0 capturable when no Bypass TUN UID is configured.
- Mark retained direct UDP DNS servers in sing-box and return that mark before the IPv4/IPv6 port-53 redirects, preventing sing-box's own resolver traffic from looping through `magicnet-dns-in`.
- Add regression coverage for root/netd bypass behavior and retained UDP resolver marks.

## Validation

- `bash scripts/test-app-routing-policy.sh`
- `bash scripts/test-dns-profile-safety.sh`
- `bash scripts/test-dns-leak-guard-timeout.sh`
- `bash scripts/pre-commit.sh` (all checks passed locally except the existing network-dependent subscription smoke fixture, which returned one node instead of two)
