### PR TITLE
fix: restore eBPF state on transparent rollback

### DIFF
--- a/crates/magicnet-cli/src/service.rs
+++ b/crates/magicnet-cli/src/service.rs
@@ -30,6 +30,14 @@ const TRANSPARENT_RECENT_ERROR: &str = ".state/transparent-recent-error";
 const TRANSPARENT_CAPABILITY: &str = ".state/transparent-ebpf/capability";
 const TRANSPARENT_PROBE_REPORT: &str = ".state/transparent-ebpf/probe.json";
 const TRANSPARENT_SHARED_PENDING: &str = ".state/transparent-ebpf/shared.pending";
+const TRANSPARENT_SHARED_INTERFACES: &str = ".state/transparent-ebpf/shared-interfaces.list";
+const TRANSPARENT_EBPF_STATE_VERSION: &str = "old-ebpf-state-version";
+const TRANSPARENT_EBPF_STATE_FILES: &[(&str, &str)] = &[
+    (TRANSPARENT_CAPABILITY, "capability"),
+    (TRANSPARENT_PROBE_REPORT, "probe"),
+    (TRANSPARENT_SHARED_PENDING, "shared-pending"),
+    (TRANSPARENT_SHARED_INTERFACES, "shared-interfaces"),
+];
 const CONFIG_APPLY_LOCK: &str = ".state/config-apply.lock";
 const LIFECYCLE_LOCK_TIMEOUT: Duration = Duration::from_secs(2);
 const CONFIG_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(25);
@@ -773,9 +781,41 @@ fn prepare_transparent_transaction(
     } else {
         write_private_file(&staging.join("old-config-present"), b"0\n")?;
     }
+    // Candidate rendering publishes eBPF evidence before the old core stops.
+    // Keep rollback byte-consistent when a later preflight check rejects it.
+    for (path, name) in TRANSPARENT_EBPF_STATE_FILES {
+        snapshot_optional_transparent_file(app, &staging, path, name)?;
+    }
+    write_private_file(&staging.join(TRANSPARENT_EBPF_STATE_VERSION), b"1\n")?;
     fs::rename(&staging, &journal)
         .map_err(|error| format!("publish transparent journal: {error}"))?;
     Ok(())
+}
+
+fn snapshot_optional_transparent_file(
+    app: &App,
+    staging: &Path,
+    relative_path: &str,
+    snapshot_name: &str,
+) -> Result<(), String> {
+    let source = app.moddir.join(relative_path);
+    match fs::read(&source) {
+        Ok(bytes) => {
+            write_private_file(&staging.join(format!("old-ebpf-{snapshot_name}")), &bytes)?;
+            write_private_file(
+                &staging.join(format!("old-ebpf-{snapshot_name}-present")),
+                b"1\n",
+            )
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => write_private_file(
+            &staging.join(format!("old-ebpf-{snapshot_name}-present")),
+            b"0\n",
+        ),
+        Err(error) => Err(format!(
+            "snapshot transparent state {}: {error}",
+            source.display()
+        )),
+    }
 }
 
 fn write_private_file(path: &Path, bytes: &[u8]) -> Result<(), String> {
@@ -838,7 +878,66 @@ fn restore_transaction_snapshot(app: &App, old_mode: &TransparentModeState) -> R
         },
         _ => return Err("invalid transparent config snapshot marker".to_string()),
     }
+    restore_transparent_state_snapshot(app, &journal)?;
     Ok(())
+}
+
+fn restore_transparent_state_snapshot(app: &App, journal: &Path) -> Result<(), String> {
+    let version = match fs::read_to_string(journal.join(TRANSPARENT_EBPF_STATE_VERSION)) {
+        Ok(version) => version,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(format!("read transparent state snapshot version: {error}")),
+    };
+    if version.trim() != "1" {
+        return Err("invalid transparent state snapshot version".to_string());
+    }
+    for (path, name) in TRANSPARENT_EBPF_STATE_FILES {
+        restore_optional_transparent_file(app, journal, path, name)?;
+    }
+    Ok(())
+}
+
+fn restore_optional_transparent_file(
+    app: &App,
+    journal: &Path,
+    relative_path: &str,
+    snapshot_name: &str,
+) -> Result<(), String> {
+    let marker = fs::read_to_string(journal.join(format!("old-ebpf-{snapshot_name}-present")))
+        .map_err(|error| format!("read transparent state {snapshot_name} marker: {error}"))?;
+    let destination = app.moddir.join(relative_path);
+    match marker.trim() {
+        "1" => {
+            let bytes = fs::read(journal.join(format!("old-ebpf-{snapshot_name}")))
+                .map_err(|error| format!("read transparent state {snapshot_name}: {error}"))?;
+            let parent = destination
+                .parent()
+                .ok_or_else(|| format!("transparent state path has no parent: {relative_path}"))?;
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("create transparent state directory: {error}"))?;
+            let temporary = destination.with_file_name(format!(
+                ".{}.transaction-restore.{}",
+                destination
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .ok_or_else(|| format!("invalid transparent state path: {relative_path}"))?,
+                std::process::id()
+            ));
+            write_private_file(&temporary, &bytes)?;
+            fs::rename(&temporary, &destination)
+                .map_err(|error| format!("restore transparent state {snapshot_name}: {error}"))
+        }
+        "0" => match fs::remove_file(&destination) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(format!(
+                "restore absent transparent state {snapshot_name}: {error}"
+            )),
+        },
+        _ => Err(format!(
+            "invalid transparent state {snapshot_name} snapshot marker"
+        )),
+    }
 }
 
 fn rollback_transparent_preflight(

--- a/crates/magicnet-cli/tests/internal/service.rs
+++ b/crates/magicnet-cli/tests/internal/service.rs
@@ -2,9 +2,11 @@
 
 use super::{
     api_host_port, config_apply_lock, config_apply_lock_bounded, normalize_transparent_mode,
-    read_transparent_mode, restart_command, safe_log_name, service_log_path,
-    stop_runtime_cleanup_command, supervisor_cmdline_matches, REPAIR_COMMAND, START_KERNEL_COMMAND,
-    TRANSPARENT_MODE_CONF,
+    prepare_transparent_transaction, read_transparent_mode, restart_command,
+    rollback_transparent_preflight, safe_log_name, service_log_path, stop_runtime_cleanup_command,
+    supervisor_cmdline_matches, REPAIR_COMMAND, START_KERNEL_COMMAND, TRANSPARENT_CAPABILITY,
+    TRANSPARENT_CONFIG, TRANSPARENT_MODE_CONF, TRANSPARENT_PROBE_REPORT,
+    TRANSPARENT_SHARED_INTERFACES, TRANSPARENT_SHARED_PENDING, TRANSPARENT_TRANSACTION,
 };
 use crate::App;
 use std::fs;
@@ -67,6 +69,55 @@ fn transparent_mode_file_is_strict_and_missing_defaults_to_tun() {
     .unwrap();
     assert!(read_transparent_mode(&app).is_err());
 
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn transparent_preflight_rollback_restores_ebpf_runtime_state() {
+    let (app, root) = fixture_app("transparent-state-rollback");
+    let mode_path = root.join(TRANSPARENT_MODE_CONF);
+    let config_path = root.join(TRANSPARENT_CONFIG);
+    fs::create_dir_all(mode_path.parent().unwrap()).unwrap();
+    fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    fs::write(&mode_path, "MAGICNET_TRANSPARENT_MODE=ebpf\n").unwrap();
+    fs::write(&config_path, b"old-ebpf-config\n").unwrap();
+
+    let old_state = [
+        (TRANSPARENT_CAPABILITY, b"ok\n".as_slice()),
+        (
+            TRANSPARENT_PROBE_REPORT,
+            br#"{"active_programs":[{"name":"sb_ebpf_conn4"}]}"#.as_slice(),
+        ),
+        (TRANSPARENT_SHARED_INTERFACES, b"wlan2\n".as_slice()),
+    ];
+    for (path, contents) in old_state {
+        let path = root.join(path);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, contents).unwrap();
+    }
+
+    let old_mode = read_transparent_mode(&app).unwrap();
+    prepare_transparent_transaction(&app, &old_mode, "tun").unwrap();
+
+    fs::write(&mode_path, "MAGICNET_TRANSPARENT_MODE=tun\n").unwrap();
+    fs::write(&config_path, b"candidate-tun-config\n").unwrap();
+    fs::remove_file(root.join(TRANSPARENT_CAPABILITY)).unwrap();
+    fs::remove_file(root.join(TRANSPARENT_PROBE_REPORT)).unwrap();
+    fs::write(root.join(TRANSPARENT_SHARED_PENDING), b"candidate\n").unwrap();
+    fs::write(root.join(TRANSPARENT_SHARED_INTERFACES), b"").unwrap();
+
+    rollback_transparent_preflight(&app, &old_mode).unwrap();
+
+    assert_eq!(
+        fs::read_to_string(&mode_path).unwrap(),
+        "MAGICNET_TRANSPARENT_MODE=ebpf\n"
+    );
+    assert_eq!(fs::read(&config_path).unwrap(), b"old-ebpf-config\n");
+    for (path, contents) in old_state {
+        assert_eq!(fs::read(root.join(path)).unwrap(), contents);
+    }
+    assert!(!root.join(TRANSPARENT_SHARED_PENDING).exists());
+    assert!(!root.join(TRANSPARENT_TRANSACTION).exists());
     fs::remove_dir_all(root).unwrap();
 }
 

--- a/scripts/test-ebpf-transparent-mode.sh
+++ b/scripts/test-ebpf-transparent-mode.sh
@@ -230,6 +230,31 @@ fi
 [[ ! -e "$MODDIR/.state/transparent-ebpf/probe.json" ]]
 unset MAGICNET_TEST_EBPF_PROBE_FAIL
 
+# Interrupted/preflight rollback restores the eBPF runtime evidence together
+# with mode/config. Target TUN rendering clears these files before the old core
+# is stopped, so omitting them from the journal makes a failed switch appear
+# degraded even though the old eBPF generation is still running.
+STATE_DIR="$MODDIR/.state/transparent-ebpf"
+JOURNAL="$MODDIR/.state/transparent-state-test-journal"
+mkdir -p "$STATE_DIR" "$JOURNAL"
+printf '%s\n' 1 >"$JOURNAL/old-ebpf-state-version"
+printf '%s\n' ok >"$JOURNAL/old-ebpf-capability"
+printf '%s\n' 1 >"$JOURNAL/old-ebpf-capability-present"
+printf '%s\n' '{"active_programs":[{"name":"sb_ebpf_conn4"}]}' >"$JOURNAL/old-ebpf-probe"
+printf '%s\n' 1 >"$JOURNAL/old-ebpf-probe-present"
+printf '%s\n' pending >"$JOURNAL/old-ebpf-shared-pending"
+printf '%s\n' 1 >"$JOURNAL/old-ebpf-shared-pending-present"
+printf '%s\n' wlan2 >"$JOURNAL/old-ebpf-shared-interfaces"
+printf '%s\n' 1 >"$JOURNAL/old-ebpf-shared-interfaces-present"
+rm -f "$STATE_DIR/capability" "$STATE_DIR/probe.json" "$STATE_DIR/shared.pending"
+: >"$STATE_DIR/shared-interfaces.list"
+magicnet_restore_transparent_state_snapshot "$JOURNAL"
+[[ "$(<"$STATE_DIR/capability")" == ok ]]
+"$HOST_JQ" -e '.active_programs[0].name == "sb_ebpf_conn4"' "$STATE_DIR/probe.json" >/dev/null
+[[ "$(<"$STATE_DIR/shared.pending")" == pending ]]
+[[ "$(<"$STATE_DIR/shared-interfaces.list")" == wlan2 ]]
+rm -rf "$JOURNAL"
+
 # eBPF post-start does not depend on magicnet0 and must not add the TUN-only
 # table-2022 or DNS REDIRECT controls. Cleanup/deletion commands remain allowed.
 POST_LOG="$WORK/post-start.log"

--- a/src/MagicNet/lib/magicnet/transparent.sh
+++ b/src/MagicNet/lib/magicnet/transparent.sh
@@ -426,6 +426,51 @@ magicnet_transparent_transaction_dir() {
     printf '%s\n' "${MODDIR}/.state/transparent-transaction"
 }
 
+magicnet_restore_transparent_state_file() {
+    _restore_state_transaction="$1"
+    _restore_state_name="$2"
+    _restore_state_destination="$3"
+    _restore_state_present="$(cat "${_restore_state_transaction}/old-ebpf-${_restore_state_name}-present" 2>/dev/null)" || return 1
+    case "$_restore_state_present" in
+    1)
+        _restore_state_source="${_restore_state_transaction}/old-ebpf-${_restore_state_name}"
+        [ -f "$_restore_state_source" ] || return 1
+        mkdir -p "${_restore_state_destination%/*}" || return 1
+        _restore_state_tmp="${_restore_state_destination}.transaction-restore.$$"
+        if ! (
+            umask 077
+            cp "$_restore_state_source" "$_restore_state_tmp"
+        ) || ! chmod 600 "$_restore_state_tmp" ||
+            ! mv -f "$_restore_state_tmp" "$_restore_state_destination"; then
+            rm -f "$_restore_state_tmp" 2>/dev/null || true
+            return 1
+        fi
+        ;;
+    0) rm -f "$_restore_state_destination" || return 1 ;;
+    *) return 1 ;;
+    esac
+    unset _restore_state_transaction _restore_state_name _restore_state_destination
+    unset _restore_state_present _restore_state_source _restore_state_tmp
+}
+
+magicnet_restore_transparent_state_snapshot() {
+    _restore_snapshot_transaction="$1"
+    _restore_snapshot_version_file="${_restore_snapshot_transaction}/old-ebpf-state-version"
+    # Journals published before runtime-state snapshots were introduced remain
+    # recoverable; their restored core startup will republish current evidence.
+    [ -e "$_restore_snapshot_version_file" ] || {
+        unset _restore_snapshot_transaction _restore_snapshot_version_file
+        return 0
+    }
+    [ "$(cat "$_restore_snapshot_version_file" 2>/dev/null)" = 1 ] || return 1
+    _restore_snapshot_dir="$(magicnet_ebpf_state_dir)"
+    magicnet_restore_transparent_state_file "$_restore_snapshot_transaction" capability "${_restore_snapshot_dir}/capability" || return 1
+    magicnet_restore_transparent_state_file "$_restore_snapshot_transaction" probe "${_restore_snapshot_dir}/probe.json" || return 1
+    magicnet_restore_transparent_state_file "$_restore_snapshot_transaction" shared-pending "${_restore_snapshot_dir}/shared.pending" || return 1
+    magicnet_restore_transparent_state_file "$_restore_snapshot_transaction" shared-interfaces "${_restore_snapshot_dir}/shared-interfaces.list" || return 1
+    unset _restore_snapshot_transaction _restore_snapshot_version_file _restore_snapshot_dir
+}
+
 magicnet_recover_interrupted_transparent_transaction() {
     _transaction_dir="$(magicnet_transparent_transaction_dir)"
     [ -d "$_transaction_dir" ] || return 0
@@ -463,6 +508,7 @@ magicnet_recover_interrupted_transparent_transaction() {
     else
         rm -f "$_restore_config" || return 1
     fi
+    magicnet_restore_transparent_state_snapshot "$_transaction_dir" || return 1
     rm -rf "$_transaction_dir" || return 1
     magicnet_warn "Recovered an interrupted transparent mode transition to $_old_mode"
     unset _transaction_dir _old_mode_present _old_config_present _old_mode _restore_config _restore_tmp


### PR DESCRIPTION
## Summary
- include the four owned `.state/transparent-ebpf` files in transparent-mode transaction snapshots
- restore both present and absent state atomically on preflight/full rollback and interrupted recovery
- keep journals from older builds recoverable when no state snapshot version exists
- add Rust and shell regression coverage

## Root cause
`transparent set tun` renders the TUN candidate before stopping the old eBPF core. Rendering clears eBPF capability/probe/shared state. If a later preflight check fails, rollback restored only the mode/config, so the still-running old eBPF generation was reported degraded.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p magicnet-cli service::tests`
- `bash scripts/test-ebpf-transparent-mode.sh`
- `bash scripts/test-hotspot-routing.sh`
- `bash scripts/test-repository-hygiene.sh`
- `bash scripts/test-release-integrity.sh`
- `git diff --check`

Full workspace note: 375 tests pass; two process/PID-namespace tests fail identically on clean `main` in this container.

## Sourcery 总结

在回滚失败或中断的转换时，恢复 eBPF 运行时证据以及透明模式配置。

错误修复：
- 在预检、完整事务回滚以及中断事务回滚期间，恢复透明模式的 eBPF 运行时状态，以确保活动代际保留准确的功能、探针和共享状态证据。

增强功能：
- 以原子方式保留存在和不存在的 eBPF 状态，并保持与引入状态快照之前创建的日志的兼容性。

测试：
- 添加 Rust 和 shell 回归测试，覆盖回滚和中断恢复期间透明模式 eBPF 状态的恢复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore eBPF runtime evidence alongside transparent-mode configuration when rolling back failed or interrupted transitions.

Bug Fixes:
- Restore transparent-mode eBPF runtime state during preflight, full, and interrupted transaction rollbacks so the active generation retains accurate capability, probe, and shared-state evidence.

Enhancements:
- Preserve both present and absent eBPF state atomically and maintain compatibility with journals created before state snapshots were introduced.

Tests:
- Add Rust and shell regression coverage for restoring transparent-mode eBPF state during rollback and interrupted recovery.

</details>