### PR TITLE
fix: avoid external cat in install backup cleanup

### DIFF
--- a/scripts/package-install-smoke.sh
+++ b/scripts/package-install-smoke.sh
@@ -256,6 +256,11 @@ stale_backup="${FAIL_MOD}.install-backup.999999"
 mkdir -p "$stale_backup"
 printf '%s\n' 'magicnet-install-backup-v1' >"$stale_backup/.magicnet-install-backup-v1"
 printf '%s\n' 'stale-secret-must-be-removed' >"$stale_backup/secret"
+untrusted_backup="${FAIL_MOD}.install-backup.999998"
+mkdir -p "$untrusted_backup"
+printf '%s\n%s\n' 'magicnet-install-backup-v1' 'unexpected-content' \
+    >"$untrusted_backup/.magicnet-install-backup-v1"
+printf '%s\n' 'must-not-be-removed' >"$untrusted_backup/sentinel"
 if "$HOST_ENV" -u LD_LIBRARY_PATH \
     ZIPFILE="$ZIP_PATH" \
     MODPATH="$FAIL_MOD" \
@@ -269,6 +274,10 @@ if "$HOST_ENV" -u LD_LIBRARY_PATH \
     "$FAIL_MOD/bin/sh" "$FAIL_MOD/customize.sh" >"$FAIL_LOG" 2>&1; then
     fail "unsafe previous-config symlink unexpectedly passed installer migration"
 fi
+[[ ! -e "$stale_backup" ]] || fail "failed install kept a valid stale migration backup"
+[[ -f "$untrusted_backup/sentinel" ]] \
+    || fail "installer removed a stale backup with a non-exact marker"
+rm -rf "$untrusted_backup"
 if find "$TMP" -maxdepth 1 -type d -name 'failure-module.install-backup.*' -print -quit | grep -q .; then
     fail "failed install left current or stale migration secrets behind"
 fi

--- a/src/MagicNet/customize.sh
+++ b/src/MagicNet/customize.sh
@@ -36,21 +36,30 @@ MAGICNET_BACKUP_MARKER=".magicnet-install-backup-v1"
 MAGICNET_BACKUP_ACTIVE=0
 MAGICNET_BACKUP_READY=0
 
+magicnet_install_backup_marker_valid() {
+  [ -f "$1" ] && [ ! -L "$1" ] || return 1
+  _magicnet_backup_marker=""
+  _magicnet_backup_extra=""
+  {
+    IFS= read -r _magicnet_backup_marker || return 1
+    if IFS= read -r _magicnet_backup_extra || [ -n "$_magicnet_backup_extra" ]; then
+      return 1
+    fi
+  } <"$1"
+  [ "$_magicnet_backup_marker" = "magicnet-install-backup-v1" ]
+}
+
 magicnet_cleanup_install_backup() {
   [ "${MAGICNET_BACKUP_ACTIVE:-0}" = 1 ] || return 0
   if [ -d "$MAGICNET_BACKUP_DIR" ] && [ ! -L "$MAGICNET_BACKUP_DIR" ] &&
-    [ -f "$MAGICNET_BACKUP_DIR/$MAGICNET_BACKUP_MARKER" ] &&
-    [ ! -L "$MAGICNET_BACKUP_DIR/$MAGICNET_BACKUP_MARKER" ] &&
-    [ "$(cat "$MAGICNET_BACKUP_DIR/$MAGICNET_BACKUP_MARKER" 2>/dev/null)" = "magicnet-install-backup-v1" ]; then
+    magicnet_install_backup_marker_valid "$MAGICNET_BACKUP_DIR/$MAGICNET_BACKUP_MARKER"; then
     # cp -a preserves directory modes. Make only this validated, active backup's
     # directories traversable/removable; find's default physical walk does not
     # follow symlinks, and regular files do not need permission changes for rm.
     find "$MAGICNET_BACKUP_DIR" -type d -exec chmod u+rwx '{}' \; || return 1
     # Revalidate after the permission walk before deleting the sibling path.
     [ -d "$MAGICNET_BACKUP_DIR" ] && [ ! -L "$MAGICNET_BACKUP_DIR" ] &&
-      [ -f "$MAGICNET_BACKUP_DIR/$MAGICNET_BACKUP_MARKER" ] &&
-      [ ! -L "$MAGICNET_BACKUP_DIR/$MAGICNET_BACKUP_MARKER" ] &&
-      [ "$(cat "$MAGICNET_BACKUP_DIR/$MAGICNET_BACKUP_MARKER" 2>/dev/null)" = "magicnet-install-backup-v1" ] || return 1
+      magicnet_install_backup_marker_valid "$MAGICNET_BACKUP_DIR/$MAGICNET_BACKUP_MARKER" || return 1
     rm -rf "$MAGICNET_BACKUP_DIR" || return 1
   else
     return 1
@@ -67,9 +76,7 @@ for _stale_backup in "${MODPATH}.install-backup."*; do
   "${MODPATH}.install-backup."*[!0-9]*) continue ;;
   esac
   if [ -d "$_stale_backup" ] && [ ! -L "$_stale_backup" ] &&
-    [ -f "$_stale_backup/$MAGICNET_BACKUP_MARKER" ] &&
-    [ ! -L "$_stale_backup/$MAGICNET_BACKUP_MARKER" ] &&
-    [ "$(cat "$_stale_backup/$MAGICNET_BACKUP_MARKER" 2>/dev/null)" = "magicnet-install-backup-v1" ]; then
+    magicnet_install_backup_marker_valid "$_stale_backup/$MAGICNET_BACKUP_MARKER"; then
     rm -rf "$_stale_backup" || abort "! failed to remove stale MagicNet migration data"
   fi
 done


### PR DESCRIPTION
Fixes the current `Build Kam Module` regression introduced by `beb2276`.

`package-install-smoke.sh` deliberately runs `customize.sh` with a restricted installer `PATH`. The new migration-backup validation used external `cat`, which is unavailable in that environment, so the marker check failed before cleanup and installation aborted with `! failed to remove the MagicNet migration backup`.

This changes marker validation to use the shell builtin `read`, keeping the existing file/symlink ownership checks while removing the unnecessary external-command dependency. The same helper is used for stale-backup validation.

Validation:
- reproduced the failure from the generated `MagicNet.zip`
- patched the generated module locally and reran the same restricted-PATH migration scenario successfully
- backup cleanup completes and the caller-supplied poisoned backup path remains untouched

## Sourcery 总结

使迁移备份清理能够在受限的安装程序环境中正常工作，而不依赖外部命令。

错误修复：
- 通过验证迁移备份标记，而不是依赖外部 `cat` 命令，修复受限 `PATH` 环境下的安装失败问题。

功能增强：
- 集中处理迁移备份标记验证，同时保留对活动备份和过期备份的文件、符号链接及标记内容检查。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

使 MagicNet 迁移备份验证和清理能够在不依赖外部命令的情况下可靠运行。

错误修复：
- 移除对外部 `cat` 命令的依赖，修复受限 `PATH` 环境中的安装备份清理问题。
- 防止清理操作删除标记文件包含意外额外内容的备份。

增强功能：
- 集中处理迁移备份标记验证，同时保留对活动备份和过期备份的文件、符号链接及精确内容检查。

测试：
- 扩展软件包安装冒烟测试，验证有效的过期备份会被删除，而标记无效或包含哨兵数据的备份会被保留。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make MagicNet migration-backup validation and cleanup work reliably without external command dependencies.

Bug Fixes:
- Fix installation backup cleanup in restricted-PATH environments by removing its dependency on the external `cat` command.
- Prevent cleanup from removing backups whose marker files contain unexpected extra content.

Enhancements:
- Centralize migration-backup marker validation while retaining file, symlink, and exact-content checks for active and stale backups.

Tests:
- Extend the package installation smoke test to verify valid stale backups are removed while backups with invalid markers and sentinel data are preserved.

</details>

</details>