### PR TITLE
fix: keep WeChat push endpoints direct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Route maintained WeChat destination IPs through `cn-direct` so push long
+  connections do not fall through to the proxy after domain information is lost.
 - Fix #121 by clearing the zero-node bootstrap selector cache after the first successful subscription import so populated proxy groups cannot remain pinned to `block`.
 - Fix #119 by propagating CLI parent death to privileged workers, preserving subscription rollback traps, bounding status lock recovery, and reconciling interrupted transactions during startup.
 - Fix #115 by aligning config-editor template sync with the packaged MagicSingBox routing baseline, removing the stale FakeIP blackhole and restoring early X domain ownership.

--- a/crates/magicnet-cli/src/config_editor.rs
+++ b/crates/magicnet-cli/src/config_editor.rs
@@ -20,9 +20,9 @@ const VALIDATOR_TIMEOUT: Duration = Duration::from_secs(20);
 const TEMPLATE_FETCH_TIMEOUT: Duration = Duration::from_secs(45);
 const TEMPLATE_MAX_BYTES: usize = 1024 * 1024;
 const VALIDATOR_OUTPUT_LIMIT: usize = 256 * 1024;
-const MAGIC_SINGBOX_TEMPLATE_URL: &str = "https://raw.githubusercontent.com/LIghtJUNction/MagicSingBox/9d354b0717636271eaa4bb1a3cbe5bb93cafd8f5/config.json";
+const MAGIC_SINGBOX_TEMPLATE_URL: &str = "https://raw.githubusercontent.com/LIghtJUNction/MagicSingBox/63780ca3a96ee65af18b17aa87e11b536bbc5a73/config.json";
 const MAGIC_SINGBOX_TEMPLATE_SHA256: &str =
-    "8e91177e9222b2e5dee91ec849716757601156a28e7a056e6091ab5c71e102a5";
+    "ba0f9057b2b6ac896a8783a5691388325306be066e81c4098d9f62d79ac7ee50";
 const STANDALONE_CONFIG_MARKER: &str = ".config/sing-box/standalone-config";
 const TAILSCALE_AUTH_PATH: &str = ".config/sing-box/tailscale-auth.json";
 static CONFIG_EDITOR_STAGE_SEQUENCE: AtomicUsize = AtomicUsize::new(0);

--- a/hooks/pre-build/5450.update_sing_box_rules.sh
+++ b/hooks/pre-build/5450.update_sing_box_rules.sh
@@ -68,6 +68,7 @@ rule_source() {
         hagezi-normal.srs) printf '%s|%s|%s\n' "https://github.com/razaxq/dns-blocklists-sing-box.git" "rule-set" "hagezi-normal.srs" ;;
         hagezi-anti-piracy.srs) printf '%s|%s|%s\n' "https://github.com/razaxq/dns-blocklists-sing-box.git" "rule-set" "hagezi-anti-piracy.srs" ;;
         karing-acl4ssr-ai.srs) printf '%s|%s|%s\n' "https://github.com/KaringX/karing-ruleset.git" "sing" "ACL4SSR/AI.srs" ;;
+        karing-acl4ssr-wechat.srs) printf '%s|%s|%s\n' "https://github.com/KaringX/karing-ruleset.git" "sing" "ACL4SSR/Wechat.srs" ;;
         karing-acl4ssr-proxy-lite.srs) printf '%s|%s|%s\n' "https://github.com/KaringX/karing-ruleset.git" "sing" "ACL4SSR/ProxyLite.srs" ;;
         karing-acl4ssr-proxy-gfwlist.srs) printf '%s|%s|%s\n' "https://github.com/KaringX/karing-ruleset.git" "sing" "ACL4SSR/ProxyGFWlist.srs" ;;
         karing-acl4ssr-banad.srs) printf '%s|%s|%s\n' "https://github.com/KaringX/karing-ruleset.git" "sing" "ACL4SSR/BanAD.srs" ;;

--- a/scripts/package-smoke.sh
+++ b/scripts/package-smoke.sh
@@ -1462,17 +1462,6 @@ if not voice_rule["ip_cidr"]:
     raise SystemExit("packaged ChatGPT Voice route has no official IP prefixes")
 for prefix in voice_rule["ip_cidr"]:
     ipaddress.ip_network(prefix)
-cn_ip_indexes = [
-    index
-    for index, rule in enumerate(route_rules)
-    if rule.get("outbound") == "cn-direct" and (rule.get("ip_cidr") or rule.get("rule_set"))
-]
-if not cn_ip_indexes or voice_index >= min(cn_ip_indexes):
-    raise SystemExit(
-        f"packaged ChatGPT Voice route must precede CN IP ownership: "
-        f"voice={voice_index} cn={cn_ip_indexes}"
-    )
-
 x_package_routes = [
     index
     for index, rule in enumerate(route_rules)

--- a/scripts/test-action-routing.sh
+++ b/scripts/test-action-routing.sh
@@ -235,15 +235,10 @@ if not voice_cidrs:
 for prefix in voice_cidrs:
     ipaddress.ip_network(prefix)
 
-cn_ip_indexes = [
-    index
-    for index, rule in enumerate(route_rules)
-    if rule.get("outbound") == "cn-direct"
-    and (rule.get("ip_cidr") or rule.get("rule_set"))
-]
-if not cn_ip_indexes or voice_index >= min(cn_ip_indexes):
+if voice_index >= cn_ip_indexes[0]:
     raise AssertionError(
-        f"ChatGPT Voice route must precede CN IP ownership: voice={voice_index} cn={cn_ip_indexes}"
+        "ChatGPT Voice route must precede generic CN IP ownership: "
+        f"voice={voice_index} cn={cn_ip_indexes}"
     )
 
 voice_address = str(ipaddress.ip_network(voice_cidrs[0]).network_address)

--- a/scripts/test-wechat-routing.sh
+++ b/scripts/test-wechat-routing.sh
@@ -31,6 +31,8 @@ wechat_domains = [
 ]
 wechat_route = {"domain_suffix": wechat_domains, "outbound": "cn-direct"}
 wechat_dns = {"domain_suffix": wechat_domains, "server": "bootstrap-local-dns"}
+wechat_rule_set_tag = "karing-acl4ssr-wechat"
+wechat_ip_route = {"rule_set": wechat_rule_set_tag, "outbound": "cn-direct"}
 
 
 def exact_indexes(rules, expected):
@@ -64,10 +66,27 @@ def domain_matches(rule, domain):
 
 wechat_route_indexes = exact_indexes(route_rules, wechat_route)
 wechat_dns_indexes = exact_indexes(dns_rules, wechat_dns)
+wechat_ip_route_indexes = exact_indexes(route_rules, wechat_ip_route)
 if len(wechat_route_indexes) != 1:
     raise AssertionError(f"expected one canonical WeChat direct route, got {wechat_route_indexes}")
 if len(wechat_dns_indexes) != 1:
     raise AssertionError(f"expected one canonical WeChat local-DNS rule, got {wechat_dns_indexes}")
+if len(wechat_ip_route_indexes) != 1:
+    raise AssertionError(f"expected one maintained WeChat IP route, got {wechat_ip_route_indexes}")
+
+wechat_rule_set_definitions = [
+    rule for rule in config["route"]["rule_set"]
+    if rule.get("tag") == wechat_rule_set_tag
+]
+if wechat_rule_set_definitions != [{
+    "type": "local",
+    "tag": wechat_rule_set_tag,
+    "format": "binary",
+    "path": "rules/karing-acl4ssr-wechat.srs",
+}]:
+    raise AssertionError(
+        f"expected one packaged WeChat rule-set definition, got {wechat_rule_set_definitions}"
+    )
 
 global_route_indexes = [
     index for index, rule in enumerate(route_rules) if rule.get("clash_mode") == "Global"
@@ -79,6 +98,8 @@ if global_route_indexes and wechat_route_indexes[0] <= global_route_indexes[-1]:
     raise AssertionError("Global route mode must retain priority over the WeChat direct route")
 if global_dns_indexes and wechat_dns_indexes[0] <= global_dns_indexes[-1]:
     raise AssertionError("Global DNS mode must retain priority over the WeChat local resolver")
+if wechat_ip_route_indexes[0] != wechat_route_indexes[0] + 1:
+    raise AssertionError("maintained WeChat IP routing must immediately follow its domain route")
 
 if any(
     "com.tencent.mm" in rule.get("package_name", [])
@@ -95,3 +116,17 @@ for domain in ("mmbiz.qpic.cn", "wx.qlogo.cn", "res.wx.qq.com", "weixin.qq.com")
 
 print("WeChat media routing policy test passed")
 PY
+
+WECHAT_RULE_FILE="$CONFIG_DIR/rules/karing-acl4ssr-wechat.srs"
+if command -v sing-box >/dev/null 2>&1 && [[ -s "$WECHAT_RULE_FILE" ]]; then
+    match_output=$(sing-box rule-set match -f binary "$WECHAT_RULE_FILE" 101.32.104.4 2>&1)
+    [[ "$match_output" == *"match rules."* ]] || {
+        printf 'WeChat routing test failed: packaged rule set misses a dedicated WeChat IP\n' >&2
+        exit 1
+    }
+    non_match_output=$(sing-box rule-set match -f binary "$WECHAT_RULE_FILE" 8.8.8.8 2>&1)
+    [[ -z "$non_match_output" ]] || {
+        printf 'WeChat routing test failed: packaged rule set captures unrelated public IPs\n' >&2
+        exit 1
+    }
+fi


### PR DESCRIPTION
## Summary

- add the maintained Karing/ACL4SSR WeChat rule set to the offline rule bundle
- route its dedicated WeChat destination IPs through `cn-direct` immediately after the existing WeChat domain rule
- preserve Direct/Global overrides, app-specific routing, and generic CN ownership ordering
- pin the runtime config editor to the matching MagicSingBox baseline from LIghtJUNction/MagicSingBox#11

This addresses IP-only WeChat push long connections without forcing the entire `com.tencent.mm` package to bypass MagicNet.

## Validation

- `bash scripts/test-wechat-routing.sh`
- `bash scripts/test-default-routing-policy.sh`
- `bash scripts/test-action-routing.sh`
- `bash scripts/test-config-template-pin.sh`
- `bash scripts/test-policy-architecture.sh`
- `bash scripts/test-rule-hash-retry.sh`
- `sing-box check -c config.json` (sing-box 1.13.14)
- rule-set positive match: `101.32.104.4`
- unrelated-IP negative match: `8.8.8.8`
- `git diff --check`

Rust tests were not run locally because Cargo is unavailable in this environment; CI covers them.

Closes #139

## Sourcery 摘要

通过添加维护中的目标 IP 路由，使微信推送流量保持直连，同时不会绕过整个微信应用的 MagicNet。

新功能：
- 将维护中的 ACL4SSR 微信规则集添加到离线路由包中。
- 在现有微信域名策略的基础上，将指定的微信目标 IP 通过 `cn-direct` 直连。

错误修复：
- 修复在域名信息不可用时，仅包含 IP 的微信推送连接落入代理路由的问题。

增强功能：
- 更新配置编辑器基线时，保留现有的覆盖规则、应用专属规则和通用中国 IP 路由优先级。

文档：
- 在未发布的更新日志中记录微信目标 IP 直连修复。

测试：
- 扩展路由验证，覆盖打包的微信规则集、路由顺序，以及 IP 正向和反向匹配。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将维护的微信目标 IP 通过 cn-direct 路由，同时不会绕过整个微信应用的 MagicNet。

Bug 修复：
- 当路由在缺少域名信息的情况下回退到目标 IP 时，保持微信推送连接直连。

功能增强：
- 在添加专用微信 IP 路由的同时，保留现有的 Direct/Global 覆盖规则、应用专属路由以及通用的中国 IP 归属顺序。
- 将运行时配置编辑器固定到更新后的匹配 MagicSingBox 配置基线。

构建：
- 将维护的 ACL4SSR 微信规则集打包到离线规则包中。

文档：
- 在未发布的变更日志中记录微信目标 IP 直连修复。

测试：
- 扩展路由验证，以检查已打包的微信规则集、路由顺序，以及 IP 正向和反向匹配。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route maintained WeChat destination IPs through cn-direct without bypassing MagicNet for the entire WeChat application.

Bug Fixes:
- Keep WeChat push connections direct when routing falls back to destination IPs without domain information.

Enhancements:
- Preserve existing Direct/Global overrides, app-specific routing, and generic China IP ownership ordering while adding dedicated WeChat IP routing.
- Pin the runtime configuration editor to the updated matching MagicSingBox configuration baseline.

Build:
- Package the maintained ACL4SSR WeChat rule set in the offline rule bundle.

Documentation:
- Document the WeChat destination IP direct-routing fix in the unreleased changelog.

Tests:
- Extend routing validation to verify the packaged WeChat rule set, route ordering, and positive and negative IP matching.

</details>

</details>