### PR TITLE
style(webui): 补充 GPT-6 彩蛋，改为竖屏分组设置布局

### DIFF
--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -1,0 +1,33 @@
+name: WebUI
+on:
+  pull_request:
+    paths: ['webui/**', '.github/workflows/webui.yml']
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: webui-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: webui/package-lock.json
+      - run: npm ci
+        working-directory: webui
+      - run: npm run check
+        working-directory: webui
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: webui-preview
+          path: webui/dist/
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -16,6 +16,13 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
+      - run: git archive --format=zip --output=webui-source.zip HEAD webui
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: webui-source
+          path: webui-source.zip
+          if-no-files-found: error
+          retention-days: 7
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'

--- a/webui/console-layout.test.mjs
+++ b/webui/console-layout.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
+import postcss from "postcss";
 
 const read = (path) => readFileSync(new URL(path, import.meta.url), "utf8");
 const css = read("./src/console.css");
@@ -12,9 +13,23 @@ test("page heading and both action slots share a wrapping header", () => {
   assert.match(css, /\.mn-page-header\s*\{[^}]*display: flex;[^}]*flex-wrap: wrap;/);
 });
 
-test("console refinements load after the existing theme", () => {
+test("console refinements load after the existing theme with narrowly scoped overrides", () => {
   assert.match(read("./src/main.ts"), /import "\.\/styles\.css";\s*import "\.\/console\.css";/);
-  assert.doesNotMatch(css, /!important|@import|url\(/);
+  assert.doesNotMatch(css, /@import|url\(/);
+  const important = [];
+  postcss.parse(css).walkDecls((decl) => {
+    if (!decl.important) return;
+    important.push(`${decl.parent.selector}: ${decl.prop}`);
+  });
+  // Existing nav rules and Tailwind !p-* utilities require these exact overrides.
+  // Other pages and properties must not accumulate priority escapes.
+  assert.deepEqual(important, [
+    ".mobile-nav button.mn-nav-active: border-color",
+    ".mobile-nav button.mn-nav-active: border-top-color",
+    ".mobile-nav button.mn-nav-active: background",
+    ".mobile-nav button.mn-nav-active: border-top-color",
+    '.page-surface[data-page="control"] > .grid > .grid > .magic-card: padding',
+  ]);
 });
 
 test("mobile status details wrap and high-contrast tabs retain selection", () => {

--- a/webui/frontend-refactor-contract.test.mjs
+++ b/webui/frontend-refactor-contract.test.mjs
@@ -295,9 +295,15 @@ assert.doesNotMatch(
 const pageHeader = read(join(src, "components", "ui", "PageHeader.vue"));
 assert.match(
   pageHeader,
-  /<div class="contents">/,
-  "PageHeader actions must participate in the owning page grid",
+  /<div class="mn-page-header">/,
+  "PageHeader must keep its title and actions in one normal-flow header",
 );
+assert.match(
+  read(join(src, "console.css")),
+  /\.mn-page-header\s*\{[^}]*display: flex;[^}]*flex-wrap: wrap;/,
+  "PageHeader must wrap actions rather than overlap the owning page",
+);
+assert.match(pageHeader, /<slot name="actions">\s*<slot \/>/);
 const controlPage = read(join(pagesDir, "ControlPage.vue"));
 assert.doesNotMatch(
   controlPage,

--- a/webui/mobile-settings.test.mjs
+++ b/webui/mobile-settings.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { runInNewContext } from "node:vm";
+const app = readFileSync(new URL("./src/App.vue", import.meta.url), "utf8");
+const css = readFileSync(new URL("./src/console.css", import.meta.url), "utf8");
+
+test("five clicks reveal GPT-6, retain previous visitors, and wrap the rotation", () => {
+  const visitors = runInNewContext(app.match(/const easterEggVisitors = ([\s\S]*?) as const;/)[1]);
+  assert.equal(visitors.map(({ name }) => name).join(","), "GPT-6,SOL,Grok 4.5,Kimi K3,Fable 5");
+  let now = 1000;
+  const scope = { Date: { now: () => now }, window: { clearTimeout() {}, setTimeout: () => 1 },
+    closeEasterEgg() {}, easterEggVisitors: visitors, brandClickCount: 0, brandClickWindowStartedAt: 0,
+    easterEggNextIndex: 0, easterEggShownIndex: { value: 0 }, easterEggVisible: { value: false }, easterEggTimer: undefined };
+  runInNewContext(app.match(/function handleBrandMarkClick\(\): void \{[\s\S]*?\n\}/)[0].replace(": void", ""), scope);
+  for (let i = 0; i < 4; i++) scope.handleBrandMarkClick();
+  assert.equal(scope.easterEggVisible.value, false);
+  scope.handleBrandMarkClick();
+  assert.equal(scope.easterEggVisible.value, true);
+  assert.equal(scope.easterEggShownIndex.value, 0);
+  for (let i = 1; i <= visitors.length; i++) {
+    for (let click = 0; click < 5; click++) scope.handleBrandMarkClick();
+    assert.equal(scope.easterEggShownIndex.value, i % visitors.length);
+  }
+  scope.handleBrandMarkClick(); now += 2500; scope.handleBrandMarkClick();
+  assert.equal(scope.brandClickCount, 1);
+});
+
+test("run-page layout is scoped and short viewports retain scrolling menus", () => {
+  assert.match(app, /class="page-surface" :data-page="activeTab"/);
+  assert.match(css, /\.page-surface\[data-page="control"\]/);
+  assert.match(css, /\.mn-utility-sheet\s*\{[^}]*max-height:[^}]*100dvh[^}]*overflow-y: auto/s);
+});

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -162,6 +162,11 @@ const onboardingTrigger = ref<HTMLElement | null>(null);
 
 const easterEggVisitors = [
   {
+    name: "GPT-6",
+    title: "GPT-6 到此一游",
+    body: "少画几个框，多留一点位置给内容。",
+  },
+  {
     name: "SOL",
     title: "准备好你的太阳镜 😎",
     body: "SOL 到此一游 · 光太亮，别直视内核。",
@@ -581,7 +586,7 @@ onUnmounted(() => {
         </header>
 
         <!-- KeepAlive preserves form state across all four workspaces. -->
-        <section class="page-surface">
+        <section class="page-surface" :data-page="activeTab">
           <Suspense>
             <KeepAlive :max="11">
               <component

--- a/webui/src/console.css
+++ b/webui/src/console.css
@@ -291,3 +291,11 @@
 }
 .page-surface[data-page="control"] .mn-page-header p,
 .page-surface[data-page="control"] .mn-page-actions > span { display: none; }
+
+/* Intrinsic form widths must not force a wider page when text is enlarged. */
+.page-surface :where(.grid, .flex) > * { min-width: 0; }
+.page-surface :where(input, select, textarea) { max-width: 100%; }
+.page-surface :where(p, code, dd) { overflow-wrap: anywhere; }
+.page-surface .mn-segmented { flex-wrap: wrap; }
+.page-surface[data-page="health"] .magic-card > .flex > .flex,
+.page-surface[data-page="tools"] .magic-card > .flex { flex-wrap: wrap; }

--- a/webui/src/console.css
+++ b/webui/src/console.css
@@ -162,3 +162,132 @@
     border-inline-start-color: CanvasText;
   }
 }
+
+/* Mobile settings: quiet chrome and continuous sections, not a card dashboard. */
+.mn-shell { --mn-ivory: var(--mn-surface-raised); background: var(--mn-ivory); }
+.mn-command-bar { min-height: 60px; }
+.mn-brand-mark { border: 0; background: transparent; }
+.mn-brand-copy > p { display: none; }
+.mn-brand-mark img { width: 32px; height: 32px; }
+.mn-global-actions > .mn-button { border-color: transparent; }
+.mn-runtime-brief {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  margin-block: 0 16px;
+  padding: 12px 0;
+  border: 0;
+  border-bottom: 1px solid var(--mn-border);
+  border-radius: 0;
+  background: transparent;
+}
+.mn-runtime-brief > p { flex: 1 1 8rem; white-space: normal; overflow: visible; }
+.mn-runtime-brief[data-state] { border-inline-start: 0; }
+.mn-runtime-mode { border: 0; background: transparent; padding: 0; }
+.mn-page-header h2 { font-size: 1.25rem; }
+.mn-page-header p { margin-top: 4px; }
+.mn-page-actions { gap: 4px 12px; }
+.mn-page-actions > .mn-button { padding-inline: 0; border-color: transparent; }
+.mn-page-actions > span { padding-inline: 0; border: 0; background: transparent; }
+.mn-workspace-header { margin-bottom: 12px; }
+.mn-section-tabs { gap: 24px; padding-inline: 0; }
+.mn-section-tabs button { font-weight: 500; }
+.mn-section-tabs button.is-active { font-weight: 650; }
+
+/* Scope structural rules to the run page; editors and other page grids stay intact. */
+.page-surface[data-page="control"] > .grid > .grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.page-surface[data-page="control"] > .grid > .grid > .magic-card {
+  min-height: 0;
+  border: 0;
+  border-top: 1px solid var(--mn-border);
+  border-radius: 0;
+  background: transparent;
+}
+.page-surface[data-page="control"] .magic-card h3 { font-size: 1rem; line-height: 1.5; }
+.page-surface[data-page="control"] .magic-card[class*="mn-tone-"] { gap: 8px; }
+.page-surface[data-page="control"] .magic-card[class*="mn-tone-"] > p { line-height: 1.6; }
+.page-surface[data-page="control"] .magic-card[class*="mn-tone-"] > .flex > span {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  font-weight: 400;
+}
+.page-surface[data-page="control"] > .grid > .grid > .magic-card:nth-child(2) {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  align-items: center;
+}
+.page-surface[data-page="control"] > .grid > .grid > .magic-card:nth-child(2) > p {
+  grid-column: 1 / -1;
+  grid-row: 2;
+}
+.page-surface[data-page="control"] > .grid > .grid > .magic-card:nth-child(2) > .mn-button {
+  grid-column: 2;
+  grid-row: 1;
+  width: auto;
+  justify-self: end;
+  min-width: 0;
+  max-width: 100%;
+}
+.page-surface[data-page="control"] > .grid > .grid > .magic-card:nth-child(3) .mn-button {
+  justify-content: flex-start;
+  padding-inline: 0;
+  border-color: transparent;
+  background: transparent;
+}
+.mn-utility-sheet {
+  max-height: calc(100dvh - env(safe-area-inset-top) - 16px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+.mn-utility-grid { grid-template-columns: minmax(0, 1fr); gap: 0; }
+.mn-utility-grid > .mn-button {
+  min-height: 52px;
+  justify-content: flex-start;
+  border: 0;
+  border-top: 1px solid var(--mn-border);
+  border-radius: 0;
+}
+.mn-easter-egg {
+  max-height: calc(100dvh - 160px - env(safe-area-inset-bottom));
+  overflow-y: auto;
+  border-color: var(--mn-border);
+}
+.mn-easter-copy { min-width: 0; overflow-wrap: anywhere; }
+.mn-visitor-line { flex-wrap: wrap; }
+
+@media (max-width: 899px) {
+  .mn-shell { padding-bottom: calc(112px + env(safe-area-inset-bottom)); }
+  .mn-command-bar { gap: 4px; }
+  .mn-global-actions { gap: 2px; }
+  .mn-workspace-frame { margin-top: 0; }
+  .mn-page-header { gap: 4px; }
+  .mn-page-header > div:first-child { flex-basis: auto; }
+  .mobile-nav { padding-inline: max(12px, env(safe-area-inset-left)) max(12px, env(safe-area-inset-right)); }
+  .mobile-nav button { border-radius: 0; border-top: 2px solid transparent; }
+  .mobile-nav button.mn-nav-active {
+    border-color: transparent !important;
+    border-top-color: var(--mn-primary) !important;
+    background: transparent !important;
+  }
+  .mn-easter-egg { bottom: calc(96px + env(safe-area-inset-bottom)); }
+}
+@media (max-width: 359px) {
+  .mn-brand-lockup { gap: 6px; }
+  .mn-brand-copy h1 { font-size: 1rem; }
+  .mn-section-tabs { gap: 12px; }
+}
+@media (forced-colors: active) {
+  .mobile-nav button.mn-nav-active { border-top-color: Highlight !important; }
+  .mn-utility-grid > .mn-button { border-color: ButtonText; }
+}
+
+/* Match the layer of existing !p-* utilities instead of escalating every rule. */
+@layer utilities {
+  .page-surface[data-page="control"] > .grid > .grid > .magic-card { padding: 16px 0 !important; }
+}
+.page-surface[data-page="control"] .mn-page-header p,
+.page-surface[data-page="control"] .mn-page-actions > span { display: none; }


### PR DESCRIPTION
继续处理界面评审反馈。此 PR 叠加在 #152 上；未合并、未发布，网络控制逻辑和操作确认流程保持不变。

## 改动

- 为现有模型署名彩蛋加入 GPT-6。2.4 秒内连续点击品牌图标五次，首次显示 GPT-6；保留 SOL、Grok 4.5、Kimi K3、Fable 5 的后续轮播。这只是署名彩蛋，没有新增模型 API 功能。
- 运行页改为连续分组与细分隔线，压缩重复标题、状态标签和说明；保留设备权限提示、错误信息、状态颜色及全部操作。
- 主操作与状态并排，次要操作取消整块底色；底部导航用选中线，系统工具改为可滚动纵向菜单。
- 为窄屏、短视口、安全区和长内容增加约束。运行页的结构调整由 data-page 明确限定；另外修复应用、健康检查、工具、输出四页在放大根字号时的表单和按钮组溢出。
- 新增独立 WebUI CI：npm ci → npm run check → 上传本分支构建产物。原 Code Quality 只覆盖 Rust/Shell。

## 已完成验证

验证提交：`cf5a502b6c3cedd1469530e1b8b7b2532fd982f6`。

WebUI CI 已通过：https://github.com/LIghtJUNction/MagicNet/actions/runs/33920122548 。`npm run check` 包含项目测试、TypeScript 检查和 Vite 构建。预览构建产物 ID 为 `9954687543`，SHA-256 为 `1624a2e38be2392e59050858c9897dd7d290e06cfc5ec177eee88844f0604602`，下载后已核对摘要。

浏览器验证使用这次源码构建的 JS/CSS，仅将模块、图片、样式内嵌为离线评审 HTML；保留原始 dist。没有替换页面代码、模拟成功状态或模拟设备桥接。离线预览使用临时内存存储。

Chromium 共完成 286 组布局检查：11 页，浅/深色，100% 根字号下宽度 320/360/390/412/430/768/900/1440，以及前五种宽度的 200% 根字号。页面和可见页面操作控件未出现横向溢出，页面脚本异常为 0。390×844 下启动按钮顶部约 422.5px，完整位于底部导航上方。

交互检查通过：四次点击不触发、第五次首先显示 GPT-6、全部原访客轮播并回到 GPT-6、Escape 关闭、工具菜单初始焦点/焦点约束/关闭后恢复、320×320 且 200% 根字号时菜单可滚动到最后一项、高对比导航标记、键盘焦点及减少动画偏好。

## 测试契约调整

独立前端 CI 揭示两条旧结构断言与当前设计冲突：PageHeader 的 display:contents 断言更新为标题与 actions/default 插槽共用正常文档流、可换行的 header；CSS 的全局 !important 禁令改为 PostCSS 解析后仅允许五个确有现有优先级冲突的定向声明，其他页面和属性不允许新增优先级覆盖。没有删除测试，也没有绕过 npm run check。

## 边界

Android/KernelSU 真机尚未验证，离线界面如实显示状态未知和设备执行通道缺失。完整 Android 模块打包截至本次检查仍在运行；不将前端构建成功等同于完整模块构建或真机通过。

## Sourcery 摘要

优化 WebUI，使垂直设置布局具备响应式表现，同时加入 GPT-6 彩蛋和专用的前端验证。

新功能：
- 将 GPT-6 添加到现有的品牌点击彩蛋轮换中，同时保留之前的访客消息。

错误修复：
- 防止表单控件、按钮组和长内容在窄屏显示以及根字体大小增大时溢出。

增强功能：
- 将 WebUI 重构为按垂直方向分组的响应式设置布局，采用更简洁的界面装饰、分隔的区域、内联主要操作、活动导航指示器以及可滚动的工具菜单。
- 明确限定运行页面结构样式的作用范围，并保留安全区域、短视口、无障碍和高对比度行为。
- 更新结构和 CSS 契约测试，以验证可换行的页面标题以及作用范围更窄的优先级覆盖规则。

CI：
- 添加独立的 WebUI GitHub Actions 工作流，用于安装依赖、运行 WebUI 检查，并上传源代码和预览构建产物。

测试：
- 添加 GPT-6 彩蛋轮换和响应式运行页面布局约束的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the WebUI for responsive vertical settings layouts while adding the GPT-6 easter egg and dedicated frontend validation.

New Features:
- Add GPT-6 to the existing brand-click easter-egg rotation while preserving the previous visitor messages.

Bug Fixes:
- Prevent form controls, button groups, and long content from overflowing on narrow screens and when the root font size is enlarged.

Enhancements:
- Rework the WebUI into a vertically grouped, responsive settings layout with quieter chrome, separated sections, inline primary actions, active navigation indicators, and a scrollable utility menu.
- Scope run-page structural styling explicitly and retain safe-area, short-viewport, accessibility, and high-contrast behavior.
- Update structural and CSS contract tests to validate the wrapping page header and narrowly scoped priority overrides.

CI:
- Add an independent WebUI GitHub Actions workflow that installs dependencies, runs the WebUI checks, and uploads source and preview build artifacts.

Tests:
- Add coverage for the GPT-6 easter egg rotation and responsive run-page layout constraints.

</details>