### PR TITLE
style(webui): 精简控制台视觉层级，修复小屏和大字号布局

### DIFF
--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -1,0 +1,40 @@
+name: WebUI
+on:
+  pull_request:
+    paths: ['webui/**', '.github/workflows/webui.yml']
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: webui-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - run: git archive --format=zip --output=webui-source.zip HEAD webui
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: webui-source
+          path: webui-source.zip
+          if-no-files-found: error
+          retention-days: 7
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: webui/package-lock.json
+      - run: npm ci
+        working-directory: webui
+      - run: npm run check
+        working-directory: webui
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: webui-preview
+          path: webui/dist/
+          if-no-files-found: error
+          retention-days: 7

--- a/webui/console-layout.test.mjs
+++ b/webui/console-layout.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
+import postcss from "postcss";
 
 const read = (path) => readFileSync(new URL(path, import.meta.url), "utf8");
 const css = read("./src/console.css");
@@ -12,9 +13,23 @@ test("page heading and both action slots share a wrapping header", () => {
   assert.match(css, /\.mn-page-header\s*\{[^}]*display: flex;[^}]*flex-wrap: wrap;/);
 });
 
-test("console refinements load after the existing theme", () => {
+test("console refinements load after the existing theme with narrowly scoped overrides", () => {
   assert.match(read("./src/main.ts"), /import "\.\/styles\.css";\s*import "\.\/console\.css";/);
-  assert.doesNotMatch(css, /!important|@import|url\(/);
+  assert.doesNotMatch(css, /@import|url\(/);
+  const important = [];
+  postcss.parse(css).walkDecls((decl) => {
+    if (!decl.important) return;
+    important.push(`${decl.parent.selector}: ${decl.prop}`);
+  });
+  // Existing nav rules and Tailwind !p-* utilities require these exact overrides.
+  // Other pages and properties must not accumulate priority escapes.
+  assert.deepEqual(important, [
+    ".mobile-nav button.mn-nav-active: border-color",
+    ".mobile-nav button.mn-nav-active: border-top-color",
+    ".mobile-nav button.mn-nav-active: background",
+    ".mobile-nav button.mn-nav-active: border-top-color",
+    '.page-surface[data-page="control"] > .grid > .grid > .magic-card: padding',
+  ]);
 });
 
 test("mobile status details wrap and high-contrast tabs retain selection", () => {

--- a/webui/console-layout.test.mjs
+++ b/webui/console-layout.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (path) => readFileSync(new URL(path, import.meta.url), "utf8");
+const css = read("./src/console.css");
+const header = read("./src/components/ui/PageHeader.vue");
+
+test("page heading and both action slots share a wrapping header", () => {
+  assert.match(header, /<div class="mn-page-header">/);
+  assert.match(header, /<slot name="actions">\s*<slot \/>/);
+  assert.match(css, /\.mn-page-header\s*\{[^}]*display: flex;[^}]*flex-wrap: wrap;/);
+});
+
+test("console refinements load after the existing theme", () => {
+  assert.match(read("./src/main.ts"), /import "\.\/styles\.css";\s*import "\.\/console\.css";/);
+  assert.doesNotMatch(css, /!important|@import|url\(/);
+});
+
+test("mobile status details wrap and high-contrast tabs retain selection", () => {
+  assert.match(css, /\.mn-runtime-brief > p\s*\{[^}]*grid-row: 2;[^}]*white-space: normal;/);
+  assert.match(css, /@media \(forced-colors: active\)[\s\S]*border-bottom-color: Highlight;/);
+});
+
+test("card actions stay inside their card when text is enlarged", () => {
+  assert.match(read("./src/components/ui/CardHeading.vue"), /flex max-w-full shrink-0 flex-wrap/);
+});

--- a/webui/frontend-refactor-contract.test.mjs
+++ b/webui/frontend-refactor-contract.test.mjs
@@ -295,9 +295,15 @@ assert.doesNotMatch(
 const pageHeader = read(join(src, "components", "ui", "PageHeader.vue"));
 assert.match(
   pageHeader,
-  /<div class="contents">/,
-  "PageHeader actions must participate in the owning page grid",
+  /<div class="mn-page-header">/,
+  "PageHeader must keep its title and actions in one normal-flow header",
 );
+assert.match(
+  read(join(src, "console.css")),
+  /\.mn-page-header\s*\{[^}]*display: flex;[^}]*flex-wrap: wrap;/,
+  "PageHeader must wrap actions rather than overlap the owning page",
+);
+assert.match(pageHeader, /<slot name="actions">\s*<slot \/>/);
 const controlPage = read(join(pagesDir, "ControlPage.vue"));
 assert.doesNotMatch(
   controlPage,

--- a/webui/mobile-settings.test.mjs
+++ b/webui/mobile-settings.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { runInNewContext } from "node:vm";
+const app = readFileSync(new URL("./src/App.vue", import.meta.url), "utf8");
+const css = readFileSync(new URL("./src/console.css", import.meta.url), "utf8");
+
+test("five clicks reveal GPT-6, retain previous visitors, and wrap the rotation", () => {
+  const visitors = runInNewContext(app.match(/const easterEggVisitors = ([\s\S]*?) as const;/)[1]);
+  assert.equal(visitors.map(({ name }) => name).join(","), "GPT-6,SOL,Grok 4.5,Kimi K3,Fable 5");
+  let now = 1000;
+  const scope = { Date: { now: () => now }, window: { clearTimeout() {}, setTimeout: () => 1 },
+    closeEasterEgg() {}, easterEggVisitors: visitors, brandClickCount: 0, brandClickWindowStartedAt: 0,
+    easterEggNextIndex: 0, easterEggShownIndex: { value: 0 }, easterEggVisible: { value: false }, easterEggTimer: undefined };
+  runInNewContext(app.match(/function handleBrandMarkClick\(\): void \{[\s\S]*?\n\}/)[0].replace(": void", ""), scope);
+  for (let i = 0; i < 4; i++) scope.handleBrandMarkClick();
+  assert.equal(scope.easterEggVisible.value, false);
+  scope.handleBrandMarkClick();
+  assert.equal(scope.easterEggVisible.value, true);
+  assert.equal(scope.easterEggShownIndex.value, 0);
+  for (let i = 1; i <= visitors.length; i++) {
+    for (let click = 0; click < 5; click++) scope.handleBrandMarkClick();
+    assert.equal(scope.easterEggShownIndex.value, i % visitors.length);
+  }
+  scope.handleBrandMarkClick(); now += 2500; scope.handleBrandMarkClick();
+  assert.equal(scope.brandClickCount, 1);
+});
+
+test("run-page layout is scoped and short viewports retain scrolling menus", () => {
+  assert.match(app, /class="page-surface" :data-page="activeTab"/);
+  assert.match(css, /\.page-surface\[data-page="control"\]/);
+  assert.match(css, /\.mn-utility-sheet\s*\{[^}]*max-height:[^}]*100dvh[^}]*overflow-y: auto/s);
+});

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -162,6 +162,11 @@ const onboardingTrigger = ref<HTMLElement | null>(null);
 
 const easterEggVisitors = [
   {
+    name: "GPT-6",
+    title: "GPT-6 到此一游",
+    body: "少画几个框，多留一点位置给内容。",
+  },
+  {
     name: "SOL",
     title: "准备好你的太阳镜 😎",
     body: "SOL 到此一游 · 光太亮，别直视内核。",
@@ -581,7 +586,7 @@ onUnmounted(() => {
         </header>
 
         <!-- KeepAlive preserves form state across all four workspaces. -->
-        <section class="page-surface">
+        <section class="page-surface" :data-page="activeTab">
           <Suspense>
             <KeepAlive :max="11">
               <component

--- a/webui/src/components/ui/CardHeading.vue
+++ b/webui/src/components/ui/CardHeading.vue
@@ -44,7 +44,7 @@ const titleClass = computed(() =>
         <slot name="description">{{ description }}</slot>
       </p>
     </div>
-    <div v-if="$slots.default" class="flex shrink-0 flex-wrap items-center gap-2">
+    <div v-if="$slots.default" class="flex max-w-full shrink-0 flex-wrap items-center gap-2">
       <slot />
     </div>
   </div>

--- a/webui/src/components/ui/PageHeader.vue
+++ b/webui/src/components/ui/PageHeader.vue
@@ -7,8 +7,8 @@ defineProps<{
 </script>
 
 <template>
-  <div class="contents">
-    <div class="max-w-3xl">
+  <div class="mn-page-header">
+    <div class="min-w-0 max-w-3xl">
       <h2 class="text-[clamp(1.5rem,5vw,2rem)] font-semibold leading-tight tracking-[-0.025em] text-[var(--mn-ink)]">{{ title }}</h2>
       <p v-if="description" class="mt-2 max-w-[62ch] text-sm leading-6 text-[var(--mn-ink-muted)]">{{ description }}</p>
     </div>

--- a/webui/src/console.css
+++ b/webui/src/console.css
@@ -1,0 +1,164 @@
+/* Quiet Console chrome: keep the page task, not its container, prominent. */
+.mn-page-header {
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  padding-block: 8px;
+}
+
+.mn-page-header > div:first-child {
+  flex: 1 1 24rem;
+  overflow-wrap: anywhere;
+}
+
+.mn-page-header > .mn-page-actions {
+  flex: 0 1 auto;
+  align-self: center;
+  margin: 0;
+}
+
+.page-surface > .grid > * {
+  min-width: 0;
+}
+
+.mn-workspace-header {
+  margin-bottom: 20px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: var(--mn-ivory);
+  box-shadow: none;
+  contain: none;
+}
+
+.mn-workspace-header > div:first-child {
+  display: none;
+}
+
+.mn-section-tabs {
+  width: 100%;
+  gap: 20px;
+  margin: 0;
+  padding: 4px;
+  border: 0;
+  border-bottom: 1px solid var(--mn-border);
+}
+
+.mn-section-tabs button {
+  min-height: 44px;
+  padding: 8px 2px;
+}
+
+.mn-runtime-brief,
+.magic-card {
+  box-shadow: none;
+}
+
+/* Preserve the observed status color without filling the whole workspace. */
+.magic-card.mn-tone-ok,
+.magic-card.mn-tone-warn,
+.magic-card.mn-tone-danger,
+.magic-card.mn-tone-info {
+  border-color: var(--mn-border);
+  border-inline-start: 3px solid var(--mn-current-tone-ink);
+  background: var(--mn-surface-raised);
+}
+
+.magic-card[class*="mn-tone-"] > p {
+  color: var(--mn-ink-soft);
+}
+
+.mn-button {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  text-align: center;
+}
+
+.mn-button svg {
+  flex-shrink: 0;
+}
+
+.mobile-nav {
+  gap: 8px;
+  padding-inline: 12px;
+}
+
+@media (min-width: 900px) {
+  .mn-shell {
+    padding: 24px 32px 32px;
+  }
+
+  .mn-command-bar {
+    padding: 0 0 20px;
+    border: 0;
+    border-bottom: 1px solid var(--mn-border);
+    border-radius: 0;
+    background: transparent;
+  }
+
+  .mn-runtime-brief {
+    margin-block: 16px 24px;
+  }
+
+  .mn-workspace-frame {
+    gap: 28px;
+    margin-top: 0;
+  }
+
+  .desktop-rail {
+    padding: 0;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .desktop-rail nav button {
+    min-height: 48px;
+    padding: 12px;
+  }
+
+  .mn-rail-foot {
+    margin-top: 24px;
+  }
+}
+
+@media (max-width: 639px) {
+  .mn-shell {
+    padding-inline: 16px;
+  }
+
+  .mn-command-bar {
+    margin-inline: -16px;
+    padding-inline: 16px;
+  }
+
+  .mn-page-header {
+    gap: 12px;
+    padding-block: 0 4px;
+  }
+
+  .mn-runtime-brief {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    column-gap: 8px;
+  }
+
+  .mn-runtime-brief > p {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+}
+
+@media (forced-colors: active) {
+  .mn-section-tabs button.is-active {
+    border-bottom-color: Highlight;
+  }
+
+  .magic-card[class*="mn-tone-"] {
+    border-inline-start-color: CanvasText;
+  }
+}

--- a/webui/src/console.css
+++ b/webui/src/console.css
@@ -162,3 +162,140 @@
     border-inline-start-color: CanvasText;
   }
 }
+
+/* Mobile settings: quiet chrome and continuous sections, not a card dashboard. */
+.mn-shell { --mn-ivory: var(--mn-surface-raised); background: var(--mn-ivory); }
+.mn-command-bar { min-height: 60px; }
+.mn-brand-mark { border: 0; background: transparent; }
+.mn-brand-copy > p { display: none; }
+.mn-brand-mark img { width: 32px; height: 32px; }
+.mn-global-actions > .mn-button { border-color: transparent; }
+.mn-runtime-brief {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  margin-block: 0 16px;
+  padding: 12px 0;
+  border: 0;
+  border-bottom: 1px solid var(--mn-border);
+  border-radius: 0;
+  background: transparent;
+}
+.mn-runtime-brief > p { flex: 1 1 8rem; white-space: normal; overflow: visible; }
+.mn-runtime-brief[data-state] { border-inline-start: 0; }
+.mn-runtime-mode { border: 0; background: transparent; padding: 0; }
+.mn-page-header h2 { font-size: 1.25rem; }
+.mn-page-header p { margin-top: 4px; }
+.mn-page-actions { gap: 4px 12px; }
+.mn-page-actions > .mn-button { padding-inline: 0; border-color: transparent; }
+.mn-page-actions > span { padding-inline: 0; border: 0; background: transparent; }
+.mn-workspace-header { margin-bottom: 12px; }
+.mn-section-tabs { gap: 24px; padding-inline: 0; }
+.mn-section-tabs button { font-weight: 500; }
+.mn-section-tabs button.is-active { font-weight: 650; }
+
+/* Scope structural rules to the run page; editors and other page grids stay intact. */
+.page-surface[data-page="control"] > .grid > .grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.page-surface[data-page="control"] > .grid > .grid > .magic-card {
+  min-height: 0;
+  border: 0;
+  border-top: 1px solid var(--mn-border);
+  border-radius: 0;
+  background: transparent;
+}
+.page-surface[data-page="control"] .magic-card h3 { font-size: 1rem; line-height: 1.5; }
+.page-surface[data-page="control"] .magic-card[class*="mn-tone-"] { gap: 8px; }
+.page-surface[data-page="control"] .magic-card[class*="mn-tone-"] > p { line-height: 1.6; }
+.page-surface[data-page="control"] .magic-card[class*="mn-tone-"] > .flex > span {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  font-weight: 400;
+}
+.page-surface[data-page="control"] > .grid > .grid > .magic-card:nth-child(2) {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  align-items: center;
+}
+.page-surface[data-page="control"] > .grid > .grid > .magic-card:nth-child(2) > p {
+  grid-column: 1 / -1;
+  grid-row: 2;
+}
+.page-surface[data-page="control"] > .grid > .grid > .magic-card:nth-child(2) > .mn-button {
+  grid-column: 2;
+  grid-row: 1;
+  width: auto;
+  justify-self: end;
+  min-width: 0;
+  max-width: 100%;
+}
+.page-surface[data-page="control"] > .grid > .grid > .magic-card:nth-child(3) .mn-button {
+  justify-content: flex-start;
+  padding-inline: 0;
+  border-color: transparent;
+  background: transparent;
+}
+.mn-utility-sheet {
+  max-height: calc(100dvh - env(safe-area-inset-top) - 16px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+.mn-utility-grid { grid-template-columns: minmax(0, 1fr); gap: 0; }
+.mn-utility-grid > .mn-button {
+  min-height: 52px;
+  justify-content: flex-start;
+  border: 0;
+  border-top: 1px solid var(--mn-border);
+  border-radius: 0;
+}
+.mn-easter-egg {
+  max-height: calc(100dvh - 160px - env(safe-area-inset-bottom));
+  overflow-y: auto;
+  border-color: var(--mn-border);
+}
+.mn-easter-copy { min-width: 0; overflow-wrap: anywhere; }
+.mn-visitor-line { flex-wrap: wrap; }
+
+@media (max-width: 899px) {
+  .mn-shell { padding-bottom: calc(112px + env(safe-area-inset-bottom)); }
+  .mn-command-bar { gap: 4px; }
+  .mn-global-actions { gap: 2px; }
+  .mn-workspace-frame { margin-top: 0; }
+  .mn-page-header { gap: 4px; }
+  .mn-page-header > div:first-child { flex-basis: auto; }
+  .mobile-nav { padding-inline: max(12px, env(safe-area-inset-left)) max(12px, env(safe-area-inset-right)); }
+  .mobile-nav button { border-radius: 0; border-top: 2px solid transparent; }
+  .mobile-nav button.mn-nav-active {
+    border-color: transparent !important;
+    border-top-color: var(--mn-primary) !important;
+    background: transparent !important;
+  }
+  .mn-easter-egg { bottom: calc(96px + env(safe-area-inset-bottom)); }
+}
+@media (max-width: 359px) {
+  .mn-brand-lockup { gap: 6px; }
+  .mn-brand-copy h1 { font-size: 1rem; }
+  .mn-section-tabs { gap: 12px; }
+}
+@media (forced-colors: active) {
+  .mobile-nav button.mn-nav-active { border-top-color: Highlight !important; }
+  .mn-utility-grid > .mn-button { border-color: ButtonText; }
+}
+
+/* Match the layer of existing !p-* utilities instead of escalating every rule. */
+@layer utilities {
+  .page-surface[data-page="control"] > .grid > .grid > .magic-card { padding: 16px 0 !important; }
+}
+.page-surface[data-page="control"] .mn-page-header p,
+.page-surface[data-page="control"] .mn-page-actions > span { display: none; }
+
+/* Intrinsic form widths must not force a wider page when text is enlarged. */
+.page-surface :where(.grid, .flex) > * { min-width: 0; }
+.page-surface :where(input, select, textarea) { max-width: 100%; }
+.page-surface :where(p, code, dd) { overflow-wrap: anywhere; }
+.page-surface .mn-segmented { flex-wrap: wrap; }
+.page-surface[data-page="health"] .magic-card > .flex > .flex,
+.page-surface[data-page="tools"] .magic-card > .flex { flex-wrap: wrap; }

--- a/webui/src/main.ts
+++ b/webui/src/main.ts
@@ -3,6 +3,7 @@ import App from "./App.vue";
 import { installMagicNetFavicon } from "@/branding";
 import { bootstrapTheme } from "@/composables/useTheme";
 import "./styles.css";
+import "./console.css";
 
 installMagicNetFavicon();
 bootstrapTheme();


### PR DESCRIPTION
## 界面调整

沿用 `webui/DESIGN.md` 已批准的 Quiet Console 方向，仅调整 WebUI 表现层。5 个文件，新增 195 行、删除 3 行；不新增依赖，不修改代理、命令执行、权限或状态判断逻辑。

- 桌面端去掉导航和顶栏的重复外框，移除重复的工作区标题，保留清晰的当前页面标题与页签选中态。
- `PageHeader` 将标题和操作按钮放在同一个可换行布局中，保留默认及具名 action slot。
- 状态卡片使用中性底色与状态色侧边线，继续区分正常、警告和错误；浅色、深色主题共用既有语义变量。
- 手机端状态说明独占下一行并允许换行；健康检查页网格子项允许收缩；卡片操作区限制最大宽度，修复 200% 字号下 Wi-Fi 操作按钮溢出。
- 保留现有焦点、减少动态效果规则，并补充系统强制颜色模式下的页签选中线。

## 已完成的验证

`node --test console-layout.test.mjs`：4 项结构回归测试通过。

离线 Chromium 布局检查：11 个页面 × 6 种宽度（360、390、768、900、1280、1440）× 浅色/深色主题，共 132 组；另检查运行页在 390/1440 宽度、根字号 200% 下的布局，合计 134 组。未发现页面或可见操作控件的横向溢出，未记录 pageerror。另检查键盘焦点、forced-colors 页签选中线和 reduced-motion。

## 验证边界

当前执行环境无法联网安装依赖或克隆完整仓库。上述浏览器检查使用仓库此前成功 CI 产物（artifact 9950911156，源提交 9008010a1806efceff7b9c7a72c3b93925d39b97），应用与本 PR 对应的三个组件 class 替换及新增 CSS，离线运行真实 Vue 页面。

这不是本分支重新构建的产物。尚未本地执行完整 `npm run check`，也未进行 Android/KernelSU 真机测试；无设备连接时页面保持“状态未知”，未伪造正常运行数据。完整源码构建及现有测试仍需由仓库 CI 验证。预览截图、离线交互 HTML 和浏览器检查报告随本次对话交付。

不合并、不发布，供界面评审。

## Sourcery 摘要

在不改变应用行为的前提下，简化 WebUI 控制台的呈现方式，并提升响应式可访问性。

错误修复：
- 防止状态详情和卡片操作控件在窄屏及放大文本尺寸下溢出。
- 在强制颜色模式下保留可见的标签页选中状态。

改进：
- 移除多余的桌面端框架和工作区标题，简化控制台的视觉层次结构。
- 优化页面标题、导航标签页、状态卡片和响应式布局，以便在浅色、深色、移动端和桌面端视图中呈现得更加清晰。

测试：
- 添加结构回归测试，覆盖响应式标题、样式表顺序、移动端换行、强制颜色模式下的标签页选中状态，以及放大文本时的卡片操作控件。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在保持应用行为不变的同时，优化 WebUI 控制台的呈现效果和响应式可访问性。

错误修复：
- 防止状态详情和卡片操作在窄屏或放大文本时溢出。
- 在强制颜色模式下保留可见的标签页选中指示器。
- 确保实用工具和模态框内容在视口高度较小时仍可滚动。

增强功能：
- 通过移除冗余的桌面框架和工作区标题，简化 WebUI 控制台层级结构。
- 改进移动端和桌面主题下的页面标题、导航标签、状态卡片及响应式布局。
- 将 GPT-6 条目添加到现有的访客彩蛋轮换中。

CI：
- 添加 WebUI GitHub Actions 工作流，用于运行检查并发布源代码和预览构件。

测试：
- 添加结构回归测试，覆盖响应式标题、样式表排序、移动端换行、强制颜色模式下的选中状态、放大文本时的卡片操作，以及作用域限定的运行页面布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the WebUI console presentation and responsive accessibility while preserving application behavior.

Bug Fixes:
- Prevent status details and card actions from overflowing on narrow screens or when text is enlarged.
- Preserve visible tab selection indicators in forced-colors mode.
- Keep utility and modal content scrollable within short viewports.

Enhancements:
- Simplify the WebUI console hierarchy by removing redundant desktop framing and workspace headings.
- Improve page headers, navigation tabs, status cards, and responsive layouts across mobile and desktop themes.
- Add the GPT-6 entry to the existing visitor easter-egg rotation.

CI:
- Add a WebUI GitHub Actions workflow that runs checks and publishes source and preview artifacts.

Tests:
- Add structural regression tests for responsive headers, stylesheet ordering, mobile wrapping, forced-colors selection, enlarged-text card actions, and scoped run-page layouts.

</details>

</details>