### PR TITLE
feat(webui): 新增 magicnet0 TUN 路径速览页

### DIFF
--- a/webui/about-overview.test.mjs
+++ b/webui/about-overview.test.mjs
@@ -1,38 +1,59 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import {
-  DATAPLANE_IFACE,
-  dataPlaneFacts,
-  firstRunSteps,
-  formatAboutOverview,
-  successChecks,
-} from "./src/components/pages/aboutOverview.ts";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "./node_modules/typescript/lib/typescript.js";
 
-const facts = dataPlaneFacts();
-const steps = firstRunSteps();
-const checks = successChecks();
-const report = formatAboutOverview();
+function transpile(source) {
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText;
+}
+
 const aboutPage = readFileSync(new URL("./src/components/pages/AboutPage.vue", import.meta.url), "utf8");
 const app = readFileSync(new URL("./src/App.vue", import.meta.url), "utf8");
-
-assert.equal(DATAPLANE_IFACE, "magicnet0");
-assert.equal(facts.length, 3);
-assert.equal(steps.length, 3);
-assert.equal(checks.length, 3);
-assert.ok(facts.every((item) => item.code && item.title && item.detail));
-assert.match(report, /dataplane=sing-box TUN/);
-assert.match(report, /iface=magicnet0/);
-assert.match(report, /cli health/);
-assert.match(report, /cli transparent status/);
-assert.doesNotMatch(report, /\bTProxy\b/);
-assert.doesNotMatch(report, /\beBPF\b/);
-assert.doesNotMatch(report, /ALLOW_MULTI/);
-assert.doesNotMatch(report, /cli ebpf status/);
-assert.doesNotMatch(report, /\bauto\b/);
-assert.equal(
-  successChecks().map((item) => item.command).join(" | "),
-  "cli health | cli transparent status | magicnet0",
+const overviewSource = readFileSync(
+  new URL("./src/components/pages/aboutOverview.ts", import.meta.url),
+  "utf8",
 );
+
+const dir = await mkdtemp(join(tmpdir(), "magicnet-about-overview-"));
+try {
+  await writeFile(join(dir, "aboutOverview.mjs"), transpile(overviewSource), "utf8");
+  const overview = await import(pathToFileURL(join(dir, "aboutOverview.mjs")).href);
+
+  const facts = overview.dataPlaneFacts();
+  const steps = overview.firstRunSteps();
+  const checks = overview.successChecks();
+  const report = overview.formatAboutOverview();
+
+  assert.equal(overview.DATAPLANE_IFACE, "magicnet0");
+  assert.equal(facts.length, 3);
+  assert.equal(steps.length, 3);
+  assert.equal(checks.length, 3);
+  assert.ok(facts.every((item) => item.code && item.title && item.detail));
+  assert.match(report, /dataplane=sing-box TUN/);
+  assert.match(report, /iface=magicnet0/);
+  assert.match(report, /cli health/);
+  assert.match(report, /cli transparent status/);
+  assert.doesNotMatch(report, /\bTProxy\b/);
+  assert.doesNotMatch(report, /\beBPF\b/);
+  assert.doesNotMatch(report, /ALLOW_MULTI/);
+  assert.doesNotMatch(report, /cli ebpf status/);
+  assert.doesNotMatch(report, /\bauto\b/);
+  assert.equal(
+    checks.map((item) => item.command).join(" | "),
+    "cli health | cli transparent status | magicnet0",
+  );
+} finally {
+  await rm(dir, { recursive: true, force: true });
+}
 
 assert.match(aboutPage, /路径速览/);
 assert.match(aboutPage, /goto-tab/);

--- a/webui/about-overview.test.mjs
+++ b/webui/about-overview.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  DATAPLANE_IFACE,
+  dataPlaneFacts,
+  firstRunSteps,
+  formatAboutOverview,
+  successChecks,
+} from "./src/components/pages/aboutOverview.ts";
+
+const facts = dataPlaneFacts();
+const steps = firstRunSteps();
+const checks = successChecks();
+const report = formatAboutOverview();
+const aboutPage = readFileSync(new URL("./src/components/pages/AboutPage.vue", import.meta.url), "utf8");
+const app = readFileSync(new URL("./src/App.vue", import.meta.url), "utf8");
+
+assert.equal(DATAPLANE_IFACE, "magicnet0");
+assert.equal(facts.length, 3);
+assert.equal(steps.length, 3);
+assert.equal(checks.length, 3);
+assert.ok(facts.every((item) => item.code && item.title && item.detail));
+assert.match(report, /dataplane=sing-box TUN/);
+assert.match(report, /iface=magicnet0/);
+assert.match(report, /cli health/);
+assert.match(report, /cli transparent status/);
+assert.doesNotMatch(report, /\bTProxy\b/);
+assert.doesNotMatch(report, /\beBPF\b/);
+assert.doesNotMatch(report, /ALLOW_MULTI/);
+assert.doesNotMatch(report, /cli ebpf status/);
+assert.doesNotMatch(report, /\bauto\b/);
+assert.equal(
+  successChecks().map((item) => item.command).join(" | "),
+  "cli health | cli transparent status | magicnet0",
+);
+
+assert.match(aboutPage, /路径速览/);
+assert.match(aboutPage, /goto-tab/);
+assert.match(aboutPage, /DATAPLANE_IFACE/);
+assert.doesNotMatch(aboutPage, /TProxy|eBPF|ALLOW_MULTI|cli ebpf status/);
+
+assert.match(app, /type TabKey =[\s\S]*"about"/);
+assert.match(app, /import\("@\/components\/pages\/AboutPage\.vue"\)/);
+assert.match(app, /key: "about", label: "路径速览"/);
+assert.match(app, /@goto-tab="setTab"/);
+assert.match(app, /<KeepAlive :max="11">/);
+
+console.log("about overview tests passed");

--- a/webui/frontend-refactor-contract.test.mjs
+++ b/webui/frontend-refactor-contract.test.mjs
@@ -184,6 +184,11 @@ assert.match(
 );
 assert.match(
   app,
+  /import\("@\/components\/pages\/AboutPage\.vue"\)/,
+  "App.vue must dynamic-import AboutPage",
+);
+assert.match(
+  app,
   /import\("@\/components\/pages\/ConfigPage\.vue"\)/,
   "App.vue must dynamic-import ConfigPage",
 );
@@ -224,7 +229,7 @@ assert.match(
 );
 assert.match(
   app,
-  /应用|黑名单|链式代理|订阅|工具|面板|输出/,
+  /路径速览|应用|黑名单|链式代理|订阅|工具|面板|输出/,
   "all local page labels must remain reachable",
 );
 assert.match(

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -28,7 +28,7 @@ import { useMagicNet } from "@/composables/useMagicNet";
 import { useTheme } from "@/composables/useTheme";
 import { restoreFocusAfterUpdate, trapFocusWithin } from "@/lib/focus";
 
-type TabKey = "control" | "config" | "apps" | "block" | "chain" | "subs" | "tools" | "health" | "webui" | "output";
+type TabKey = "control" | "about" | "config" | "apps" | "block" | "chain" | "subs" | "tools" | "health" | "webui" | "output";
 type WorkspaceKey = "run" | "route" | "configure" | "diagnose";
 type OnboardingTarget = Extract<TabKey, "control" | "subs" | "health" | "output">;
 type OnboardingPreference = "dismissed" | "completed";
@@ -52,6 +52,7 @@ const ONBOARDING_STORAGE_KEY = "magicnet.webui.onboarding.v1";
 
 const pageLoaders: Record<TabKey, () => Promise<{ default: Component }>> = {
   control: () => import("@/components/pages/ControlPage.vue"),
+  about: () => import("@/components/pages/AboutPage.vue"),
   config: () => import("@/components/pages/ConfigPage.vue"),
   apps: () => import("@/components/pages/AppsPage.vue"),
   block: () => import("@/components/pages/BlocklistPage.vue"),
@@ -77,6 +78,7 @@ const asyncPages = Object.fromEntries(
 
 const tabs: readonly TabDefinition[] = [
   { key: "control", label: "运行总览", code: "STATUS", workspace: "run" },
+  { key: "about", label: "路径速览", code: "PATH", workspace: "run" },
   { key: "apps", label: "应用策略", code: "APPS", workspace: "route" },
   { key: "block", label: "规则黑名单", code: "BLOCK", workspace: "route" },
   { key: "chain", label: "链式代理", code: "CHAIN", workspace: "route" },
@@ -140,7 +142,7 @@ const {
 const { preference: themePreference, label: themeLabel, cycleTheme } = useTheme();
 
 const activeTab = ref<TabKey>("control");
-/** Keep the complete ten-page surface warm so unfinished forms survive workspace switches. */
+/** Keep the complete page surface warm so unfinished forms survive workspace switches. */
 const visitedTabs = ref<TabKey[]>(["control"]);
 const lastTabByWorkspace = ref<Record<WorkspaceKey, TabKey>>({
   run: "control",
@@ -602,10 +604,11 @@ onUnmounted(() => {
         <!-- KeepAlive preserves form state across all four workspaces. -->
         <section class="page-surface">
           <Suspense>
-            <KeepAlive :max="10">
+            <KeepAlive :max="11">
               <component
                 :is="activeComponent"
                 @goto-output="setTab('output')"
+                @goto-tab="setTab"
               />
             </KeepAlive>
             <template #fallback>

--- a/webui/src/components/pages/AboutPage.vue
+++ b/webui/src/components/pages/AboutPage.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { Activity, CheckCircle2, Copy, Radio, Stethoscope } from "lucide-vue-next";
+import { computed, ref } from "vue";
+import Badge from "@/components/ui/Badge.vue";
+import Button from "@/components/ui/Button.vue";
+import Card from "@/components/ui/Card.vue";
+import CardHeading from "@/components/ui/CardHeading.vue";
+import PageHeader from "@/components/ui/PageHeader.vue";
+import StatTile from "@/components/ui/StatTile.vue";
+import { useMagicNet } from "@/composables/useMagicNet";
+import { copyText } from "@/utils";
+import {
+  DATAPLANE_IFACE,
+  dataPlaneFacts,
+  firstRunSteps,
+  formatAboutOverview,
+  successChecks,
+} from "./aboutOverview";
+
+const emit = defineEmits<{
+  (e: "goto-tab", tab: "control" | "subs" | "health"): void;
+}>();
+
+const { state } = useMagicNet();
+const copied = ref(false);
+
+const facts = dataPlaneFacts();
+const steps = firstRunSteps();
+const checks = successChecks();
+const overview = computed(() => formatAboutOverview(facts, steps, checks));
+
+const tunLabel = computed(() => {
+  if (state.runtime.singBoxState === "sing-box") return "sing-box 运行中";
+  if (state.runtime.singBoxState === "stopped") return "已停止";
+  return "状态未知";
+});
+
+const tunTone = computed(() => {
+  if (state.runtime.singBoxState === "sing-box") return "success" as const;
+  if (state.runtime.singBoxState === "stopped") return "warning" as const;
+  return "neutral" as const;
+});
+
+async function copyOverview(): Promise<void> {
+  copied.value = await copyText(overview.value);
+  state.notice = copied.value
+    ? "路径速览已复制。"
+    : "剪贴板不可用，路径速览未复制。";
+}
+</script>
+
+<template>
+  <div class="grid gap-4 md:gap-5">
+    <PageHeader
+      overline="Data Plane"
+      title="路径速览"
+      description="一眼看清 MagicNet 当前只走 sing-box magicnet0 TUN，以及怎样用健康检查证明接管成功。"
+    >
+      <template #actions>
+        <Button variant="outline" @click="copyOverview">
+          <Copy :size="17" aria-hidden="true" />{{ copied ? "已复制说明" : "复制说明" }}
+        </Button>
+        <Badge :tone="tunTone">{{ tunLabel }}</Badge>
+      </template>
+    </PageHeader>
+
+    <div class="grid gap-3 sm:grid-cols-3">
+      <StatTile label="数据面" :value="DATAPLANE_IFACE" hint="唯一透明接口" mono />
+      <StatTile label="核心" value="sing-box TUN" hint="不占用系统 VPN slot" />
+      <StatTile
+        label="验收"
+        value="health + TUN"
+        hint="以 cli 与 magicnet0 为准"
+      />
+    </div>
+
+    <Card class="grid gap-4 !p-4 md:!p-6">
+      <CardHeading
+        overline="PATH"
+        title="Android root → magicnet0 → sing-box"
+        description="这是模块 WebUI 要先证明的真实路径。节点选择仍由 sing-box 面板负责。"
+      >
+        <Radio :size="18" aria-hidden="true" />
+      </CardHeading>
+      <div class="grid gap-3 md:grid-cols-3">
+        <div
+          v-for="fact in facts"
+          :key="fact.code"
+          class="grid gap-2 rounded-[2px] border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] p-3"
+        >
+          <code class="text-[11px] tracking-[0.08em] text-[var(--mn-ink-faint)]">{{ fact.code }}</code>
+          <h3 class="text-base font-semibold text-[var(--mn-ink)]">{{ fact.title }}</h3>
+          <p class="text-sm leading-6 text-[var(--mn-ink-muted)]">{{ fact.detail }}</p>
+        </div>
+      </div>
+    </Card>
+
+    <div class="grid gap-4 lg:grid-cols-2">
+      <Card class="grid gap-4 !p-4 md:!p-6">
+        <CardHeading
+          overline="START"
+          title="首次成功运行"
+          description="三步就能确认设备已经被 TUN 接管。"
+        />
+        <ol class="grid gap-3">
+          <li
+            v-for="(step, index) in steps"
+            :key="step.id"
+            class="grid gap-1 rounded-[2px] border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] p-3 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-start sm:gap-3"
+          >
+            <span class="font-mono text-xs text-[var(--mn-ink-faint)]">{{ String(index + 1).padStart(2, "0") }}</span>
+            <div class="grid gap-1">
+              <strong class="text-sm text-[var(--mn-ink)]">{{ step.title }}</strong>
+              <p class="text-sm leading-6 text-[var(--mn-ink-muted)]">{{ step.detail }}</p>
+            </div>
+          </li>
+        </ol>
+        <div class="flex flex-wrap gap-2">
+          <Button variant="secondary" @click="emit('goto-tab', 'subs')">
+            <Activity :size="17" aria-hidden="true" />去订阅
+          </Button>
+          <Button variant="secondary" @click="emit('goto-tab', 'health')">
+            <Stethoscope :size="17" aria-hidden="true" />去健康检查
+          </Button>
+        </div>
+      </Card>
+
+      <Card class="grid gap-4 !p-4 md:!p-6">
+        <CardHeading
+          overline="ACCEPT"
+          title="成功判据"
+          description="不要寻找已删除的旁路。主线只支持 sing-box magicnet0 TUN。"
+        />
+        <ul class="grid gap-3">
+          <li
+            v-for="check in checks"
+            :key="check.command"
+            class="grid gap-1 rounded-[2px] border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] p-3"
+          >
+            <div class="flex items-center gap-2">
+              <CheckCircle2 :size="16" aria-hidden="true" />
+              <code class="text-sm text-[var(--mn-ink)]">{{ check.command }}</code>
+            </div>
+            <p class="text-sm leading-6 text-[var(--mn-ink-muted)]">{{ check.expect }}</p>
+          </li>
+        </ul>
+        <Button variant="outline" @click="emit('goto-tab', 'control')">
+          返回运行总览
+        </Button>
+      </Card>
+    </div>
+  </div>
+</template>

--- a/webui/src/components/pages/aboutOverview.ts
+++ b/webui/src/components/pages/aboutOverview.ts
@@ -1,0 +1,99 @@
+export const DATAPLANE_IFACE = "magicnet0";
+
+export type AboutFact = {
+  code: string;
+  title: string;
+  detail: string;
+};
+
+export type AboutStep = {
+  id: string;
+  title: string;
+  detail: string;
+};
+
+export type AboutCheck = {
+  command: string;
+  expect: string;
+};
+
+export function dataPlaneFacts(): AboutFact[] {
+  return [
+    {
+      code: "ROOT",
+      title: "Android root 工作台",
+      detail:
+        "MagicNet 通过模块 CLI 管理 sing-box，不调用应用侧 VpnService.establish()，也不会占用系统 VPN slot。",
+    },
+    {
+      code: "TUN",
+      title: "sing-box magicnet0 TUN",
+      detail:
+        "当前主线只有 TUN 数据面。流量路径是 Android root → magicnet0 → sing-box → 策略/出口。",
+    },
+    {
+      code: "PROOF",
+      title: "以真实接口为准",
+      detail:
+        "真机是否成功，看 cli health、cli transparent status 和 magicnet0 是否存在。",
+    },
+  ];
+}
+
+export function firstRunSteps(): AboutStep[] {
+  return [
+    {
+      id: "dns",
+      title: "关闭私人 DNS",
+      detail: "在系统设置中关闭私人 DNS / Private DNS，不要保留为自动。",
+    },
+    {
+      id: "sub",
+      title: "保存订阅或导入本地文件",
+      detail: "在订阅页保存合法 URL，或导入 Clash YAML、分享链接、JSON 或文本订阅。",
+    },
+    {
+      id: "health",
+      title: "确认健康与 TUN",
+      detail: "健康检查没有核心/TUN 阻塞项，transparent status 显示 TUN，系统存在 magicnet0。",
+    },
+  ];
+}
+
+export function successChecks(): AboutCheck[] {
+  return [
+    {
+      command: "cli health",
+      expect: "没有核心或 TUN 阻塞项",
+    },
+    {
+      command: "cli transparent status",
+      expect: "透明路径为 TUN",
+    },
+    {
+      command: "magicnet0",
+      expect: "系统存在 magicnet0 接口",
+    },
+  ];
+}
+
+export function formatAboutOverview(
+  facts = dataPlaneFacts(),
+  steps = firstRunSteps(),
+  checks = successChecks(),
+): string {
+  return [
+    "MagicNet path overview",
+    `iface=${DATAPLANE_IFACE}`,
+    "dataplane=sing-box TUN",
+    "",
+    "facts",
+    ...facts.map((item) => `${item.code}\t${item.title}\t${item.detail}`),
+    "",
+    "first-run",
+    ...steps.map((item, index) => `${index + 1}. ${item.title}: ${item.detail}`),
+    "",
+    "success",
+    ...checks.map((item) => `${item.command}\t${item.expect}`),
+  ].join("\n");
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
在模块 WebUI「运行」工作区新增「路径速览」页面，说明当前主线仅支持 sing-box `magicnet0` TUN，并给出首次步骤与成功判据。

## 变更
- `AboutPage.vue` + `aboutOverview.ts`：路径速览内容与纯函数数据面
- `App.vue`：注册 `about` 标签与懒加载
- 合同测试与 overview 单测

## 测试
- `node --test about-overview.test.mjs` 通过
- `npm run typecheck` / `npm run build` 通过
- 全套 `*.test.mjs`（Node 22 需 `--experimental-strip-types`）40/40 通过

## 说明
由云端子代理在分支 `cursor/simple-frontend-page-c1c7` 完成；未改动设备透明路径相关逻辑。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8166d09c-4209-4193-b03b-a4c2cfeee453?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8166d09c-4209-4193-b03b-a4c2cfeee453&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Sourcery 摘要

新增 Run 工作区概览，用于理解和验证 sing-box magicnet0 TUN 路径。

新功能：
- 新增 WebUI 路径概览页面，介绍受支持的 sing-box magicnet0 TUN 数据路径、首次运行步骤和成功标准。
- 在 Run 工作区中提供概览页面，并通过延迟加载和导航链接连接到相关页面。

增强：
- 在类型化数据模块中集中管理路径概览信息、引导步骤、验证检查项和可复制报告的生成。

测试：
- 新增契约测试和单元测试，覆盖概览内容、导航注册、受支持的路径声明以及成功检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a Run workspace overview for understanding and validating the sing-box magicnet0 TUN path.

New Features:
- Add a WebUI path overview page describing the supported sing-box magicnet0 TUN data path, first-run steps, and success criteria.
- Expose the overview page in the Run workspace with lazy loading and navigation links to related pages.

Enhancements:
- Centralize path overview facts, onboarding steps, validation checks, and copyable report generation in a typed data module.

Tests:
- Add contract and unit coverage for the overview content, navigation registration, supported path claims, and success checks.

</details>