### PR TITLE
fix(backend): 清理遗留 pidfile 并澄清 TUN-only 边界

### DIFF
--- a/crates/magicnet-cli/src/diagnostics_routing.rs
+++ b/crates/magicnet-cli/src/diagnostics_routing.rs
@@ -646,6 +646,9 @@ fn valid_user_id(value: &Value) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+
     use serde_json::{json, Value};
 
     use super::{
@@ -1913,9 +1916,18 @@ mod tests {
 
     #[test]
     fn source_config_fails_closed_without_subscription_nodes() {
-        let status = analyze_text(include_str!(
-            "../../../src/MagicNet/.config/sing-box/config.json"
-        ));
+        // Bundled MagicSingBox template lives in the sing-box config submodule.
+        // Prefer a runtime read so `cargo check` still works before
+        // `git submodule update --init src/MagicNet/.config/sing-box`.
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../src/MagicNet/.config/sing-box/config.json");
+        let text = fs::read_to_string(&path).unwrap_or_else(|err| {
+            panic!(
+                "bundled sing-box config missing at {}: {err}; run `git submodule update --init src/MagicNet/.config/sing-box`",
+                path.display()
+            )
+        });
+        let status = analyze_text(&text);
 
         assert_eq!(
             status,

--- a/crates/magicnet-cli/src/service.rs
+++ b/crates/magicnet-cli/src/service.rs
@@ -462,7 +462,6 @@ fn stop_all_direct(app: &App, preserve_config_apply: bool) -> Result<(), String>
             .join(".state/watchdog/magicnet-hotspot-route.pid"),
     );
     stop_supervisor_pidfile(app, app.moddir.join(".state/fswatch/magicnet-config.pid"));
-    stop_supervisor_pidfile(app, app.moddir.join(".state/after-kernel-start.pid"));
     ignore_command(
         "pkill",
         &[
@@ -554,9 +553,6 @@ fn supervisor_cmdline_matches(moddir: &Path, path: &Path, argv: &[String]) -> bo
             argv,
             &format!("{module}/.state/watchdog/magicnet-hotspot-route.loop.sh"),
         ),
-        // There is no current producer for this legacy pidfile.  Requiring a
-        // known command is safer than killing a reused PID from old state.
-        Some("after-kernel-start.pid") => false,
         _ => false,
     }
 }
@@ -635,14 +631,18 @@ fn write_transparent_mode(app: &App, mode: &str) -> Result<(), String> {
 }
 
 fn transparent_mode(app: &App) -> String {
+    // Status/read path only. `transparent set` already rejects non-tun values;
+    // legacy conf leftovers (proxy/hybrid/external*) are remapped to tun so
+    // callers never see deleted dataplanes, without rewriting the file here.
     fs::read_to_string(app.moddir.join(TRANSPARENT_MODE_CONF))
         .ok()
         .and_then(|text| {
             text.lines().find_map(|line| {
                 let (_, value) = line.split_once('=')?;
                 match value.trim().trim_matches('"').trim_matches('\'') {
-                    "proxy" | "external" | "external-tun" | "hybrid" => Some("tun".to_string()),
-                    "tun" => Some("tun".to_string()),
+                    "proxy" | "external" | "external-tun" | "hybrid" | "tun" => {
+                        Some("tun".to_string())
+                    }
                     _ => None,
                 }
             })

--- a/crates/magicnet-cli/tests/internal/service.rs
+++ b/crates/magicnet-cli/tests/internal/service.rs
@@ -210,7 +210,7 @@ fn supervisor_pidfiles_require_the_matching_module_command() {
     ));
     assert!(!supervisor_cmdline_matches(
         &module,
-        &module.join(".state/after-kernel-start.pid"),
+        &module.join(".state/unknown-supervisor.pid"),
         &argv(&["/data/adb/modules/MagicNet/cli", "config", "apply"])
     ));
 }

--- a/crates/magicnet-mcp-server/src/tools.rs
+++ b/crates/magicnet-mcp-server/src/tools.rs
@@ -2,7 +2,7 @@ pub(crate) const TOOLS_JSON: &str = r#"{"tools":[
 {"name":"magicnet_status","description":"Show MagicNet service status","inputSchema":{"type":"object","properties":{}}},
 {"name":"magicnet_cli","description":"Run a MagicNet CLI command with explicit argv. This is restricted to the MagicNet CLI binary, not a shell.","inputSchema":{"type":"object","properties":{"args":{"type":"array","items":{"type":"string"},"minItems":1,"maxItems":24}},"required":["args"]}},
 {"name":"magicnet_service_control","description":"Run service status/start/ensure/stop/restart/toggle/logs, optionally with a target such as current or sing-box.","inputSchema":{"type":"object","properties":{"action":{"type":"string","enum":["status","start","ensure","stop","restart","toggle","logs"]},"target":{"type":"string"}}}},
-{"name":"magicnet_core_select","description":"Select the default core.","inputSchema":{"type":"object","properties":{"core":{"type":"string","enum":["sing-box"]}},"required":["core"]}},
+{"name":"magicnet_core_select","description":"Confirm MagicNet uses the sing-box core. Only sing-box is supported.","inputSchema":{"type":"object","properties":{"core":{"type":"string","enum":["sing-box"]}},"required":["core"]}},
 {"name":"magicnet_config_apply","description":"Apply runtime config helpers.","inputSchema":{"type":"object","properties":{}}},
 {"name":"magicnet_config_get","description":"Read generated sing-box config through the config editor.","inputSchema":{"type":"object","properties":{"target":{"type":"string","enum":["sing-box"]}},"required":["target"]}},
 {"name":"magicnet_config_validate","description":"Validate sing-box config.","inputSchema":{"type":"object","properties":{"target":{"type":"string","enum":["sing-box","all"]}}}},
@@ -137,6 +137,31 @@ mod tests {
             .expect("speedtest description must be a string");
 
         assert!(description.contains("10 MiB"));
+    }
+
+    #[test]
+    fn core_select_describes_singbox_only() {
+        let document: Value = serde_json::from_str(TOOLS_JSON).expect("TOOLS_JSON must be valid");
+        let tool = document
+            .get("tools")
+            .and_then(Value::as_array)
+            .and_then(|tools| {
+                tools.iter().find(|tool| {
+                    tool.get("name").and_then(Value::as_str) == Some("magicnet_core_select")
+                })
+            })
+            .expect("core select tool must exist");
+
+        let description = tool
+            .get("description")
+            .and_then(Value::as_str)
+            .expect("core select description must be a string");
+        assert!(description.contains("sing-box"));
+        assert!(!description.to_lowercase().contains("default core"));
+        assert_eq!(
+            tool.pointer("/inputSchema/properties/core/enum"),
+            Some(&json!(["sing-box"]))
+        );
     }
 
     #[test]

--- a/src/MagicNet/lib/magicnet.sh
+++ b/src/MagicNet/lib/magicnet.sh
@@ -25,6 +25,7 @@ for _magicnet_lib in \
     core \
     action_menu \
     phases; do
+    # transparent_dns.sh = IPv6/MTU/UDP policy; DNS capture remains in network.sh.
     . "${_magicnet_lib_dir}/${_magicnet_lib}.sh"
 done
 unset _magicnet_lib _magicnet_lib_dir

--- a/src/MagicNet/lib/magicnet/common.sh
+++ b/src/MagicNet/lib/magicnet/common.sh
@@ -55,6 +55,8 @@ magicnet_transparent_conf() {
 }
 
 magicnet_transparent_mode() {
+    # Runtime dataplane is TUN-only (magicnet0). Keep this constant so shell
+    # callers never revive proxy/hybrid/external paths from stale conf.
     printf '%s\n' "tun"
 }
 

--- a/src/MagicNet/lib/magicnet/network.sh
+++ b/src/MagicNet/lib/magicnet/network.sh
@@ -170,10 +170,13 @@ magicnet_dns_capture_bypass_uids() {
         unset _dns_bypass_uid_file
         return 0
     }
-    # Android netd can emit a Bypass TUN app's DNS request as UID 0. Once
-    # netd proxies the lookup, xt_owner cannot recover the originating app;
-    # keep UID 0 outside capture whenever a real bypass UID is configured so
-    # the app and its DNS stay on the same non-MagicNet path.
+    # UID 0 matrix (keep in sync with transparent.sh TUN exclude_uid):
+    # - TUN always excludes UID 0 from magicnet0.
+    # - DNS capture usually intercepts UID 0 (Android netd).
+    # - Android netd can emit a Bypass TUN app's DNS request as UID 0. Once
+    #   netd proxies the lookup, xt_owner cannot recover the originating app;
+    #   keep UID 0 outside capture whenever a real bypass UID is configured so
+    #   the app and its DNS stay on the same non-MagicNet path.
     _dns_bypass_uids="$(awk '/^[0-9]+$/ && ($0 + 0) != 0 && !seen[$0]++ { print }' "$_dns_bypass_uid_file" 2>/dev/null)"
     if [ -n "$_dns_bypass_uids" ]; then
         printf '%s\n' 0

--- a/src/MagicNet/lib/magicnet/transparent.sh
+++ b/src/MagicNet/lib/magicnet/transparent.sh
@@ -1,4 +1,8 @@
 magicnet_singbox_apply_transparent_mode() {
+    # Materialize the only supported dataplane: sing-box magicnet0 TUN (+
+    # mixed-in / magicnet-dns-in). Older tproxy/redirect inbounds are stripped
+    # below so leftover configs cannot keep a deleted transparent path alive;
+    # they are never regenerated.
     _config="${MODDIR}/.config/sing-box/config.json"
     [ -f "$_config" ] || return 0
     _dns_strategy="$(magicnet_singbox_dns_strategy_for_mode "$_config" "tun")"
@@ -42,6 +46,12 @@ magicnet_singbox_apply_transparent_mode() {
             "auto_route": true,
             "auto_redirect": true,
             "strict_route": true,
+            # UID 0 matrix (keep in sync with network.sh DNS capture):
+            # - TUN exclude_uid always includes 0 so root/netd traffic is not
+            #   sucked into magicnet0.
+            # - DNS REDIRECT normally captures UID 0 (netd DNS).
+            # - When Bypass TUN UIDs exist, DNS capture also RETURNs UID 0 so
+            #   proxied lookups stay off MagicNet with their apps.
             "exclude_uid": [
               0
             ],
@@ -63,6 +73,9 @@ magicnet_singbox_apply_transparent_mode() {
             "mtu": $tun_mtu,
             "udp_timeout": $udp_timeout
           };
+        # managed_inbound matches current TUN/mixed/dns tags and legacy
+        # tproxy/redirect types so apply can delete them. Do not treat this as
+        # support for regenerating non-TUN transparent modes.
         def managed_inbound:
           ((.type // "") as $type | ($type == "tun" or $type == "tproxy" or $type == "redirect"))
           or ((.tag // "") == "mixed-in")

--- a/src/MagicNet/lib/magicnet/transparent_dns.sh
+++ b/src/MagicNet/lib/magicnet/transparent_dns.sh
@@ -1,3 +1,5 @@
+# Network policy helpers (IPv6 preference, TUN MTU, UDP timeout).
+# Kernel DNS capture / leak-guard live in network.sh, not here.
 magicnet_network_policy_conf() {
     printf '%s\n' "${MODDIR}/.config/magicnet/network-policy.conf"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
加固后端可维护性：清理已无生产者的 supervisor 残留，修正依赖 submodule 的编译期测试加载方式，并澄清 TUN-only / UID 0 / DNS 捕获边界，避免误读为仍支持 TProxy/eBPF 等已删路径。

## 变更
- **CLI `service.rs`**：删除对 `after-kernel-start.pid` 的 stop/匹配分支（匹配恒为 false）
- **`diagnostics_routing` 测试**：改为运行时读取 MagicSingBox `config.json`，缺失时提示 `git submodule update --init`
- **MCP `tools.rs`**：`magicnet_core_select` 文案改为单核心 sing-box 现状，并补合同测试
- **shell**：`transparent.sh` / `network.sh` UID 0 矩阵注释；`transparent_dns.sh` 与加载顺序标明“非 DNS capture”；`common.sh` 说明 mode 恒为 tun

## 测试
- `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings` 通过
- `cargo test --workspace` 通过（含 MCP 24 tests）
- `scripts/test-transparent-mode-config-safety.sh` 通过

## 说明
未恢复任何非 TUN 透明路径；`tproxy`/`redirect` 仅作为 apply 时剥离旧 inbound 的匹配条件保留。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8166d09c-4209-4193-b03b-a4c2cfeee453?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8166d09c-4209-4193-b03b-a4c2cfeee453&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Sourcery 摘要

强制并记录 MagicNet 的 sing-box 仅 TUN 模式行为，同时移除过时的 pidfile 处理逻辑，并提高依赖配置的测试的健壮性。

Bug 修复：
- 移除对已废弃 supervisor pidfile 的清理和匹配逻辑，避免处理一个当前没有生成者的状态文件。

增强功能：
- 明确 MagicNet 支持 sing-box 仅 TUN 数据平面，包括 UID 0 和 DNS 捕获边界；同时，旧版非 TUN 入站配置会被移除，而不会重新生成。
- 使路由诊断在测试运行时加载随附的 sing-box 配置；当配置不可用时，提供子模块初始化提示。
- 更新 MCP 核心选择相关消息，以描述仅支持 sing-box 的架构。

测试：
- 增加测试，确保 MCP 核心选择工具说明仅支持 sing-box。
- 更新服务测试，以适配已移除的旧版 pidfile 路径。

杂项：
- 通过注释明确 shell 辅助工具的职责和透明模式的行为。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

明确 MagicNet 仅支持 sing-box 的 TUN 行为，并移除已过时的 supervisor 状态处理。

Bug 修复：
- 移除已过时的 supervisor pidfile 清理逻辑，以及针对不再生成的 after-kernel-start 状态文件的匹配逻辑。

增强功能：
- 明确并强制 MagicNet 仅使用 sing-box 的 TUN 数据面，包括 UID 0 和 DNS 捕获边界，同时确保移除过时的非 TUN 入站，而不是重新生成它们。
- 更新 MCP 核心选择消息，以描述仅支持 sing-box 的架构。
- 让路由诊断在测试运行时加载随附的 sing-box 配置，并在其子模块不可用时提供可执行的指导。
- 通过注释明确 shell 辅助工具的职责以及仅支持 TUN 的行为。

测试：
- 添加覆盖范围，验证 MCP 核心选择工具声明仅支持 sing-box。
- 更新服务测试，以适应旧版 pidfile 路径的移除。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify MagicNet’s sing-box-only TUN behavior and remove obsolete supervisor state handling.

Bug Fixes:
- Remove obsolete supervisor pidfile cleanup and matching logic for the no-longer-produced after-kernel-start state file.

Enhancements:
- Clarify and enforce MagicNet’s sing-box-only TUN dataplane, including UID 0 and DNS-capture boundaries, while ensuring stale non-TUN inbounds are removed rather than regenerated.
- Update MCP core-selection messaging to describe the sing-box-only architecture.
- Make routing diagnostics load the bundled sing-box configuration at test runtime and provide actionable guidance when its submodule is unavailable.
- Clarify shell helper responsibilities and TUN-only behavior through comments.

Tests:
- Add coverage verifying that the MCP core-selection tool advertises sing-box-only support.
- Update service tests for removal of the legacy pidfile path.

</details>

</details>