### PR TITLE
fix: tolerate trailing NUL padding in Android proc cmdlines

### DIFF
--- a/crates/magicnet-cli/src/utils.rs
+++ b/crates/magicnet-cli/src/utils.rs
@@ -391,8 +391,16 @@ fn parse_proc_argv(path: &Path, bytes: &[u8]) -> Result<Vec<String>, String> {
             path.display()
         ));
     }
+    // Android processes may rewrite argv[0] without clearing the rest of the
+    // kernel-exposed argument buffer, leaving NUL padding after the logical
+    // command line. Ignore only that trailing padding; empty arguments between
+    // non-empty arguments remain invalid below.
+    let logical_end = bytes
+        .iter()
+        .rposition(|byte| *byte != 0)
+        .ok_or_else(|| format!("proc cmdline has no arguments: {}", path.display()))?;
     let mut argv = Vec::new();
-    for argument in bytes[..bytes.len() - 1].split(|byte| *byte == 0) {
+    for argument in bytes[..=logical_end].split(|byte| *byte == 0) {
         if argument.is_empty() || argument.contains(&b'\n') || argument.contains(&b'\r') {
             return Err(format!(
                 "proc cmdline contains an invalid argument: {}",

--- a/crates/magicnet-cli/tests/internal/utils.rs
+++ b/crates/magicnet-cli/tests/internal/utils.rs
@@ -43,6 +43,27 @@ fn bounded_proc_reader_preserves_exact_argv() {
 }
 
 #[test]
+fn bounded_proc_reader_ignores_only_trailing_nul_padding() {
+    let directory = test_directory("proc-reader-nul-padding");
+    let cmdline = directory.join("cmdline");
+    fs::write(&cmdline, b"/system/bin/sh\0/module/worker.sh\0\0\0").unwrap();
+
+    assert_eq!(
+        read_proc_argv(&cmdline).unwrap(),
+        vec![
+            "/system/bin/sh".to_string(),
+            "/module/worker.sh".to_string()
+        ]
+    );
+
+    fs::write(&cmdline, b"/system/bin/sh\0\0/module/worker.sh\0").unwrap();
+    assert!(read_proc_argv(&cmdline)
+        .unwrap_err()
+        .contains("invalid argument"));
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
 fn bounded_proc_reader_rejects_oversize_and_malformed_cmdlines() {
     let directory = test_directory("proc-reader-limits");
     let oversized = directory.join("oversized");

--- a/crates/magicnet-cli/tests/proc_reader.rs
+++ b/crates/magicnet-cli/tests/proc_reader.rs
@@ -152,6 +152,18 @@ fn script_scan_is_framed_and_fifo_failure_is_indeterminate() {
         b"MAGICNET_PROC_PIDS_V1\n123\nMAGICNET_PROC_PIDS_END 1\n"
     );
 
+    fs::write(root.join("123/cmdline"), b"com.tencent.mm:appbrand0\0\0\0")
+        .expect("write padded unrelated cmdline");
+    let output = Command::new(cli)
+        .args(["__proc-script-pids", root.to_str().unwrap(), script])
+        .output()
+        .expect("scan padded unrelated cmdline");
+    assert!(output.status.success(), "stderr={:?}", output.stderr);
+    assert_eq!(
+        output.stdout,
+        b"MAGICNET_PROC_PIDS_V1\nMAGICNET_PROC_PIDS_END 0\n"
+    );
+
     fs::remove_file(root.join("123/cmdline")).expect("remove regular cmdline");
     make_fifo(&root.join("123/cmdline"));
     let started = Instant::now();


### PR DESCRIPTION
## Summary

- trim Android's trailing NUL padding before parsing `/proc/<pid>/cmdline` arguments
- keep rejecting empty arguments inside the logical argv, line breaks, and invalid UTF-8
- cover both direct argv parsing and empty framed `__proc-script-pids` results

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p magicnet-cli --bin magicnet-cli bounded_proc_reader_ignores_only_trailing_nul_padding`
- `cargo test -p magicnet-cli --test proc_reader script_scan_is_framed_and_fifo_failure_is_indeterminate`

Fixes #141

## Sourcery 摘要

在解析进程命令行时容忍 Android 的尾随 NUL 填充，同时不放宽对格式错误参数的验证。

Bug 修复：
- 处理带有尾随 NUL 填充的 Android `/proc/<pid>/cmdline` 值，同时继续拒绝逻辑参数列表中的无效参数。

测试：
- 增加对尾随 NUL 填充、嵌入的空参数，以及脚本扫描期间带填充的无关进程命令行的覆盖测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tolerate Android's trailing NUL padding when parsing process command lines without weakening validation of malformed arguments.

Bug Fixes:
- Handle Android `/proc/<pid>/cmdline` values with trailing NUL padding while continuing to reject invalid arguments within the logical argument list.

Tests:
- Add coverage for trailing NUL padding, embedded empty arguments, and padded unrelated process cmdlines during script scanning.

</details>