### PR TITLE
fix(webui): 路径速览美化与 Node 22 测试修复

### DIFF
--- a/webui/about-overview.test.mjs
+++ b/webui/about-overview.test.mjs
@@ -31,12 +31,15 @@ try {
   const facts = overview.dataPlaneFacts();
   const steps = overview.firstRunSteps();
   const checks = overview.successChecks();
+  const pathNodes = overview.pathFlowNodes();
   const report = overview.formatAboutOverview();
 
   assert.equal(overview.DATAPLANE_IFACE, "magicnet0");
   assert.equal(facts.length, 3);
   assert.equal(steps.length, 3);
   assert.equal(checks.length, 3);
+  assert.equal(pathNodes.length, 4);
+  assert.equal(pathNodes.map((item) => item.code).join("|"), "ROOT|TUN|CORE|OUT");
   assert.ok(facts.every((item) => item.code && item.title && item.detail));
   assert.match(report, /dataplane=sing-box TUN/);
   assert.match(report, /iface=magicnet0/);
@@ -58,6 +61,8 @@ try {
 assert.match(aboutPage, /路径速览/);
 assert.match(aboutPage, /goto-tab/);
 assert.match(aboutPage, /DATAPLANE_IFACE/);
+assert.match(aboutPage, /mn-path-flow/);
+assert.match(aboutPage, /InsightChip/);
 assert.doesNotMatch(aboutPage, /TProxy|eBPF|ALLOW_MULTI|cli ebpf status/);
 
 assert.match(app, /type TabKey =[\s\S]*"about"/);
@@ -65,5 +70,12 @@ assert.match(app, /import\("@\/components\/pages\/AboutPage\.vue"\)/);
 assert.match(app, /key: "about", label: "路径速览"/);
 assert.match(app, /@goto-tab="setTab"/);
 assert.match(app, /<KeepAlive :max="11">/);
+
+const controlPage = readFileSync(
+  new URL("./src/components/pages/ControlPage.vue", import.meta.url),
+  "utf8",
+);
+assert.match(controlPage, /goto-tab',\s*'about'|goto-tab",\s*"about"/);
+assert.match(controlPage, /路径速览/);
 
 console.log("about overview tests passed");

--- a/webui/about-overview.test.mjs
+++ b/webui/about-overview.test.mjs
@@ -1,38 +1,59 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import {
-  DATAPLANE_IFACE,
-  dataPlaneFacts,
-  firstRunSteps,
-  formatAboutOverview,
-  successChecks,
-} from "./src/components/pages/aboutOverview.ts";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "./node_modules/typescript/lib/typescript.js";
 
-const facts = dataPlaneFacts();
-const steps = firstRunSteps();
-const checks = successChecks();
-const report = formatAboutOverview();
+function transpile(source) {
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText;
+}
+
 const aboutPage = readFileSync(new URL("./src/components/pages/AboutPage.vue", import.meta.url), "utf8");
 const app = readFileSync(new URL("./src/App.vue", import.meta.url), "utf8");
-
-assert.equal(DATAPLANE_IFACE, "magicnet0");
-assert.equal(facts.length, 3);
-assert.equal(steps.length, 3);
-assert.equal(checks.length, 3);
-assert.ok(facts.every((item) => item.code && item.title && item.detail));
-assert.match(report, /dataplane=sing-box TUN/);
-assert.match(report, /iface=magicnet0/);
-assert.match(report, /cli health/);
-assert.match(report, /cli transparent status/);
-assert.doesNotMatch(report, /\bTProxy\b/);
-assert.doesNotMatch(report, /\beBPF\b/);
-assert.doesNotMatch(report, /ALLOW_MULTI/);
-assert.doesNotMatch(report, /cli ebpf status/);
-assert.doesNotMatch(report, /\bauto\b/);
-assert.equal(
-  successChecks().map((item) => item.command).join(" | "),
-  "cli health | cli transparent status | magicnet0",
+const overviewSource = readFileSync(
+  new URL("./src/components/pages/aboutOverview.ts", import.meta.url),
+  "utf8",
 );
+
+const dir = await mkdtemp(join(tmpdir(), "magicnet-about-overview-"));
+try {
+  await writeFile(join(dir, "aboutOverview.mjs"), transpile(overviewSource), "utf8");
+  const overview = await import(pathToFileURL(join(dir, "aboutOverview.mjs")).href);
+
+  const facts = overview.dataPlaneFacts();
+  const steps = overview.firstRunSteps();
+  const checks = overview.successChecks();
+  const report = overview.formatAboutOverview();
+
+  assert.equal(overview.DATAPLANE_IFACE, "magicnet0");
+  assert.equal(facts.length, 3);
+  assert.equal(steps.length, 3);
+  assert.equal(checks.length, 3);
+  assert.ok(facts.every((item) => item.code && item.title && item.detail));
+  assert.match(report, /dataplane=sing-box TUN/);
+  assert.match(report, /iface=magicnet0/);
+  assert.match(report, /cli health/);
+  assert.match(report, /cli transparent status/);
+  assert.doesNotMatch(report, /\bTProxy\b/);
+  assert.doesNotMatch(report, /\beBPF\b/);
+  assert.doesNotMatch(report, /ALLOW_MULTI/);
+  assert.doesNotMatch(report, /cli ebpf status/);
+  assert.doesNotMatch(report, /\bauto\b/);
+  assert.equal(
+    checks.map((item) => item.command).join(" | "),
+    "cli health | cli transparent status | magicnet0",
+  );
+} finally {
+  await rm(dir, { recursive: true, force: true });
+}
 
 assert.match(aboutPage, /路径速览/);
 assert.match(aboutPage, /goto-tab/);

--- a/webui/about-overview.test.mjs
+++ b/webui/about-overview.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  DATAPLANE_IFACE,
+  dataPlaneFacts,
+  firstRunSteps,
+  formatAboutOverview,
+  successChecks,
+} from "./src/components/pages/aboutOverview.ts";
+
+const facts = dataPlaneFacts();
+const steps = firstRunSteps();
+const checks = successChecks();
+const report = formatAboutOverview();
+const aboutPage = readFileSync(new URL("./src/components/pages/AboutPage.vue", import.meta.url), "utf8");
+const app = readFileSync(new URL("./src/App.vue", import.meta.url), "utf8");
+
+assert.equal(DATAPLANE_IFACE, "magicnet0");
+assert.equal(facts.length, 3);
+assert.equal(steps.length, 3);
+assert.equal(checks.length, 3);
+assert.ok(facts.every((item) => item.code && item.title && item.detail));
+assert.match(report, /dataplane=sing-box TUN/);
+assert.match(report, /iface=magicnet0/);
+assert.match(report, /cli health/);
+assert.match(report, /cli transparent status/);
+assert.doesNotMatch(report, /\bTProxy\b/);
+assert.doesNotMatch(report, /\beBPF\b/);
+assert.doesNotMatch(report, /ALLOW_MULTI/);
+assert.doesNotMatch(report, /cli ebpf status/);
+assert.doesNotMatch(report, /\bauto\b/);
+assert.equal(
+  successChecks().map((item) => item.command).join(" | "),
+  "cli health | cli transparent status | magicnet0",
+);
+
+assert.match(aboutPage, /路径速览/);
+assert.match(aboutPage, /goto-tab/);
+assert.match(aboutPage, /DATAPLANE_IFACE/);
+assert.doesNotMatch(aboutPage, /TProxy|eBPF|ALLOW_MULTI|cli ebpf status/);
+
+assert.match(app, /type TabKey =[\s\S]*"about"/);
+assert.match(app, /import\("@\/components\/pages\/AboutPage\.vue"\)/);
+assert.match(app, /key: "about", label: "路径速览"/);
+assert.match(app, /@goto-tab="setTab"/);
+assert.match(app, /<KeepAlive :max="11">/);
+
+console.log("about overview tests passed");

--- a/webui/frontend-refactor-contract.test.mjs
+++ b/webui/frontend-refactor-contract.test.mjs
@@ -184,6 +184,11 @@ assert.match(
 );
 assert.match(
   app,
+  /import\("@\/components\/pages\/AboutPage\.vue"\)/,
+  "App.vue must dynamic-import AboutPage",
+);
+assert.match(
+  app,
   /import\("@\/components\/pages\/ConfigPage\.vue"\)/,
   "App.vue must dynamic-import ConfigPage",
 );
@@ -224,7 +229,7 @@ assert.match(
 );
 assert.match(
   app,
-  /应用|黑名单|链式代理|订阅|工具|面板|输出/,
+  /路径速览|应用|黑名单|链式代理|订阅|工具|面板|输出/,
   "all local page labels must remain reachable",
 );
 assert.match(

--- a/webui/package.json
+++ b/webui/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",
-    "test": "node --test *.test.mjs",
+    "test": "node --experimental-strip-types --test *.test.mjs",
     "typecheck": "tsc --noEmit",
     "build": "vite build",
     "check": "npm run test && npm run typecheck && npm run build",

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -95,7 +95,7 @@ const workspaces: readonly WorkspaceDefinition[] = [
     key: "run",
     label: "运行",
     code: "RUN",
-    description: "确认核心状态并执行设备级高频控制。",
+    description: "确认核心状态、路径速览并执行设备级高频控制。",
     icon: Gauge,
   },
   {

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -28,7 +28,7 @@ import { useMagicNet } from "@/composables/useMagicNet";
 import { useTheme } from "@/composables/useTheme";
 import { restoreFocusAfterUpdate, trapFocusWithin } from "@/lib/focus";
 
-type TabKey = "control" | "config" | "apps" | "block" | "chain" | "subs" | "tools" | "health" | "webui" | "output";
+type TabKey = "control" | "about" | "config" | "apps" | "block" | "chain" | "subs" | "tools" | "health" | "webui" | "output";
 type WorkspaceKey = "run" | "route" | "configure" | "diagnose";
 type OnboardingTarget = Extract<TabKey, "control" | "subs" | "health" | "output">;
 type OnboardingPreference = "dismissed" | "completed";
@@ -52,6 +52,7 @@ const ONBOARDING_STORAGE_KEY = "magicnet.webui.onboarding.v1";
 
 const pageLoaders: Record<TabKey, () => Promise<{ default: Component }>> = {
   control: () => import("@/components/pages/ControlPage.vue"),
+  about: () => import("@/components/pages/AboutPage.vue"),
   config: () => import("@/components/pages/ConfigPage.vue"),
   apps: () => import("@/components/pages/AppsPage.vue"),
   block: () => import("@/components/pages/BlocklistPage.vue"),
@@ -77,6 +78,7 @@ const asyncPages = Object.fromEntries(
 
 const tabs: readonly TabDefinition[] = [
   { key: "control", label: "运行总览", code: "STATUS", workspace: "run" },
+  { key: "about", label: "路径速览", code: "PATH", workspace: "run" },
   { key: "apps", label: "应用策略", code: "APPS", workspace: "route" },
   { key: "block", label: "规则黑名单", code: "BLOCK", workspace: "route" },
   { key: "chain", label: "链式代理", code: "CHAIN", workspace: "route" },
@@ -140,7 +142,7 @@ const {
 const { preference: themePreference, label: themeLabel, cycleTheme } = useTheme();
 
 const activeTab = ref<TabKey>("control");
-/** Keep the complete ten-page surface warm so unfinished forms survive workspace switches. */
+/** Keep the complete page surface warm so unfinished forms survive workspace switches. */
 const visitedTabs = ref<TabKey[]>(["control"]);
 const lastTabByWorkspace = ref<Record<WorkspaceKey, TabKey>>({
   run: "control",
@@ -602,10 +604,11 @@ onUnmounted(() => {
         <!-- KeepAlive preserves form state across all four workspaces. -->
         <section class="page-surface">
           <Suspense>
-            <KeepAlive :max="10">
+            <KeepAlive :max="11">
               <component
                 :is="activeComponent"
                 @goto-output="setTab('output')"
+                @goto-tab="setTab"
               />
             </KeepAlive>
             <template #fallback>

--- a/webui/src/components/pages/AboutPage.vue
+++ b/webui/src/components/pages/AboutPage.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
-import { Activity, CheckCircle2, Copy, Radio, Stethoscope } from "lucide-vue-next";
+import { Activity, ArrowRight, CheckCircle2, Copy, Radio, Stethoscope } from "lucide-vue-next";
 import { computed, ref } from "vue";
 import Badge from "@/components/ui/Badge.vue";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
 import CardHeading from "@/components/ui/CardHeading.vue";
+import InsightChip from "@/components/ui/InsightChip.vue";
 import PageHeader from "@/components/ui/PageHeader.vue";
 import StatTile from "@/components/ui/StatTile.vue";
+import StatusDot from "@/components/ui/StatusDot.vue";
 import { useMagicNet } from "@/composables/useMagicNet";
 import { copyText } from "@/utils";
 import {
@@ -14,6 +16,7 @@ import {
   dataPlaneFacts,
   firstRunSteps,
   formatAboutOverview,
+  pathFlowNodes,
   successChecks,
 } from "./aboutOverview";
 
@@ -27,6 +30,7 @@ const copied = ref(false);
 const facts = dataPlaneFacts();
 const steps = firstRunSteps();
 const checks = successChecks();
+const pathNodes = pathFlowNodes();
 const overview = computed(() => formatAboutOverview(facts, steps, checks));
 
 const tunLabel = computed(() => {
@@ -41,6 +45,18 @@ const tunTone = computed(() => {
   return "neutral" as const;
 });
 
+const pathState = computed(() => {
+  if (state.runtime.singBoxState === "sing-box") return "active";
+  if (state.runtime.singBoxState === "stopped") return "stopped";
+  return "unknown";
+});
+
+const statusDotTone = computed(() => {
+  if (state.runtime.singBoxState === "sing-box") return "ok" as const;
+  if (state.runtime.singBoxState === "stopped") return "stop" as const;
+  return "unknown" as const;
+});
+
 async function copyOverview(): Promise<void> {
   copied.value = await copyText(overview.value);
   state.notice = copied.value
@@ -50,7 +66,7 @@ async function copyOverview(): Promise<void> {
 </script>
 
 <template>
-  <div class="grid gap-4 md:gap-5">
+  <div class="mn-path-page grid gap-4 md:gap-5">
     <PageHeader
       overline="Data Plane"
       title="路径速览"
@@ -60,7 +76,10 @@ async function copyOverview(): Promise<void> {
         <Button variant="outline" @click="copyOverview">
           <Copy :size="17" aria-hidden="true" />{{ copied ? "已复制说明" : "复制说明" }}
         </Button>
-        <Badge :tone="tunTone">{{ tunLabel }}</Badge>
+        <Badge :tone="tunTone" class="gap-2">
+          <StatusDot :tone="statusDotTone" />
+          {{ tunLabel }}
+        </Badge>
       </template>
     </PageHeader>
 
@@ -74,24 +93,54 @@ async function copyOverview(): Promise<void> {
       />
     </div>
 
+    <Card class="mn-path-board !p-0">
+      <div class="mn-path-board__head">
+        <CardHeading
+          overline="LIVE PATH"
+          title="Android root → magicnet0 → sing-box"
+          description="这是模块 WebUI 要先证明的真实路径。节点选择仍由 sing-box 面板负责。"
+        >
+          <Radio :size="18" aria-hidden="true" />
+        </CardHeading>
+      </div>
+      <ol class="mn-path-flow" :data-state="pathState" aria-label="MagicNet TUN 数据面路径">
+        <li
+          v-for="(node, index) in pathNodes"
+          :key="node.code"
+          class="mn-path-flow__node"
+          :style="{ '--mn-path-delay': `${index * 45}ms` }"
+        >
+          <span class="mn-path-flow__index" aria-hidden="true">{{ node.index }}</span>
+          <div class="mn-path-flow__body">
+            <strong>{{ node.label }}</strong>
+            <code>{{ node.code }}</code>
+          </div>
+          <ArrowRight
+            v-if="index < pathNodes.length - 1"
+            class="mn-path-flow__arrow"
+            :size="16"
+            aria-hidden="true"
+          />
+        </li>
+      </ol>
+    </Card>
+
     <Card class="grid gap-4 !p-4 md:!p-6">
       <CardHeading
         overline="PATH"
-        title="Android root → magicnet0 → sing-box"
-        description="这是模块 WebUI 要先证明的真实路径。节点选择仍由 sing-box 面板负责。"
-      >
-        <Radio :size="18" aria-hidden="true" />
-      </CardHeading>
-      <div class="grid gap-3 md:grid-cols-3">
-        <div
+        title="为什么只保留这条路径"
+        description="主线刻意收敛，避免旁路模式把状态判断搞乱。"
+      />
+      <div class="mn-path-facts">
+        <article
           v-for="fact in facts"
           :key="fact.code"
-          class="grid gap-2 rounded-[2px] border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] p-3"
+          class="mn-path-fact"
         >
-          <code class="text-[11px] tracking-[0.08em] text-[var(--mn-ink-faint)]">{{ fact.code }}</code>
-          <h3 class="text-base font-semibold text-[var(--mn-ink)]">{{ fact.title }}</h3>
-          <p class="text-sm leading-6 text-[var(--mn-ink-muted)]">{{ fact.detail }}</p>
-        </div>
+          <code>{{ fact.code }}</code>
+          <h3>{{ fact.title }}</h3>
+          <p>{{ fact.detail }}</p>
+        </article>
       </div>
     </Card>
 
@@ -102,16 +151,16 @@ async function copyOverview(): Promise<void> {
           title="首次成功运行"
           description="三步就能确认设备已经被 TUN 接管。"
         />
-        <ol class="grid gap-3">
+        <ol class="mn-path-steps">
           <li
             v-for="(step, index) in steps"
             :key="step.id"
-            class="grid gap-1 rounded-[2px] border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] p-3 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-start sm:gap-3"
+            class="mn-path-step"
           >
-            <span class="font-mono text-xs text-[var(--mn-ink-faint)]">{{ String(index + 1).padStart(2, "0") }}</span>
-            <div class="grid gap-1">
-              <strong class="text-sm text-[var(--mn-ink)]">{{ step.title }}</strong>
-              <p class="text-sm leading-6 text-[var(--mn-ink-muted)]">{{ step.detail }}</p>
+            <span class="mn-path-step__index" aria-hidden="true">{{ String(index + 1).padStart(2, "0") }}</span>
+            <div class="mn-path-step__body">
+              <strong>{{ step.title }}</strong>
+              <p>{{ step.detail }}</p>
             </div>
           </li>
         </ol>
@@ -131,17 +180,18 @@ async function copyOverview(): Promise<void> {
           title="成功判据"
           description="不要寻找已删除的旁路。主线只支持 sing-box magicnet0 TUN。"
         />
-        <ul class="grid gap-3">
+        <ul class="mn-path-checks">
           <li
             v-for="check in checks"
             :key="check.command"
-            class="grid gap-1 rounded-[2px] border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] p-3"
+            class="mn-path-check"
           >
-            <div class="flex items-center gap-2">
+            <div class="mn-path-check__title">
               <CheckCircle2 :size="16" aria-hidden="true" />
-              <code class="text-sm text-[var(--mn-ink)]">{{ check.command }}</code>
+              <code>{{ check.command }}</code>
+              <InsightChip tone="ok" label="required" />
             </div>
-            <p class="text-sm leading-6 text-[var(--mn-ink-muted)]">{{ check.expect }}</p>
+            <p>{{ check.expect }}</p>
           </li>
         </ul>
         <Button variant="outline" @click="emit('goto-tab', 'control')">

--- a/webui/src/components/pages/AboutPage.vue
+++ b/webui/src/components/pages/AboutPage.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { Activity, CheckCircle2, Copy, Radio, Stethoscope } from "lucide-vue-next";
+import { computed, ref } from "vue";
+import Badge from "@/components/ui/Badge.vue";
+import Button from "@/components/ui/Button.vue";
+import Card from "@/components/ui/Card.vue";
+import CardHeading from "@/components/ui/CardHeading.vue";
+import PageHeader from "@/components/ui/PageHeader.vue";
+import StatTile from "@/components/ui/StatTile.vue";
+import { useMagicNet } from "@/composables/useMagicNet";
+import { copyText } from "@/utils";
+import {
+  DATAPLANE_IFACE,
+  dataPlaneFacts,
+  firstRunSteps,
+  formatAboutOverview,
+  successChecks,
+} from "./aboutOverview";
+
+const emit = defineEmits<{
+  (e: "goto-tab", tab: "control" | "subs" | "health"): void;
+}>();
+
+const { state } = useMagicNet();
+const copied = ref(false);
+
+const facts = dataPlaneFacts();
+const steps = firstRunSteps();
+const checks = successChecks();
+const overview = computed(() => formatAboutOverview(facts, steps, checks));
+
+const tunLabel = computed(() => {
+  if (state.runtime.singBoxState === "sing-box") return "sing-box 运行中";
+  if (state.runtime.singBoxState === "stopped") return "已停止";
+  return "状态未知";
+});
+
+const tunTone = computed(() => {
+  if (state.runtime.singBoxState === "sing-box") return "success" as const;
+  if (state.runtime.singBoxState === "stopped") return "warning" as const;
+  return "neutral" as const;
+});
+
+async function copyOverview(): Promise<void> {
+  copied.value = await copyText(overview.value);
+  state.notice = copied.value
+    ? "路径速览已复制。"
+    : "剪贴板不可用，路径速览未复制。";
+}
+</script>
+
+<template>
+  <div class="grid gap-4 md:gap-5">
+    <PageHeader
+      overline="Data Plane"
+      title="路径速览"
+      description="一眼看清 MagicNet 当前只走 sing-box magicnet0 TUN，以及怎样用健康检查证明接管成功。"
+    >
+      <template #actions>
+        <Button variant="outline" @click="copyOverview">
+          <Copy :size="17" aria-hidden="true" />{{ copied ? "已复制说明" : "复制说明" }}
+        </Button>
+        <Badge :tone="tunTone">{{ tunLabel }}</Badge>
+      </template>
+    </PageHeader>
+
+    <div class="grid gap-3 sm:grid-cols-3">
+      <StatTile label="数据面" :value="DATAPLANE_IFACE" hint="唯一透明接口" mono />
+      <StatTile label="核心" value="sing-box TUN" hint="不占用系统 VPN slot" />
+      <StatTile
+        label="验收"
+        value="health + TUN"
+        hint="以 cli 与 magicnet0 为准"
+      />
+    </div>
+
+    <Card class="grid gap-4 !p-4 md:!p-6">
+      <CardHeading
+        overline="PATH"
+        title="Android root → magicnet0 → sing-box"
+        description="这是模块 WebUI 要先证明的真实路径。节点选择仍由 sing-box 面板负责。"
+      >
+        <Radio :size="18" aria-hidden="true" />
+      </CardHeading>
+      <div class="grid gap-3 md:grid-cols-3">
+        <div
+          v-for="fact in facts"
+          :key="fact.code"
+          class="grid gap-2 rounded-[2px] border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] p-3"
+        >
+          <code class="text-[11px] tracking-[0.08em] text-[var(--mn-ink-faint)]">{{ fact.code }}</code>
+          <h3 class="text-base font-semibold text-[var(--mn-ink)]">{{ fact.title }}</h3>
+          <p class="text-sm leading-6 text-[var(--mn-ink-muted)]">{{ fact.detail }}</p>
+        </div>
+      </div>
+    </Card>
+
+    <div class="grid gap-4 lg:grid-cols-2">
+      <Card class="grid gap-4 !p-4 md:!p-6">
+        <CardHeading
+          overline="START"
+          title="首次成功运行"
+          description="三步就能确认设备已经被 TUN 接管。"
+        />
+        <ol class="grid gap-3">
+          <li
+            v-for="(step, index) in steps"
+            :key="step.id"
+            class="grid gap-1 rounded-[2px] border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] p-3 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-start sm:gap-3"
+          >
+            <span class="font-mono text-xs text-[var(--mn-ink-faint)]">{{ String(index + 1).padStart(2, "0") }}</span>
+            <div class="grid gap-1">
+              <strong class="text-sm text-[var(--mn-ink)]">{{ step.title }}</strong>
+              <p class="text-sm leading-6 text-[var(--mn-ink-muted)]">{{ step.detail }}</p>
+            </div>
+          </li>
+        </ol>
+        <div class="flex flex-wrap gap-2">
+          <Button variant="secondary" @click="emit('goto-tab', 'subs')">
+            <Activity :size="17" aria-hidden="true" />去订阅
+          </Button>
+          <Button variant="secondary" @click="emit('goto-tab', 'health')">
+            <Stethoscope :size="17" aria-hidden="true" />去健康检查
+          </Button>
+        </div>
+      </Card>
+
+      <Card class="grid gap-4 !p-4 md:!p-6">
+        <CardHeading
+          overline="ACCEPT"
+          title="成功判据"
+          description="不要寻找已删除的旁路。主线只支持 sing-box magicnet0 TUN。"
+        />
+        <ul class="grid gap-3">
+          <li
+            v-for="check in checks"
+            :key="check.command"
+            class="grid gap-1 rounded-[2px] border border-[color-mix(in_srgb,var(--mn-ink)_12%,transparent)] bg-[var(--mn-ivory)] p-3"
+          >
+            <div class="flex items-center gap-2">
+              <CheckCircle2 :size="16" aria-hidden="true" />
+              <code class="text-sm text-[var(--mn-ink)]">{{ check.command }}</code>
+            </div>
+            <p class="text-sm leading-6 text-[var(--mn-ink-muted)]">{{ check.expect }}</p>
+          </li>
+        </ul>
+        <Button variant="outline" @click="emit('goto-tab', 'control')">
+          返回运行总览
+        </Button>
+      </Card>
+    </div>
+  </div>
+</template>

--- a/webui/src/components/pages/ControlPage.vue
+++ b/webui/src/components/pages/ControlPage.vue
@@ -55,6 +55,10 @@ const {
   shellQuote,
 } = useMagicNet();
 const { isRunning, withAction } = useActionLock();
+
+const emit = defineEmits<{
+  (e: "goto-tab", tab: "about" | "health" | "output"): void;
+}>();
 type HotspotPolicyPhase = "loading" | "ready" | "error";
 type SingBoxStatusPresentation = {
   label: string;
@@ -369,6 +373,7 @@ onMounted(() => {
       description="管理模块生命周期和常用入口；节点、测速与代理组继续由 sing-box WebUI 负责。"
     >
       <template #actions>
+        <Button variant="outline" @click="emit('goto-tab', 'about')">路径速览</Button>
         <Button variant="outline" @click="copyControlSnapshot"
           ><Copy :size="17" />{{
             snapshotCopied ? "已复制快照" : "复制快照"

--- a/webui/src/components/pages/aboutOverview.ts
+++ b/webui/src/components/pages/aboutOverview.ts
@@ -17,6 +17,21 @@ export type AboutCheck = {
   expect: string;
 };
 
+export type AboutPathNode = {
+  index: string;
+  label: string;
+  code: string;
+};
+
+export function pathFlowNodes(): AboutPathNode[] {
+  return [
+    { index: "01", label: "Android root", code: "ROOT" },
+    { index: "02", label: DATAPLANE_IFACE, code: "TUN" },
+    { index: "03", label: "sing-box", code: "CORE" },
+    { index: "04", label: "策略 / 出口", code: "OUT" },
+  ];
+}
+
 export function dataPlaneFacts(): AboutFact[] {
   return [
     {

--- a/webui/src/components/pages/aboutOverview.ts
+++ b/webui/src/components/pages/aboutOverview.ts
@@ -1,0 +1,99 @@
+export const DATAPLANE_IFACE = "magicnet0";
+
+export type AboutFact = {
+  code: string;
+  title: string;
+  detail: string;
+};
+
+export type AboutStep = {
+  id: string;
+  title: string;
+  detail: string;
+};
+
+export type AboutCheck = {
+  command: string;
+  expect: string;
+};
+
+export function dataPlaneFacts(): AboutFact[] {
+  return [
+    {
+      code: "ROOT",
+      title: "Android root 工作台",
+      detail:
+        "MagicNet 通过模块 CLI 管理 sing-box，不调用应用侧 VpnService.establish()，也不会占用系统 VPN slot。",
+    },
+    {
+      code: "TUN",
+      title: "sing-box magicnet0 TUN",
+      detail:
+        "当前主线只有 TUN 数据面。流量路径是 Android root → magicnet0 → sing-box → 策略/出口。",
+    },
+    {
+      code: "PROOF",
+      title: "以真实接口为准",
+      detail:
+        "真机是否成功，看 cli health、cli transparent status 和 magicnet0 是否存在。",
+    },
+  ];
+}
+
+export function firstRunSteps(): AboutStep[] {
+  return [
+    {
+      id: "dns",
+      title: "关闭私人 DNS",
+      detail: "在系统设置中关闭私人 DNS / Private DNS，不要保留为自动。",
+    },
+    {
+      id: "sub",
+      title: "保存订阅或导入本地文件",
+      detail: "在订阅页保存合法 URL，或导入 Clash YAML、分享链接、JSON 或文本订阅。",
+    },
+    {
+      id: "health",
+      title: "确认健康与 TUN",
+      detail: "健康检查没有核心/TUN 阻塞项，transparent status 显示 TUN，系统存在 magicnet0。",
+    },
+  ];
+}
+
+export function successChecks(): AboutCheck[] {
+  return [
+    {
+      command: "cli health",
+      expect: "没有核心或 TUN 阻塞项",
+    },
+    {
+      command: "cli transparent status",
+      expect: "透明路径为 TUN",
+    },
+    {
+      command: "magicnet0",
+      expect: "系统存在 magicnet0 接口",
+    },
+  ];
+}
+
+export function formatAboutOverview(
+  facts = dataPlaneFacts(),
+  steps = firstRunSteps(),
+  checks = successChecks(),
+): string {
+  return [
+    "MagicNet path overview",
+    `iface=${DATAPLANE_IFACE}`,
+    "dataplane=sing-box TUN",
+    "",
+    "facts",
+    ...facts.map((item) => `${item.code}\t${item.title}\t${item.detail}`),
+    "",
+    "first-run",
+    ...steps.map((item, index) => `${index + 1}. ${item.title}: ${item.detail}`),
+    "",
+    "success",
+    ...checks.map((item) => `${item.command}\t${item.expect}`),
+  ].join("\n");
+}

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -1461,9 +1461,250 @@ html[data-theme="dark"] .mn-tag-remove {
   }
 }
 
+.mn-path-board__head {
+  padding: 1rem 1rem 0.75rem;
+}
+
+@media (min-width: 768px) {
+  .mn-path-board__head {
+    padding: 1.25rem 1.5rem 1rem;
+  }
+}
+
+.mn-path-flow {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border-top: 1px solid var(--mn-border);
+  background: var(--mn-surface-sunken);
+}
+
+.mn-path-flow__node {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-height: 64px;
+  padding: 12px 14px;
+  border-top: 1px solid var(--mn-border);
+  animation: mn-path-rise 320ms var(--mn-motion-spring) both;
+  animation-delay: var(--mn-path-delay, 0ms);
+}
+
+.mn-path-flow__node:first-child {
+  border-top: 0;
+}
+
+.mn-path-flow__index {
+  display: grid;
+  width: 34px;
+  height: 28px;
+  place-items: center;
+  border: 1px solid var(--mn-border-strong);
+  background: var(--mn-surface-raised);
+  color: var(--mn-ink-faint);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.mn-path-flow__body {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.mn-path-flow__body strong {
+  color: var(--mn-ink);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.mn-path-flow__body code {
+  color: var(--mn-ink-faint);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+}
+
+.mn-path-flow__arrow {
+  color: var(--mn-ink-faint);
+  opacity: 0.55;
+}
+
+.mn-path-flow[data-state="active"] .mn-path-flow__index {
+  border-color: var(--mn-cactus);
+  background: var(--mn-cactus);
+  color: var(--mn-on-accent);
+}
+
+.mn-path-flow[data-state="active"] .mn-path-flow__arrow {
+  color: var(--mn-cactus);
+  opacity: 1;
+}
+
+.mn-path-flow[data-state="stopped"] .mn-path-flow__index {
+  border-color: var(--mn-danger);
+  color: var(--mn-danger);
+}
+
+.mn-path-facts {
+  display: grid;
+  gap: 0;
+  border: 1px solid var(--mn-border);
+  background: var(--mn-border);
+}
+
+.mn-path-fact {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  background: var(--mn-surface-raised);
+}
+
+.mn-path-fact code {
+  color: var(--mn-ink-faint);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+}
+
+.mn-path-fact h3 {
+  margin: 0;
+  color: var(--mn-ink);
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+
+.mn-path-fact p {
+  margin: 0;
+  color: var(--mn-ink-muted);
+  font-size: 0.875rem;
+  line-height: 1.6;
+}
+
+.mn-path-steps,
+.mn-path-checks {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border: 1px solid var(--mn-border);
+  background: var(--mn-border);
+}
+
+.mn-path-step,
+.mn-path-check {
+  display: grid;
+  gap: 6px;
+  padding: 14px;
+  background: var(--mn-surface-raised);
+}
+
+.mn-path-step {
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
+  gap: 12px;
+}
+
+.mn-path-step__index {
+  display: grid;
+  width: 34px;
+  height: 28px;
+  place-items: center;
+  border: 1px solid var(--mn-cactus);
+  background: color-mix(in srgb, var(--mn-cactus) 12%, var(--mn-surface-raised));
+  color: var(--mn-cactus-deep);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+html[data-theme="dark"] .mn-path-step__index {
+  color: var(--mn-cactus);
+}
+
+.mn-path-step__body,
+.mn-path-check {
+  min-width: 0;
+}
+
+.mn-path-step__body strong,
+.mn-path-check__title code {
+  color: var(--mn-ink);
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.mn-path-step__body p,
+.mn-path-check p {
+  margin: 0;
+  color: var(--mn-ink-muted);
+  font-size: 0.875rem;
+  line-height: 1.6;
+}
+
+.mn-path-check__title {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  color: var(--mn-success);
+}
+
+@keyframes mn-path-rise {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (min-width: 768px) {
+  .mn-path-flow {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .mn-path-flow__node {
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-rows: auto auto;
+    align-content: center;
+    min-height: 108px;
+    padding: 16px;
+    border-top: 0;
+    border-left: 1px solid var(--mn-border);
+  }
+
+  .mn-path-flow__node:first-child {
+    border-left: 0;
+  }
+
+  .mn-path-flow__arrow {
+    display: none;
+  }
+
+  .mn-path-facts {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .mn-path-fact + .mn-path-fact {
+    border-left: 0;
+  }
+}
+
 @media (hover: hover) and (pointer: fine) {
   .magic-card:hover {
-    border-left-color: var(--mn-cactus);
+    border-top-color: var(--mn-cactus);
     background: color-mix(in srgb, var(--mn-cactus) 3%, var(--mn-surface-raised));
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
在既有「路径速览」功能之上修复前端测试环境问题，并按 Phosphor Grid 规范提升页面层次与交互反馈。

## 变更
- **路径速览**：增加状态感知的 LIVE PATH 流程条、事实网格、步骤时间线与成功判据样式；复用 `StatusDot` / `InsightChip`
- **控制页**：增加跳转到「路径速览」入口
- **样式**：修正 `.magic-card:hover` 无效的 `border-left-color`，改为可见的顶边强调；新增 `.mn-path-*` 布局（无渐变/无玻璃模糊）
- **测试**：`npm test` 增加 `--experimental-strip-types`，在 Node 22 下无需 Bun 即可跑通

## 测试
- `npm run check`（test + typecheck + build）通过，40/40

## 说明
本分支基于此前路径速览提交；未改动 TUN 以外的透明路径逻辑。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8166d09c-4209-4193-b03b-a4c2cfeee453?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8166d09c-4209-4193-b03b-a4c2cfeee453&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Sourcery 摘要

为 sing-box TUN 数据平面新增状态感知的路径概览，并使 WebUI 测试套件兼容 Node 22。

新功能：
- 新增专属的“路径概览”页面，展示 sing-box TUN 数据路径、运行事实、首次运行步骤和成功标准。
- 新增控制页面与路径概览之间的导航，包括指向订阅页面和健康检查页面的快捷入口。

错误修复：
- 使 WebUI 测试套件能够在 Node 22 下运行，无需依赖 Bun。
- 修正卡片悬停强调效果，确保视觉边框高亮能够正常显示。

增强功能：
- 在整个路径概览中实时反映 sing-box TUN 状态，并支持复制简洁的路径报告。

测试：
- 为路径概览内容、导航以及受支持的仅 TUN 术语添加契约覆盖测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在 WebUI 中新增支持状态感知的 sing-box TUN 路径概览，并使其测试套件兼容 Node 22。

新功能：
- 新增专用路径概览页面，展示 sing-box TUN 数据路径、运行时状态、首次运行指导和成功标准。
- 增加控制页面、路径概览、订阅、健康检查及 WebUI 其他页面之间的导航。

错误修复：
- 使 WebUI 测试能够在 Node 22 下运行，无需 Bun。
- 修复卡片悬停高亮问题，使可见的顶部边框更加突出。

增强功能：
- 以状态感知的流程、事实面板、步骤指导和可复制的概览文本呈现 TUN 路径，同时将受支持的数据平面术语集中于 sing-box 和 magicnet0。

测试：
- 增加对路径概览内容、导航、受支持的 TUN 术语以及生成的概览数据的契约测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a status-aware sing-box TUN path overview to the WebUI and make its test suite compatible with Node 22.

New Features:
- Add a dedicated path overview page showing the sing-box TUN data path, runtime status, first-run guidance, and success criteria.
- Add navigation between the control page, path overview, subscriptions, health checks, and the rest of the WebUI.

Bug Fixes:
- Make WebUI tests run under Node 22 without requiring Bun.
- Fix card hover highlighting so the visible top border is emphasized.

Enhancements:
- Present the TUN path with status-aware flow, fact panels, step guidance, and copyable overview text while keeping the supported dataplane terminology focused on sing-box and magicnet0.

Tests:
- Add contract coverage for path overview content, navigation, supported TUN terminology, and generated overview data.

</details>

</details>