### PR TITLE
refactor(webui): reuse proxy text sanitizer

### DIFF
--- a/webui/src/composables/proxyGroupParsers.ts
+++ b/webui/src/composables/proxyGroupParsers.ts
@@ -5,6 +5,8 @@ export type ProxyGroupSummary = {
   proxies: string[];
 };
 
+export { sanitizeNodeText as sanitizeProxyName } from "./nodeDelayParsers.ts";
+
 export type ProxyGroupsSnapshot = {
   groups: ProxyGroupSummary[];
 };
@@ -24,12 +26,6 @@ export function parseProxyGroupsSnapshot(text: string): ProxyGroupsSnapshot | nu
   } catch {
     return null;
   }
-}
-
-export function sanitizeProxyName(value: string): string {
-  return value
-    .replace(/\b(?:https?|socks?|ss|ssr|vmess|vless|trojan|hysteria2?|tuic|anytls):\/\/[^\s"'<>]+/gi, "[filtered-url]")
-    .replace(/\b(private_?key|password|passwd|token|secret|uuid|api[_-]?key)(\s*[:=]\s*)[^\s,;}\]]+/gi, "$1$2[filtered]");
 }
 
 function parseProxyGroupObject(source: Record<string, unknown> | null): ProxyGroupSummary[] {


### PR DESCRIPTION
## Problem

`proxyGroupParsers.ts` duplicated the exact sensitive URL and credential filtering implementation already exported by `nodeDelayParsers.ts`. Keeping two identical regex chains creates a drift risk: future protocol or secret-pattern updates could protect one proxy UI surface but not the other.

## Change

Re-export the existing `sanitizeNodeText` implementation as `sanitizeProxyName`.

- Preserves the public `sanitizeProxyName` API used by the proxy-groups page.
- Removes the duplicate regex implementation.
- Keeps all call sites unchanged.
- Does not change runtime behavior; both functions were byte-for-byte equivalent before this refactor.

## Verification

- `npm run check` — passed
  - Node test runner: 53/53 tests passed
  - TypeScript: `tsc --noEmit` passed
  - Vite production build passed (1,896 modules transformed)
- `npx tsc --noEmit --noUnusedLocals --noUnusedParameters` — passed
- Direct sanitizer equivalence check — passed for function identity and representative URL, credential, and ordinary node inputs
- `git diff --check` — passed

## Diff

- Additions: 2
- Deletions: 6
- Net: -4 lines
- Files changed: 1

## Risk

Low. This only replaces an identical local function body with an alias of the existing canonical implementation. No device-facing path, privileged command, configuration format, error handling, or public behavior changes.

## Sourcery 总结

增强功能：
- 重用规范的节点文本清理器来处理代理名称，同时保留现有的公共 API 和行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Reuse the canonical node text sanitizer for proxy names while preserving the existing public API and behavior.

</details>