### PR TITLE
style(webui): 应用第三版网络工具界面源码补丁

### DIFF
--- a/webui/DESIGN.md
+++ b/webui/DESIGN.md
@@ -1,123 +1,43 @@
 ---
-name: "MagicNet Quiet Console"
-version: "2.0.0"
-status: "approved"
-approved_direction: "B — 安静控制台"
-approved_by: "user"
-approved_at: "2026-09-01"
-colors:
-  background: "#0B0D12"
-  surface: "#151A23"
-  text: "#F2F4F7"
-  primary: "#60A5FA"
+name: "MagicNet — Network Utility"
+version: "3.0.0"
+status: "proposal"
 ---
 
-# MagicNet Quiet Console
+# MagicNet visual direction
 
-Quiet Console is a compact, high-trust control surface for Android root users. It behaves like a careful native settings tool with an IDE-grade editor—not a terminal costume and not a generic card dashboard.
+This revision is a proposal responding to rejection of the previous two iterations. It has not been approved by the user.
 
-## Product character
+## Composition
 
-- Calm under failure: failures are local, specific, and recoverable.
-- Dense without clutter: one dominant task per page; supporting facts recede.
-- Direct Chinese: labels name the user outcome; implementation detail appears only where it changes a decision.
-- Precise: state colors, numbers, paths, and editor locations mean exactly one thing.
-- Frontend only: visuals and copy never invent backend capability.
+The mobile home screen starts with a single, large, observed sing-box state. The recovery explanation follows it; the full-width service control and four maintenance actions follow that explanation. Configured and effective modes remain separately labelled in the transparent-mode disclosure, without repeating them in the overview.
 
-## Visual world
+Transparent mode, Wi-Fi policy and hotspot policy use native details/summary disclosures. Their forms remain mounted, keyboard-operable and available without changing navigation. A recent transparent-mode error remains visible outside the disclosure. Node and proxy-group management links to the existing zashboard entry point.
 
-### Color
+There is no second page title, wall of peer cards, fake speed chart, connection percentage, or invented device state. Missing device access continues to say so. The copy-state action retains the existing redaction logic.
+
+Desktop separates the service controls and network settings into two columns, with a narrow workspace rail. The mobile bottom navigation keeps four labelled destinations. Global operation feedback, root confirmation, application drafts, theme switching and the five-click brand signature stay available. The home screen suppresses only the idle duplicate status strip; tasks, device-side errors and background output keep it visible. A missing execution bridge is already explained beside the home status. Other pages retain the strip.
+
+## Colour and typography
+
+The effective visual tokens live in `src/console.css`, loaded after the shared foundation in `src/styles.css`. The previous console override file is replaced, not appended. Base semantic classes and page primitives still share the same token names.
 
 | Role | Light | Dark |
 | --- | --- | --- |
-| background | `#F6F7F9` | `#0B0D12` |
-| raised surface | `#FFFFFF` | `#151A23` |
-| sunken surface | `#F0F2F5` | `#0F131A` |
-| primary | `#2563EB` | `#60A5FA` |
-| text | `#172033` | `#F2F4F7` |
-| muted text | `#667085` | `#98A2B3` |
-| border | `#D7DCE3` | `#293140` |
-| success | `#15803D` | `#4ADE80` |
-| warning | `#A16207` | `#FBBF24` |
-| danger | `#C2414B` | `#FB7185` |
+| Canvas | `#F4F4EF` | `#171B16` |
+| Text | `#292B27` | `#ECEDE6` |
+| Secondary text | `#696E64` | `#A7AFA0` |
+| Interaction accent | `#B3462B` | `#F0A181` |
+| Service control | `#30392D` | `#E0E7D5` |
 
-Primary: "#60A5FA"
+The accent identifies interaction. Success, warning and danger retain distinct semantic tokens and visible labels. The service button uses a high-contrast ink surface, without glow or animated decoration.
 
-Blue is interactive emphasis, never decoration. Green, amber, and red are reserved for observed state. Neutral surfaces carry hierarchy. Do not use gradients, glass blur, phosphor glow, or monochrome neon fields.
+System fonts and CJK fallbacks stay local. A 34–50px status heading establishes hierarchy; body text, control labels and secondary labels remain smaller. No remote font requests or additional runtime dependencies are introduced.
 
-### Type
+## Interaction and accessibility
 
-- UI: system sans with CJK fallbacks; sentence case; no decorative all-caps English.
-- Code/data: system monospace only for JSON, paths, addresses, identifiers, and values users copy.
-- Page title: 24–32px, semibold, tight tracking.
-- Body/helper: 13–14px, regular, 1.5–1.7 line height.
-- Labels: 12–13px, semibold; operational terms stay recognizable.
+Disclosures use native keyboard behaviour and a rotating chevron. Buttons keep their labels during loading. Destructive actions still call the existing confirmation functions. The primary action remains service start/stop; restart remains a separately labelled action.
 
-### Shape and depth
+Controls wrap at narrow widths and enlarged text sizes. Safe areas, scrollable short-viewport menus, focus trapping, focus restoration, reduced motion and forced-colour selection indicators are retained. Text and primary control token contrast is tested against 4.5:1 in both themes.
 
-- Radius scale: 6 / 8 / 10px. Pills are reserved for compact status/category semantics.
-- One-pixel borders define sections. Shadows only separate sticky/floating layers.
-- Nested cards use a sunken surface and no shadow. Prefer grouped lists and split workspaces over equal card grids.
-- Spacing scale: 4 / 8 / 12 / 16 / 24 / 32px.
-
-## Signature Mechanism: Precision Editor Rail
-
-The configuration editor is the product's memorable mechanism. Its quiet line rail is always aligned with native textarea content, virtualizes large files, highlights current and syntax-error lines, accepts direct line clicks, and turns error location text into a jump action. It should feel like a small IDE embedded in a native control tool.
-
-The mechanism may reappear as precise row indices, step indices, and live state markers elsewhere, but never as decorative terminal syntax.
-
-## Shell and navigation
-
-- Mobile: solid command bar, concise runtime strip, horizontal page tabs, four-item bottom navigation.
-- Desktop: compact command bar, runtime strip, 204px task-group rail, page tabs above the surface.
-- Navigation labels use outcomes (`运行状态`, `配置文件`, `最近输出`) rather than internal codenames.
-- The shell reports global state once. Detailed route diagrams live on their dedicated page.
-
-## Page hierarchy
-
-1. Page identity: one title and at most one short outcome sentence.
-2. Primary action/task: editor, list, form, or operation.
-3. Current state and result.
-4. Secondary context or advanced settings behind natural disclosure.
-5. Destructive actions separated by consequence-specific confirmation.
-
-No page should open with a wall of equally loud summary cards.
-
-## Components
-
-- `Button`: label remains visible during loading; blue primary, neutral secondary, red destructive.
-- `Card`: quiet section surface; no decorative radius/shadow escalation.
-- `PageHeader`: title + concise outcome; no bracketed English kicker.
-- `Badge`/`StatusDot`: observed status only.
-- `Tag`/`RemovableTag`: categories and removable selections only.
-- `ConfirmPanel`: names object and consequence; destructive confirmation is visually distinct.
-- `ConfigCodeEditor`: native editing/undo/selection is authoritative; syntax layer is visual only.
-
-## Feedback and copy
-
-- Loading under 300ms remains quiet; longer work names the object being loaded.
-- Failure says what failed and what the user can do next. Preserve drafts.
-- Empty states distinguish first use, no matches, unavailable data, and permission limits.
-- Remove phrases that merely restate architecture, implementation safety, or a sequence the UI already shows.
-- Use protocol names only when users must identify, configure, or debug them.
-
-## Responsive and accessibility
-
-- Primary interactive targets are at least 44px; tightly spaced editor line targets use the WCAG 2.2 24px minimum and remain at least 44px wide.
-- At 360px, show one task column; actions wrap without covering content.
-- At 200% text, navigation and primary flows remain operable.
-- Focus is always visible. Selected/current/error states use shape, border, label, or icon as well as color.
-- Forced colors preserve borders and selected state.
-- Reduced motion removes nonessential transitions.
-
-## Source Evidence & Confidence
-
-- [observed] path: `src/styles.css`
-  sha256: `09ea94fbcad925fe5af6cc1744ca2d107a00cd98fad8cb9036fcd53d0bce5dbc`
-  confidence: high
-- [observed] path: `src/App.vue`
-  sha256: `08f38023230313dcf7127925fa778f9a7a6c71b10874241b53ab5fa709fc09b6`
-  confidence: high
-- [observed] path: `src/components/ConfigCodeEditor.vue`
-  sha256: `bdeb5bdaded41eb5d32fb8db7089baf2af8a307d2d20b04609e72ea2ad14758d`
-  confidence: high
+The design must be reviewed from the compiled application in both themes. Passing tests is not an aesthetic approval, and a browser preview is not evidence of Android/KernelSU device validation.

--- a/webui/console-layout.test.mjs
+++ b/webui/console-layout.test.mjs
@@ -21,14 +21,12 @@ test("console refinements load after the existing theme with narrowly scoped ove
     if (!decl.important) return;
     important.push(`${decl.parent.selector}: ${decl.prop}`);
   });
-  // Existing nav rules and Tailwind !p-* utilities require these exact overrides.
-  // Other pages and properties must not accumulate priority escapes.
+  // The base navigation state is the only inherited important declaration.
+  // New components and layout rules must not add priority escapes.
   assert.deepEqual(important, [
     ".mobile-nav button.mn-nav-active: border-color",
-    ".mobile-nav button.mn-nav-active: border-top-color",
     ".mobile-nav button.mn-nav-active: background",
-    ".mobile-nav button.mn-nav-active: border-top-color",
-    '.page-surface[data-page="control"] > .grid > .grid > .magic-card: padding',
+    ".mobile-nav button.mn-nav-active: color",
   ]);
 });
 

--- a/webui/quiet-console-style-contract.test.mjs
+++ b/webui/quiet-console-style-contract.test.mjs
@@ -1,55 +1,75 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
+import postcss from "postcss";
 
-const read = (relativePath) =>
-  readFileSync(new URL(relativePath, import.meta.url), "utf8");
+const read = (path) => readFileSync(new URL(path, import.meta.url), "utf8");
 const styles = read("./src/styles.css");
+const consoleStyles = read("./src/console.css");
 const app = read("./src/App.vue");
-const button = read("./src/components/ui/Button.vue");
-const pageHeader = read("./src/components/ui/PageHeader.vue");
-const design = read("./DESIGN.md");
+const control = read("./src/components/pages/ControlPage.vue");
 
-void test("quiet console uses neutral surfaces and blue action emphasis", () => {
-  assert.match(styles, /--mn-ivory:\s*#0b0d12/i);
-  assert.match(styles, /--mn-surface-raised:\s*#151a23/i);
-  assert.match(styles, /--mn-primary:\s*#60a5fa/i);
-  assert.match(styles, /--mn-radius-lg:\s*10px/i);
-  assert.match(styles, /--mn-shadow-card:\s*0 1px 2px/i);
-  assert.doesNotMatch(
-    styles,
-    /linear-gradient|radial-gradient|backdrop-filter:\s*blur/i,
-  );
+function themeTokens(theme) {
+  const tokens = {};
+  postcss.parse(consoleStyles).walkRules((rule) => {
+    if (rule.parent.type !== "root") return;
+    if (!rule.selector.includes(`html[data-theme="${theme}"]`)) return;
+    rule.walkDecls((decl) => { tokens[decl.prop] = decl.value; });
+  });
+  return tokens;
+}
+function luminance(hex) {
+  const values = hex.slice(1).match(/../g).map((c) => parseInt(c, 16) / 255);
+  const [r, g, b] = values.map((v) => v <= 0.04045 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4);
+  return r * 0.2126 + g * 0.7152 + b * 0.0722;
+}
+function contrast(a, b) {
+  const values = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (values[0] + 0.05) / (values[1] + 0.05);
+}
+
+for (const theme of ["light", "dark"]) {
+  test(`${theme} theme keeps body, secondary text, links and primary controls readable`, () => {
+    const tokens = themeTokens(theme);
+    for (const [foreground, background] of [
+      ["--mn-ink", "--mn-ivory"], ["--mn-ink-muted", "--mn-ivory"],
+      ["--mn-primary-strong", "--mn-ivory"], ["--mn-on-accent", "--mn-primary"],
+      ["--mn-control-text", "--mn-control-ink"],
+    ]) {
+      assert.ok(contrast(tokens[foreground], tokens[background]) >= 4.5, `${theme}: ${foreground} / ${background}`);
+    }
+  });
+}
+
+test("surfaces do not add decorative gradients, glow, or remote font dependencies", () => {
+  assert.doesNotMatch(styles + consoleStyles, /linear-gradient|radial-gradient|backdrop-filter:\s*blur/i);
+  assert.doesNotMatch(consoleStyles, /@import|url\(/);
+  assert.doesNotMatch(consoleStyles, /nth-child/);
 });
 
-void test("shell is outcome-led rather than terminal-themed", () => {
+test("the home page has one leading state and three native settings disclosures", () => {
+  assert.equal((control.match(/id="mn-runtime-title"/g) || []).length, 1);
+  assert.equal((control.match(/<details class="mn-setting"/g) || []).length, 3);
+  for (const key of ["transparent", "wifi", "hotspot"]) assert.match(control, new RegExp(`data-setting="${key}"`));
+  assert.doesNotMatch(control, /<PageHeader|<Card\s/);
+  assert.match(control, /pendingDangerAction/);
+  assert.match(control, /requestTransparentMode\('tun'/);
+  assert.match(control, /requestTransparentMode\('ebpf'/);
+  assert.match(control, /state\.runtime\.transparentRecentError/);
+});
+
+test("shell retains device truth, original branding, history and all workspace access", () => {
   assert.match(app, /class="mn-runtime-brief"/);
-  assert.match(app, />网络控制</);
-  assert.match(app, /查看状态并控制服务。/);
-  assert.match(app, /检查问题并运行维护工具。/);
-  assert.doesNotMatch(
-    app,
-    /ROOT:\/\/MAGICNET|ROUTE_STACK|WORKSPACES|root@magicnet/,
-  );
-  assert.doesNotMatch(app, /workspace\.code|item\.code/);
+  assert.match(app, /MAGICNET_LOGO_URL/);
   assert.match(app, /readTabFromLocation/);
   assert.match(app, /writeTabToLocation/);
-  assert.match(
-    app,
-    /window\.addEventListener\("popstate", syncTabFromLocation\)/,
-  );
+  assert.match(app, /KeepAlive/);
+  assert.match(app, /window\.addEventListener\("popstate", syncTabFromLocation\)/);
+  assert.doesNotMatch(app, /ROOT:\/\/MAGICNET|ROUTE_STACK|root@magicnet/);
 });
 
-void test("shared primitives preserve labels and reduce decorative copy", () => {
-  assert.match(button, /v-if="loading"/);
-  assert.doesNotMatch(button, /loading \? 'opacity-0'/);
-  assert.doesNotMatch(pageHeader, /mn-page-kicker/);
-  assert.match(pageHeader, /v-if="description"/);
-});
-
-void test("durable design baseline names the approved world", () => {
-  assert.match(design, /name:\s*"MagicNet Quiet Console"/);
-  assert.match(design, /primary:\s*"#60A5FA"/i);
-  assert.match(design, /Signature Mechanism:\s*Precision Editor Rail/);
-  assert.doesNotMatch(design, /Phosphor Grid|Live Route Stack/);
+test("design proposal does not claim approval on the user's behalf", () => {
+  const design = read("./DESIGN.md");
+  assert.match(design, /status:\s*"proposal"/);
+  assert.doesNotMatch(design, /approved_by:\s*"user"|status:\s*"approved"/);
 });

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -164,7 +164,7 @@ const easterEggVisitors = [
   {
     name: "GPT-6",
     title: "GPT-6 到此一游",
-    body: "少画几个框，多留一点位置给内容。",
+    body: "GPT-6 · 留个签名，继续上网。",
   },
   {
     name: "SOL",
@@ -427,7 +427,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="mn-shell">
+  <div class="mn-shell" :data-active-tab="activeTab">
     <header class="mn-command-bar">
       <div class="mn-brand-lockup">
         <button
@@ -515,8 +515,11 @@ onUnmounted(() => {
       </div>
     </header>
 
+
     <section
+      v-if="activeTab !== 'control' || state.task || (state.hasKsu && state.phase === 'error') || state.backgroundTask.log"
       class="mn-runtime-brief"
+      :data-busy="!!state.task"
       :data-state="routeStackState"
       role="status"
       aria-live="polite"
@@ -563,7 +566,7 @@ onUnmounted(() => {
       </aside>
 
       <main class="mn-workspace-main">
-        <header class="mn-workspace-header">
+        <header v-if="activeTab !== 'control'" class="mn-workspace-header">
           <div>
             <h2>{{ activeWorkspace.label }}</h2>
             <p>{{ activeWorkspace.description }}</p>

--- a/webui/src/components/pages/ControlPage.vue
+++ b/webui/src/components/pages/ControlPage.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import {
+  ArrowUpRight,
+  ChevronDown,
   Copy,
   DownloadCloud,
   ExternalLink,
@@ -17,11 +19,9 @@ import {
 import { computed, nextTick, onMounted, ref } from "vue";
 import Badge from "@/components/ui/Badge.vue";
 import Button from "@/components/ui/Button.vue";
-import Card from "@/components/ui/Card.vue";
 import CardHeading from "@/components/ui/CardHeading.vue";
 import ConfirmPanel from "@/components/ui/ConfirmPanel.vue";
 import Input from "@/components/ui/Input.vue";
-import PageHeader from "@/components/ui/PageHeader.vue";
 import RemovableTag from "@/components/ui/RemovableTag.vue";
 import StatTile from "@/components/ui/StatTile.vue";
 import StatusDot from "@/components/ui/StatusDot.vue";
@@ -428,415 +428,356 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="grid gap-4 md:gap-5">
-    <PageHeader
-      overline="Control Center"
-      title="模块控制"
-      description="查看运行状态，启动、停止或切换透明代理模式。"
-    >
-      <template #actions>
-        <Button variant="outline" @click="emit('goto-tab', 'about')">流量路径</Button>
-        <Button variant="outline" @click="copyControlSnapshot"
-          ><Copy :size="17" />{{
-            snapshotCopied ? "已复制快照" : "复制快照"
-          }}</Button
-        >
-        <Badge :tone="singBoxStatus.tone">{{ singBoxStatus.label }}</Badge>
-      </template>
-    </PageHeader>
+  <div class="mn-control-page">
+    <div class="mn-control-layout">
+      <section class="mn-control-overview" aria-labelledby="mn-runtime-title">
+        <div class="mn-runtime-heading">
+          <div>
+            <p class="mn-control-eyebrow"><StatusDot :tone="state.runtime.singBoxState === 'sing-box' ? 'ok' : state.runtime.singBoxState === 'stopped' ? 'stop' : 'unknown'" />sing-box · 核心状态</p>
+            <h2 id="mn-runtime-title">{{ singBoxStatus.label }}</h2>
+          </div>
+          <Button variant="ghost" size="icon" :aria-label="snapshotCopied ? '已复制快照' : '复制状态快照'" @click="copyControlSnapshot">
+            <Copy :size="18" />
+          </Button>
+        </div>
 
-    <div class="grid grid-cols-1 gap-3 md:grid-cols-12 md:gap-4">
-      <Card
-        class="grid gap-4 !p-4 md:col-span-7 md:row-span-2 md:min-h-[22rem] md:!p-6"
-        :class="controlInsightTone(runtimeInsight.status)"
-      >
-        <div class="flex items-start justify-between gap-3">
-          <h3 class="max-w-xl break-words text-2xl font-semibold tracking-[-0.025em] md:text-3xl">
-            {{ runtimeInsight.title }}
-          </h3>
-          <StatusDot tone="current" />
-        </div>
-        <p class="my-auto max-w-xl break-words text-sm leading-7 md:text-[15px]">
-          {{ runtimeInsight.detail }}
-        </p>
-        <div class="flex flex-wrap items-start gap-2">
-          <Badge
-            v-for="item in runtimeInsight.actions"
-            :key="item"
-            tone="neutral"
-            >{{ item }}</Badge
-          >
-        </div>
-        <div v-if="missingNodeCache" class="grid gap-2">
-          <Button
-            variant="secondary"
-            :loading="isRunning('rebuild-node-cache')"
-            @click="rebuildNodeCache"
-            ><DownloadCloud :size="17" />更新订阅并重建节点</Button
-          >
-          <p class="text-xs leading-5">
-            会执行 <code>sub update sing-box</code>，成功后再启动 sing-box。
-          </p>
-        </div>
-      </Card>
+        <details class="mn-control-insight" :class="controlInsightTone(runtimeInsight.status)" :open="state.hasKsu && (runtimeInsight.status === 'danger' || state.phase === 'error')">
+          <summary><span>{{ runtimeInsight.title }}</span><ChevronDown :size="15" aria-hidden="true" /></summary>
+          <p>{{ runtimeInsight.detail }}</p>
+          <ul v-if="runtimeInsight.actions.length" class="mn-insight-actions">
+            <li v-for="item in runtimeInsight.actions" :key="item">{{ item }}</li>
+          </ul>
+          <div v-if="missingNodeCache" class="grid gap-2">
+            <Button variant="secondary" :loading="isRunning('rebuild-node-cache')" @click="rebuildNodeCache">
+              <DownloadCloud :size="17" />更新订阅并重建节点
+            </Button>
+            <p class="text-xs leading-5">会执行 <code>sub update sing-box</code>，成功后再启动 sing-box。</p>
+          </div>
+        </details>
 
-      <Card class="grid gap-3 !p-4 md:col-span-5 md:!p-6">
-        <CardHeading overline="sing-box" :title="singBoxStatus.label">
-          <span :class="['mt-1 size-3 rounded-full', singBoxStatus.dotClass]" />
-        </CardHeading>
-        <p class="text-sm leading-6 text-[var(--mn-ink-muted)]">
-          MagicNet 当前只运行 sing-box 核心。
-        </p>
-        <Button
-          :disabled="runtimeBusy"
-          :loading="isRunning('toggle-sing-box')"
-          class="w-full"
-          @click="toggleSingBox"
-        >
-          <Power :size="18" />
-          {{
-            state.runtime.singBoxState === "sing-box"
-              ? "停止 sing-box"
-              : "启动 sing-box"
-          }}
+        <Button class="mn-service-toggle" :disabled="runtimeBusy" :loading="isRunning('toggle-sing-box')" @click="toggleSingBox">
+          <Power :size="22" />
+          <span>{{ state.runtime.singBoxState === "sing-box" ? "停止 sing-box" : "启动 sing-box" }}</span>
+          <ArrowUpRight :size="19" aria-hidden="true" />
         </Button>
-      </Card>
 
-      <Card class="!p-4 md:col-span-5 md:!p-6">
-        <h3 class="text-lg font-semibold text-[var(--mn-ink)]">快捷操作</h3>
-        <div class="mt-3 grid grid-cols-2 gap-2 md:mt-4 md:grid-cols-1 xl:grid-cols-2">
-          <Button
-            variant="secondary"
-            :disabled="runtimeBusy"
-            :loading="isRunning('restart-sing-box')"
-            @click="requestDangerAction(restartSingBoxAction(), $event.currentTarget)"
-          >
-            <RotateCcw :size="17" />重启 sing-box
+        <div class="mn-service-actions" role="group" aria-label="服务操作">
+          <Button variant="ghost" :disabled="runtimeBusy" :loading="isRunning('restart-sing-box')" aria-label="重启 sing-box" @click="requestDangerAction(restartSingBoxAction(), $event.currentTarget)">
+            <RotateCcw :size="19" /><span>重启</span>
           </Button>
-          <Button
-            variant="secondary"
-            :disabled="runtimeBusy"
-            :loading="isRunning('apply-config')"
-            @click="requestDangerAction(applyConfigAction(), $event.currentTarget)"
-          >
-            <Save :size="17" />应用配置
+          <Button variant="ghost" :disabled="runtimeBusy" :loading="isRunning('apply-config')" @click="requestDangerAction(applyConfigAction(), $event.currentTarget)">
+            <Save :size="19" /><span>应用配置</span>
           </Button>
-          <Button
-            variant="secondary"
-            :disabled="runtimeBusy"
-            :loading="isRunning('repair')"
-            @click="requestDangerAction(repairAction(), $event.currentTarget)"
-          >
-            <Zap :size="17" />一键自修复
+          <Button variant="ghost" :disabled="runtimeBusy" :loading="isRunning('repair')" aria-label="一键自修复" @click="requestDangerAction(repairAction(), $event.currentTarget)">
+            <Zap :size="19" /><span>修复</span>
           </Button>
-          <Button
-            variant="secondary"
-            :disabled="runtimeBusy"
-            :loading="isRunning('stop-all')"
-            @click="requestDangerAction(stopAllServicesAction(), $event.currentTarget)"
-          >
-            <Unplug :size="17" />停止全部
-          </Button>
-        </div>
-      </Card>
-
-      <Card class="!p-4 md:col-span-4 md:!p-6">
-        <CardHeading
-          overline="sing-box WebUI"
-          title="核心控制入口"
-          description="进入 zashboard 管理节点与代理组，或直接检查 API 连通性。"
-        />
-        <div class="mt-5 grid gap-2">
-          <Button
-            variant="outline"
-            :loading="isRunning('open-zashboard')"
-            @click="
-              withAction('open-zashboard', () => openSingBoxUi('zashboard'))
-            "
-            ><ExternalLink :size="17" />zashboard</Button
-          >
-          <Button
-            variant="outline"
-            :loading="isRunning('api-groups')"
-            @click="
-              withAction('api-groups', () =>
-                runCli('api groups', '检查 sing-box API'),
-              )
-            "
-            ><ShieldCheck :size="17" />检查 API</Button
-          >
-        </div>
-      </Card>
-
-      <Card class="grid gap-4 !p-4 md:col-span-8 md:gap-5 md:!p-6">
-        <CardHeading
-          overline="透明代理模式"
-          :title="transparentModeLabel"
-          :description="transparentDescription"
-        >
-          <Badge :tone="transparentTransitionTone">
-            {{ state.runtime.transparentTransition }}
-          </Badge>
-        </CardHeading>
-
-        <div
-          role="group"
-          aria-label="选择透明代理模式"
-          class="grid grid-cols-2 gap-2"
-        >
-          <Button
-            :variant="state.runtime.transparentMode === 'tun' ? 'default' : 'outline'"
-            :disabled="transparentSwitchBusy || state.runtime.transparentMode === 'tun'"
-            :loading="isRunning('transparent-set-tun')"
-            :aria-pressed="state.runtime.transparentMode === 'tun'"
-            :class="state.runtime.transparentMode === 'tun' ? 'disabled:cursor-default disabled:opacity-100' : ''"
-            @click="requestTransparentMode('tun', $event)"
-          >
-            使用 TUN
-          </Button>
-          <Button
-            :variant="state.runtime.transparentMode === 'ebpf' ? 'default' : 'outline'"
-            :disabled="transparentSwitchBusy || state.runtime.transparentMode === 'ebpf'"
-            :loading="isRunning('transparent-set-ebpf')"
-            :aria-pressed="state.runtime.transparentMode === 'ebpf'"
-            :class="state.runtime.transparentMode === 'ebpf' ? 'disabled:cursor-default disabled:opacity-100' : ''"
-            @click="requestTransparentMode('ebpf', $event)"
-          >
-            使用 eBPF
+          <Button variant="ghost" :disabled="runtimeBusy" :loading="isRunning('stop-all')" @click="requestDangerAction(stopAllServicesAction(), $event.currentTarget)">
+            <Unplug :size="19" /><span>停止全部</span>
           </Button>
         </div>
 
-        <dl
-          aria-live="polite"
-          class="grid gap-x-4 gap-y-2 rounded-[var(--mn-radius-md)] border border-[var(--mn-border)] bg-[var(--mn-surface-sunken)] p-3 text-xs sm:grid-cols-2"
-        >
-          <div class="min-w-0">
-            <dt class="text-[var(--mn-ink-muted)]">configured</dt>
-            <dd class="break-words font-mono text-[var(--mn-ink)]">{{ state.runtime.transparentMode }}</dd>
-          </div>
-          <div class="min-w-0">
-            <dt class="text-[var(--mn-ink-muted)]">effective</dt>
-            <dd class="break-words font-mono text-[var(--mn-ink)]">{{ transparentEffectiveLabel }}</dd>
-          </div>
-          <div class="min-w-0">
-            <dt class="text-[var(--mn-ink-muted)]">local cgroup</dt>
-            <dd class="break-words font-mono text-[var(--mn-ink)]">{{ state.runtime.transparentLocalCgroup }}</dd>
-          </div>
-          <div class="min-w-0">
-            <dt class="text-[var(--mn-ink-muted)]">shared TC</dt>
-            <dd class="break-words font-mono text-[var(--mn-ink)]">{{ state.runtime.transparentSharedTc }}</dd>
-          </div>
-          <div class="min-w-0 sm:col-span-2">
-            <dt class="text-[var(--mn-ink-muted)]">shared interfaces</dt>
-            <dd class="break-all font-mono text-[var(--mn-ink)]">{{ sharedInterfacesLabel }}</dd>
-          </div>
-          <div class="min-w-0">
-            <dt class="text-[var(--mn-ink-muted)]">capability</dt>
-            <dd class="break-words font-mono text-[var(--mn-ink)]">{{ state.runtime.transparentCapability }}</dd>
-          </div>
-          <div class="min-w-0">
-            <dt class="text-[var(--mn-ink-muted)]">transition</dt>
-            <dd class="break-words font-mono text-[var(--mn-ink)]">{{ state.runtime.transparentTransition }}</dd>
-          </div>
-        </dl>
+      </section>
 
-        <p
-          v-if="state.runtime.transparentRecentError"
-          role="alert"
-          class="break-words border-l-2 border-[var(--mn-danger)] pl-3 text-xs leading-5 text-[var(--mn-danger)]"
-        >
-          {{ state.runtime.transparentRecentError }}
-        </p>
+      <section class="mn-control-settings" aria-labelledby="mn-network-settings-title">
+        <div class="mn-settings-heading">
+          <h3 id="mn-network-settings-title">网络设置</h3>
+          <Button variant="ghost" @click="emit('goto-tab', 'about')">流量路径<ArrowUpRight :size="15" /></Button>
+        </div>
 
-        <Button
-          variant="secondary"
-          :disabled="transparentSwitchBusy"
-          :loading="isRunning('transparent-apply')"
-          @click="requestDangerAction(applyTransparentModeAction(), $event.currentTarget)"
-        >
-          <Radar :size="17" />重新应用当前模式
-        </Button>
-      </Card>
+        <details class="mn-setting" data-setting="transparent">
+          <summary>
+            <Radar :size="21" aria-hidden="true" />
+            <span><strong>透明代理</strong><small>{{ state.runtime.transparentMode === "unknown" ? "等待设备读取" : `${transparentModeLabel} · ${state.runtime.transparentTransition}` }}</small></span>
+            <ChevronDown :size="17" class="mn-disclosure-arrow" aria-hidden="true" />
+          </summary>
+          <div class="mn-setting-body">
+            <CardHeading
+              overline="透明代理模式"
+              :title="transparentModeLabel"
+              :description="transparentDescription"
+            >
+              <Badge :tone="transparentTransitionTone">
+                {{ state.runtime.transparentTransition }}
+              </Badge>
+            </CardHeading>
 
-      <Card
-        class="grid gap-4 !p-4 md:col-span-12 md:!p-6"
-        :class="
-          hotspotProxyEnabled
-            ? 'border-[color-mix(in_srgb,var(--mn-cactus)_55%,transparent)] bg-[color-mix(in_srgb,var(--mn-cactus)_10%,var(--mn-ivory))]'
-            : ''
-        "
-        :aria-busy="hotspotPolicyPhase === 'loading'"
-      >
-        <label
-          :class="[
-            'flex flex-col gap-4 rounded-[var(--mn-radius-md)] p-1 sm:flex-row sm:items-center sm:justify-between',
-            hotspotPolicyPhase === 'ready' ? 'cursor-pointer' : 'cursor-default',
-          ]"
-        >
-          <span class="flex min-w-0 items-start gap-4">
-            <input
-              type="checkbox"
-              class="mt-1 size-7 shrink-0 accent-[var(--mn-cactus)]"
-              :checked="hotspotProxyEnabled"
-              :disabled="
-                hotspotPolicyPhase !== 'ready' ||
-                runtimeBusy ||
-                isRunning('hotspot-proxy')
-              "
-              aria-describedby="hotspot-proxy-description hotspot-proxy-status"
-              @change="toggleHotspotProxy"
-            />
-            <span class="min-w-0">
-              <span class="flex items-center gap-2 text-xl font-semibold tracking-[-0.03em]">
-                <Share2 :size="21" />允许热点使用代理
+            <div
+              role="group"
+              aria-label="选择透明代理模式"
+              class="grid grid-cols-2 gap-2"
+            >
+              <Button
+                :variant="state.runtime.transparentMode === 'tun' ? 'default' : 'outline'"
+                :disabled="transparentSwitchBusy || state.runtime.transparentMode === 'tun'"
+                :loading="isRunning('transparent-set-tun')"
+                :aria-pressed="state.runtime.transparentMode === 'tun'"
+                :class="state.runtime.transparentMode === 'tun' ? 'disabled:cursor-default disabled:opacity-100' : ''"
+                @click="requestTransparentMode('tun', $event)"
+              >
+                使用 TUN
+              </Button>
+              <Button
+                :variant="state.runtime.transparentMode === 'ebpf' ? 'default' : 'outline'"
+                :disabled="transparentSwitchBusy || state.runtime.transparentMode === 'ebpf'"
+                :loading="isRunning('transparent-set-ebpf')"
+                :aria-pressed="state.runtime.transparentMode === 'ebpf'"
+                :class="state.runtime.transparentMode === 'ebpf' ? 'disabled:cursor-default disabled:opacity-100' : ''"
+                @click="requestTransparentMode('ebpf', $event)"
+              >
+                使用 eBPF
+              </Button>
+            </div>
+
+            <dl
+              aria-live="polite"
+              class="grid gap-x-4 gap-y-2 rounded-[var(--mn-radius-md)] border border-[var(--mn-border)] bg-[var(--mn-surface-sunken)] p-3 text-xs sm:grid-cols-2"
+            >
+              <div class="min-w-0">
+                <dt class="text-[var(--mn-ink-muted)]">configured</dt>
+                <dd class="break-words font-mono text-[var(--mn-ink)]">{{ state.runtime.transparentMode }}</dd>
+              </div>
+              <div class="min-w-0">
+                <dt class="text-[var(--mn-ink-muted)]">effective</dt>
+                <dd class="break-words font-mono text-[var(--mn-ink)]">{{ transparentEffectiveLabel }}</dd>
+              </div>
+              <div class="min-w-0">
+                <dt class="text-[var(--mn-ink-muted)]">local cgroup</dt>
+                <dd class="break-words font-mono text-[var(--mn-ink)]">{{ state.runtime.transparentLocalCgroup }}</dd>
+              </div>
+              <div class="min-w-0">
+                <dt class="text-[var(--mn-ink-muted)]">shared TC</dt>
+                <dd class="break-words font-mono text-[var(--mn-ink)]">{{ state.runtime.transparentSharedTc }}</dd>
+              </div>
+              <div class="min-w-0 sm:col-span-2">
+                <dt class="text-[var(--mn-ink-muted)]">shared interfaces</dt>
+                <dd class="break-all font-mono text-[var(--mn-ink)]">{{ sharedInterfacesLabel }}</dd>
+              </div>
+              <div class="min-w-0">
+                <dt class="text-[var(--mn-ink-muted)]">capability</dt>
+                <dd class="break-words font-mono text-[var(--mn-ink)]">{{ state.runtime.transparentCapability }}</dd>
+              </div>
+              <div class="min-w-0">
+                <dt class="text-[var(--mn-ink-muted)]">transition</dt>
+                <dd class="break-words font-mono text-[var(--mn-ink)]">{{ state.runtime.transparentTransition }}</dd>
+              </div>
+            </dl>
+
+            <p
+              v-if="state.runtime.transparentRecentError"
+              role="alert"
+              class="break-words border-l-2 border-[var(--mn-danger)] pl-3 text-xs leading-5 text-[var(--mn-danger)]"
+            >
+              {{ state.runtime.transparentRecentError }}
+            </p>
+
+            <Button
+              variant="secondary"
+              :disabled="transparentSwitchBusy"
+              :loading="isRunning('transparent-apply')"
+              @click="requestDangerAction(applyTransparentModeAction(), $event.currentTarget)"
+            >
+              <Radar :size="17" />重新应用当前模式
+            </Button>
+
+          </div>
+        </details>
+        <p v-if="state.runtime.transparentRecentError" class="mn-setting-error" role="alert">{{ state.runtime.transparentRecentError }}</p>
+
+        <details class="mn-setting" data-setting="wifi">
+          <summary>
+            <Wifi :size="21" aria-hidden="true" />
+            <span><strong>Wi-Fi 策略</strong><small>{{ !state.hasKsu ? "等待设备读取" : state.wifiPolicy.enabled ? "已启用自动切换" : "自动切换已停用" }}</small></span>
+            <ChevronDown :size="17" class="mn-disclosure-arrow" aria-hidden="true" />
+          </summary>
+          <div class="mn-setting-body">
+            <CardHeading
+              overline="Wi-Fi 模式策略"
+              overline-tone="faint"
+              description="黑名单命中 SSID 或 BSSID 时切换为 Direct，离开 Wi-Fi 后自动恢复 Rule。白名单模式会让名单内 Wi-Fi 使用 Rule，其他 Wi-Fi 使用 Direct。"
+            >
+              <template #title>
+                <span class="inline-flex items-center gap-2"><Wifi :size="22" />按 Wi-Fi 自动切换</span>
+              </template>
+              <Badge :tone="state.wifiPolicy.connected ? 'success' : 'neutral'">
+                {{ state.wifiPolicy.connected ? state.wifiPolicy.ssid || "Wi-Fi 已连接" : "未连接 Wi-Fi" }}
+              </Badge>
+              <Badge :tone="state.wifiPolicy.enabled ? 'success' : 'warning'">
+                {{ state.wifiPolicy.enabled ? "已启用" : "已停用" }}
+              </Badge>
+              <Button
+                :loading="isRunning('wifi-toggle')"
+                :disabled="runtimeBusy"
+                @click="toggleWifiPolicy"
+              >
+                <Power :size="17" />{{ state.wifiPolicy.enabled ? "停用" : "启用" }}
+              </Button>
+            </CardHeading>
+
+            <div class="grid gap-3 md:grid-cols-2">
+              <button
+                v-for="mode in wifiPolicyModes"
+                :key="mode"
+                type="button"
+                :aria-pressed="state.wifiPolicy.policyMode === mode"
+                :disabled="runtimeBusy || state.wifiPolicy.policyMode === mode"
+                :class="[
+                  'rounded-[2px] border border-transparent px-4 py-3 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mn-focus)] disabled:cursor-default',
+                  state.wifiPolicy.policyMode === mode
+                    ? 'bg-[var(--mn-cactus)] text-[var(--mn-on-accent)]'
+                    : 'bg-[color-mix(in_srgb,var(--mn-ink)_5%,transparent)] text-[var(--mn-ink-soft)] hover:bg-[color-mix(in_srgb,var(--mn-ink)_8%,transparent)]',
+                ]"
+                @click="setWifiPolicyMode(mode)"
+              >
+                <span class="font-semibold">{{ mode === "blacklist" ? "黑名单" : "白名单" }}</span>
+                <span class="mt-1 block text-xs">
+                  {{ mode === "blacklist" ? "名单命中 → Direct" : "名单命中 → Rule" }}
+                </span>
+              </button>
+            </div>
+
+            <div class="grid gap-3 md:grid-cols-3">
+              <StatTile label="当前 BSSID" :value="state.wifiPolicy.bssid || '—'" />
+              <StatTile label="匹配结果" :value="state.wifiPolicy.matched ? '已命中名单' : '未命中'" />
+              <StatTile label="代理模式" :value="`${state.wifiPolicy.currentMode} → ${state.wifiPolicy.desiredMode}`" />
+            </div>
+
+            <div class="grid gap-5 lg:grid-cols-2">
+              <div class="grid gap-3">
+                <div class="flex gap-2">
+                  <Input
+                    v-model="wifiSsidInput"
+                    aria-label="Wi-Fi SSID"
+                    placeholder="输入完整 SSID，例如 Home WiFi"
+                    @keyup.enter="addWifiEntry('ssid')"
+                  />
+                  <Button
+                    variant="secondary"
+                    :loading="isRunning('wifi-add-ssid')"
+                    @click="addWifiEntry('ssid')"
+                  ><Plus :size="17" />SSID</Button>
+                </div>
+                <div class="flex flex-wrap gap-2">
+                  <span v-if="!state.wifiPolicy.ssids.length" class="mn-empty text-xs">还没有 SSID 条目</span>
+                  <RemovableTag
+                    v-for="ssid in state.wifiPolicy.ssids"
+                    :key="ssid"
+                    variant="soft"
+                    remove-variant="ghost"
+                    :remove-label="`移除 SSID ${ssid}`"
+                    @remove="removeWifiEntry('ssid', ssid)"
+                  >{{ ssid }}</RemovableTag>
+                </div>
+              </div>
+
+              <div class="grid gap-3">
+                <div class="flex gap-2">
+                  <Input
+                    v-model="wifiBssidInput"
+                    aria-label="Wi-Fi BSSID"
+                    placeholder="输入 BSSID，例如 aa:bb:cc:dd:ee:ff"
+                    @keyup.enter="addWifiEntry('bssid')"
+                  />
+                  <Button
+                    variant="secondary"
+                    :loading="isRunning('wifi-add-bssid')"
+                    @click="addWifiEntry('bssid')"
+                  ><Plus :size="17" />BSSID</Button>
+                </div>
+                <div class="flex flex-wrap gap-2">
+                  <span v-if="!state.wifiPolicy.bssids.length" class="mn-empty text-xs">还没有 BSSID 条目</span>
+                  <RemovableTag
+                    v-for="bssid in state.wifiPolicy.bssids"
+                    :key="bssid"
+                    class="font-mono"
+                    variant="soft"
+                    remove-variant="ghost"
+                    :remove-label="`移除 BSSID ${bssid}`"
+                    @remove="removeWifiEntry('bssid', bssid)"
+                  >{{ bssid }}</RemovableTag>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        </details>
+
+        <details class="mn-setting" data-setting="hotspot" :aria-busy="hotspotPolicyPhase === 'loading'">
+          <summary>
+            <Share2 :size="21" aria-hidden="true" />
+            <span><strong>热点策略</strong><small>{{ hotspotPolicyPhase === "loading" ? "正在读取" : hotspotPolicyPhase === "error" ? "读取失败 · 展开查看" : hotspotProxyEnabled ? "使用 Proxy 代理组" : "使用 Direct 直连" }}</small></span>
+            <ChevronDown :size="17" class="mn-disclosure-arrow" aria-hidden="true" />
+          </summary>
+          <div class="mn-setting-body">
+            <label
+              :class="[
+                'flex flex-col gap-4 rounded-[var(--mn-radius-md)] p-1 sm:flex-row sm:items-center sm:justify-between',
+                hotspotPolicyPhase === 'ready' ? 'cursor-pointer' : 'cursor-default',
+              ]"
+            >
+              <span class="flex min-w-0 items-start gap-4">
+                <input
+                  type="checkbox"
+                  class="mt-1 size-7 shrink-0 accent-[var(--mn-cactus)]"
+                  :checked="hotspotProxyEnabled"
+                  :disabled="
+                    hotspotPolicyPhase !== 'ready' ||
+                    runtimeBusy ||
+                    isRunning('hotspot-proxy')
+                  "
+                  aria-describedby="hotspot-proxy-description hotspot-proxy-status"
+                  @change="toggleHotspotProxy"
+                />
+                <span class="min-w-0">
+                  <span class="flex items-center gap-2 text-xl font-semibold tracking-[-0.03em]">
+                    <Share2 :size="21" />允许热点使用代理
+                  </span>
+                  <span
+                    id="hotspot-proxy-description"
+                    class="mt-2 block max-w-3xl text-sm leading-6 text-[var(--mn-ink-muted)]"
+                  >
+                    勾选后，连接本机热点的设备统一走 <code>proxy</code> 代理组；不勾选时统一走
+                    <code>direct</code>。Proxy 会关闭 Android 热点硬件加速以确保流量进入 TUN；关闭后恢复原设置。
+                  </span>
+                </span>
               </span>
               <span
-                id="hotspot-proxy-description"
-                class="mt-2 block max-w-3xl text-sm leading-6 text-[var(--mn-ink-muted)]"
+                id="hotspot-proxy-status"
+                class="flex shrink-0 items-center gap-2 pl-11 sm:pl-0"
               >
-                勾选后，连接本机热点的设备统一走 <code>proxy</code> 代理组；不勾选时统一走
-                <code>direct</code>。Proxy 会关闭 Android 热点硬件加速以确保流量进入 TUN；关闭后恢复原设置。
+                <Badge v-if="hotspotPolicyPhase === 'loading'" tone="neutral">读取中</Badge>
+                <Badge v-else-if="hotspotPolicyPhase === 'error'" tone="warning">读取失败</Badge>
+                <Badge v-else :tone="hotspotProxyEnabled ? 'success' : 'neutral'">
+                  {{ hotspotProxyEnabled ? "Proxy" : "Direct" }}
+                </Badge>
               </span>
-            </span>
-          </span>
-          <span
-            id="hotspot-proxy-status"
-            class="flex shrink-0 items-center gap-2 pl-11 sm:pl-0"
-          >
-            <Badge v-if="hotspotPolicyPhase === 'loading'" tone="neutral">读取中</Badge>
-            <Badge v-else-if="hotspotPolicyPhase === 'error'" tone="warning">读取失败</Badge>
-            <Badge v-else :tone="hotspotProxyEnabled ? 'success' : 'neutral'">
-              {{ hotspotProxyEnabled ? "Proxy" : "Direct" }}
-            </Badge>
-          </span>
-        </label>
-        <div
-          v-if="hotspotPolicyPhase === 'error'"
-          class="flex flex-col gap-3 rounded-[var(--mn-radius-md)] bg-[var(--mn-tone-warn-bg)] p-4 text-[var(--mn-warning)] shadow-[inset_0_0_0_1px_var(--mn-tone-warn-border)] sm:flex-row sm:items-center sm:justify-between"
-          role="alert"
-        >
-          <p class="text-sm leading-6">{{ hotspotPolicyError }}</p>
-          <Button
-            class="shrink-0"
-            variant="outline"
-            size="sm"
-            :loading="isRunning('hotspot-policy-refresh')"
-            @click="retryHotspotPolicy"
-          >
-            <RotateCcw :size="16" />重新读取
-          </Button>
-        </div>
-      </Card>
-
-      <Card class="grid gap-4 !p-4 md:col-span-12 md:gap-5 md:!p-6">
-        <CardHeading
-          overline="Wi-Fi 模式策略"
-          overline-tone="faint"
-          description="黑名单命中 SSID 或 BSSID 时切换为 Direct，离开 Wi-Fi 后自动恢复 Rule。白名单模式会让名单内 Wi-Fi 使用 Rule，其他 Wi-Fi 使用 Direct。"
-        >
-          <template #title>
-            <span class="inline-flex items-center gap-2"><Wifi :size="22" />按 Wi-Fi 自动切换</span>
-          </template>
-          <Badge :tone="state.wifiPolicy.connected ? 'success' : 'neutral'">
-            {{ state.wifiPolicy.connected ? state.wifiPolicy.ssid || "Wi-Fi 已连接" : "未连接 Wi-Fi" }}
-          </Badge>
-          <Badge :tone="state.wifiPolicy.enabled ? 'success' : 'warning'">
-            {{ state.wifiPolicy.enabled ? "已启用" : "已停用" }}
-          </Badge>
-          <Button
-            :loading="isRunning('wifi-toggle')"
-            :disabled="runtimeBusy"
-            @click="toggleWifiPolicy"
-          >
-            <Power :size="17" />{{ state.wifiPolicy.enabled ? "停用" : "启用" }}
-          </Button>
-        </CardHeading>
-
-        <div class="grid gap-3 md:grid-cols-2">
-          <button
-            v-for="mode in wifiPolicyModes"
-            :key="mode"
-            type="button"
-            :aria-pressed="state.wifiPolicy.policyMode === mode"
-            :disabled="runtimeBusy || state.wifiPolicy.policyMode === mode"
-            :class="[
-              'rounded-[2px] border border-transparent px-4 py-3 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mn-focus)] disabled:cursor-default',
-              state.wifiPolicy.policyMode === mode
-                ? 'bg-[var(--mn-cactus)] text-[var(--mn-on-accent)]'
-                : 'bg-[color-mix(in_srgb,var(--mn-ink)_5%,transparent)] text-[var(--mn-ink-soft)] hover:bg-[color-mix(in_srgb,var(--mn-ink)_8%,transparent)]',
-            ]"
-            @click="setWifiPolicyMode(mode)"
-          >
-            <span class="font-semibold">{{ mode === "blacklist" ? "黑名单" : "白名单" }}</span>
-            <span class="mt-1 block text-xs">
-              {{ mode === "blacklist" ? "名单命中 → Direct" : "名单命中 → Rule" }}
-            </span>
-          </button>
-        </div>
-
-        <div class="grid gap-3 md:grid-cols-3">
-          <StatTile label="当前 BSSID" :value="state.wifiPolicy.bssid || '—'" />
-          <StatTile label="匹配结果" :value="state.wifiPolicy.matched ? '已命中名单' : '未命中'" />
-          <StatTile label="代理模式" :value="`${state.wifiPolicy.currentMode} → ${state.wifiPolicy.desiredMode}`" />
-        </div>
-
-        <div class="grid gap-5 lg:grid-cols-2">
-          <div class="grid gap-3">
-            <div class="flex gap-2">
-              <Input
-                v-model="wifiSsidInput"
-                aria-label="Wi-Fi SSID"
-                placeholder="输入完整 SSID，例如 Home WiFi"
-                @keyup.enter="addWifiEntry('ssid')"
-              />
+            </label>
+            <div
+              v-if="hotspotPolicyPhase === 'error'"
+              class="flex flex-col gap-3 rounded-[var(--mn-radius-md)] bg-[var(--mn-tone-warn-bg)] p-4 text-[var(--mn-warning)] shadow-[inset_0_0_0_1px_var(--mn-tone-warn-border)] sm:flex-row sm:items-center sm:justify-between"
+              role="alert"
+            >
+              <p class="text-sm leading-6">{{ hotspotPolicyError }}</p>
               <Button
-                variant="secondary"
-                :loading="isRunning('wifi-add-ssid')"
-                @click="addWifiEntry('ssid')"
-              ><Plus :size="17" />SSID</Button>
+                class="shrink-0"
+                variant="outline"
+                size="sm"
+                :loading="isRunning('hotspot-policy-refresh')"
+                @click="retryHotspotPolicy"
+              >
+                <RotateCcw :size="16" />重新读取
+              </Button>
             </div>
-            <div class="flex flex-wrap gap-2">
-              <span v-if="!state.wifiPolicy.ssids.length" class="mn-empty text-xs">还没有 SSID 条目</span>
-              <RemovableTag
-                v-for="ssid in state.wifiPolicy.ssids"
-                :key="ssid"
-                variant="soft"
-                remove-variant="ghost"
-                :remove-label="`移除 SSID ${ssid}`"
-                @remove="removeWifiEntry('ssid', ssid)"
-              >{{ ssid }}</RemovableTag>
-            </div>
-          </div>
 
-          <div class="grid gap-3">
-            <div class="flex gap-2">
-              <Input
-                v-model="wifiBssidInput"
-                aria-label="Wi-Fi BSSID"
-                placeholder="输入 BSSID，例如 aa:bb:cc:dd:ee:ff"
-                @keyup.enter="addWifiEntry('bssid')"
-              />
-              <Button
-                variant="secondary"
-                :loading="isRunning('wifi-add-bssid')"
-                @click="addWifiEntry('bssid')"
-              ><Plus :size="17" />BSSID</Button>
-            </div>
-            <div class="flex flex-wrap gap-2">
-              <span v-if="!state.wifiPolicy.bssids.length" class="mn-empty text-xs">还没有 BSSID 条目</span>
-              <RemovableTag
-                v-for="bssid in state.wifiPolicy.bssids"
-                :key="bssid"
-                class="font-mono"
-                variant="soft"
-                remove-variant="ghost"
-                :remove-label="`移除 BSSID ${bssid}`"
-                @remove="removeWifiEntry('bssid', bssid)"
-              >{{ bssid }}</RemovableTag>
-            </div>
           </div>
+        </details>
+
+        <div class="mn-panel-entry">
+          <Button variant="ghost" class="mn-panel-entry-link" :loading="isRunning('open-zashboard')" @click="withAction('open-zashboard', () => openSingBoxUi('zashboard'))">
+            <span><strong>节点与代理组</strong><small>在 zashboard 中管理</small></span><ExternalLink :size="19" />
+          </Button>
+          <Button variant="ghost" :loading="isRunning('api-groups')" @click="withAction('api-groups', () => runCli('api groups', '检查 sing-box API'))"><ShieldCheck :size="16" />检查 API</Button>
         </div>
-      </Card>
+      </section>
     </div>
 
     <div v-if="pendingDangerAction" ref="dangerConfirmCard" tabindex="-1">

--- a/webui/src/console.css
+++ b/webui/src/console.css
@@ -1,301 +1,237 @@
-/* Quiet Console chrome: keep the page task, not its container, prominent. */
-.mn-page-header {
-  min-width: 0;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 16px;
-  padding-block: 8px;
+/* Warm neutral surfaces, ink controls, and a single terracotta interaction accent.
+   This replaces the previous console refinements; page data and status tones stay shared. */
+:root,
+html[data-theme="light"] {
+  --mn-ink: #292b27;
+  --mn-ink-soft: #484b44;
+  --mn-ink-muted: #696e64;
+  --mn-ink-faint: #7d8377;
+  --mn-ivory: #f4f4ef;
+  --mn-carrier: #eceee6;
+  --mn-carrier-deep: #e1e5da;
+  --mn-primary: #b3462b;
+  --mn-primary-strong: #913820;
+  --mn-surface: #f4f4ef;
+  --mn-surface-raised: #fdfdf9;
+  --mn-surface-sunken: #eceee6;
+  --mn-surface-input: #fdfdf9;
+  --mn-border: #d9ddd2;
+  --mn-border-strong: #a4ac9b;
+  --mn-focus: #b3462b;
+  --mn-success: #37664a;
+  --mn-warning: #85611e;
+  --mn-danger: #b73535;
+  --mn-info: #3e6580;
+  --mn-on-accent: #ffffff;
+  --mn-material: #fdfdf9;
+  --mn-material-heavy: #eceee6;
+  --mn-material-edge: #ffffff;
+  --mn-code-bg: #232820;
+  --mn-shadow-card: none;
+  --mn-shadow-float: 0 18px 56px rgb(30 36 24 / 16%);
+  --mn-radius-sm: 6px;
+  --mn-radius-md: 10px;
+  --mn-radius-lg: 14px;
+  --mn-control-ink: #30392d;
+  --mn-control-text: #f9faf4;
 }
 
-.mn-page-header > div:first-child {
-  flex: 1 1 24rem;
-  overflow-wrap: anywhere;
+html[data-theme="dark"] {
+  --mn-ink: #ecede6;
+  --mn-ink-soft: #ced2c5;
+  --mn-ink-muted: #a7afa0;
+  --mn-ink-faint: #939c8a;
+  --mn-ivory: #171b16;
+  --mn-carrier: #20261e;
+  --mn-carrier-deep: #30392c;
+  --mn-primary: #f0a181;
+  --mn-primary-strong: #ffc5a9;
+  --mn-surface: #171b16;
+  --mn-surface-raised: #20261e;
+  --mn-surface-sunken: #1b2119;
+  --mn-surface-input: #1b2119;
+  --mn-border: #353e30;
+  --mn-border-strong: #68775e;
+  --mn-focus: #f0a181;
+  --mn-success: #9fc49d;
+  --mn-warning: #d7b977;
+  --mn-danger: #f39b96;
+  --mn-info: #99bed3;
+  --mn-on-accent: #30190f;
+  --mn-material: #20261e;
+  --mn-material-heavy: #30392c;
+  --mn-material-edge: #353e30;
+  --mn-code-bg: #10160e;
+  --mn-shadow-float: 0 18px 56px rgb(0 0 0 / 40%);
+  --mn-control-ink: #e0e7d5;
+  --mn-control-text: #232b1d;
 }
 
-.mn-page-header > .mn-page-actions {
-  flex: 0 1 auto;
-  align-self: center;
-  margin: 0;
+.mn-shell { max-width: 1240px; padding-inline: 24px; }
+.mn-command-bar {
+  min-height: 76px;
+  margin-inline: -24px;
+  padding: 14px 24px;
+  border: 0;
+  background: var(--mn-ivory);
 }
-
-.page-surface > .grid > * {
-  min-width: 0;
-}
-
+.mn-brand-lockup { gap: 9px; }
+.mn-brand-mark { border: 0; border-radius: 8px; background: transparent; }
+.mn-brand-mark img { width: 32px; height: 32px; border-radius: 6px; }
+.mn-brand-copy h1 { font-size: 18px; letter-spacing: -0.035em; }
+.mn-brand-copy > p { display: none; }
+.mn-global-actions { gap: 0; }
+.mn-global-actions > .mn-button { border-color: transparent; }
+.mn-workspace-frame { margin-top: 12px; }
 .mn-workspace-header {
-  margin-bottom: 20px;
+  top: 76px;
   padding: 0;
+  margin-bottom: 24px;
   border: 0;
   border-radius: 0;
   background: var(--mn-ivory);
   box-shadow: none;
   contain: none;
 }
-
-.mn-workspace-header > div:first-child {
-  display: none;
-}
-
-.mn-section-tabs {
-  width: 100%;
-  gap: 20px;
-  margin: 0;
-  padding: 4px;
-  border: 0;
-  border-bottom: 1px solid var(--mn-border);
-}
-
-.mn-section-tabs button {
-  min-height: 44px;
-  padding: 8px 2px;
-}
-
-.mn-runtime-brief,
-.magic-card {
-  box-shadow: none;
-}
-
-/* Preserve the observed status color without filling the whole workspace. */
-.magic-card.mn-tone-ok,
-.magic-card.mn-tone-warn,
-.magic-card.mn-tone-danger,
-.magic-card.mn-tone-info {
-  border-color: var(--mn-border);
-  border-inline-start: 3px solid var(--mn-current-tone-ink);
-  background: var(--mn-surface-raised);
-}
-
-.magic-card[class*="mn-tone-"] > p {
-  color: var(--mn-ink-soft);
-}
-
-.mn-button {
-  white-space: normal;
-  overflow-wrap: anywhere;
-  text-align: center;
-}
-
-.mn-button svg {
-  flex-shrink: 0;
-}
-
-.mobile-nav {
-  gap: 8px;
-  padding-inline: 12px;
-}
-
-@media (min-width: 900px) {
-  .mn-shell {
-    padding: 24px 32px 32px;
-  }
-
-  .mn-command-bar {
-    padding: 0 0 20px;
-    border: 0;
-    border-bottom: 1px solid var(--mn-border);
-    border-radius: 0;
-    background: transparent;
-  }
-
-  .mn-runtime-brief {
-    margin-block: 16px 24px;
-  }
-
-  .mn-workspace-frame {
-    gap: 28px;
-    margin-top: 0;
-  }
-
-  .desktop-rail {
-    padding: 0;
-    border: 0;
-    background: transparent;
-    box-shadow: none;
-  }
-
-  .desktop-rail nav button {
-    min-height: 48px;
-    padding: 12px;
-  }
-
-  .mn-rail-foot {
-    margin-top: 24px;
-  }
-}
-
-@media (max-width: 639px) {
-  .mn-shell {
-    padding-inline: 16px;
-  }
-
-  .mn-command-bar {
-    margin-inline: -16px;
-    padding-inline: 16px;
-  }
-
-  .mn-page-header {
-    gap: 12px;
-    padding-block: 0 4px;
-  }
-
-  .mn-runtime-brief {
-    grid-template-columns: minmax(0, 1fr) auto auto;
-    column-gap: 8px;
-  }
-
-  .mn-runtime-brief > p {
-    grid-column: 1 / -1;
-    grid-row: 2;
-    white-space: normal;
-    overflow-wrap: anywhere;
-  }
-}
-
-@media (forced-colors: active) {
-  .mn-section-tabs button.is-active {
-    border-bottom-color: Highlight;
-  }
-
-  .magic-card[class*="mn-tone-"] {
-    border-inline-start-color: CanvasText;
-  }
-}
-
-/* Mobile settings: quiet chrome and continuous sections, not a card dashboard. */
-.mn-shell { --mn-ivory: var(--mn-surface-raised); background: var(--mn-ivory); }
-.mn-command-bar { min-height: 60px; }
-.mn-brand-mark { border: 0; background: transparent; }
-.mn-brand-copy > p { display: none; }
-.mn-brand-mark img { width: 32px; height: 32px; }
-.mn-global-actions > .mn-button { border-color: transparent; }
-.mn-runtime-brief {
+.mn-workspace-header > div:first-child { display: none; }
+.mn-section-tabs { width: 100%; gap: 24px; margin: 0; padding: 0; border: 0; border-bottom: 1px solid var(--mn-border); }
+.mn-section-tabs button { min-height: 48px; padding: 8px 0; font-size: 0.875rem; font-weight: 500; }
+.mn-section-tabs button.is-active { font-weight: 650; }
+.mn-page-header {
+  min-width: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: 6px 12px;
-  margin-block: 0 16px;
-  padding: 12px 0;
-  border: 0;
-  border-bottom: 1px solid var(--mn-border);
-  border-radius: 0;
-  background: transparent;
-}
-.mn-runtime-brief > p { flex: 1 1 8rem; white-space: normal; overflow: visible; }
-.mn-runtime-brief[data-state] { border-inline-start: 0; }
-.mn-runtime-mode { border: 0; background: transparent; padding: 0; }
-.mn-page-header h2 { font-size: 1.25rem; }
-.mn-page-header p { margin-top: 4px; }
-.mn-page-actions { gap: 4px 12px; }
-.mn-page-actions > .mn-button { padding-inline: 0; border-color: transparent; }
-.mn-page-actions > span { padding-inline: 0; border: 0; background: transparent; }
-.mn-workspace-header { margin-bottom: 12px; }
-.mn-section-tabs { gap: 24px; padding-inline: 0; }
-.mn-section-tabs button { font-weight: 500; }
-.mn-section-tabs button.is-active { font-weight: 650; }
-
-/* Scope structural rules to the run page; editors and other page grids stay intact. */
-.page-surface[data-page="control"] > .grid > .grid {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-.page-surface[data-page="control"] > .grid > .grid > .magic-card {
-  min-height: 0;
-  border: 0;
-  border-top: 1px solid var(--mn-border);
-  border-radius: 0;
-  background: transparent;
-}
-.page-surface[data-page="control"] .magic-card h3 { font-size: 1rem; line-height: 1.5; }
-.page-surface[data-page="control"] .magic-card[class*="mn-tone-"] { gap: 8px; }
-.page-surface[data-page="control"] .magic-card[class*="mn-tone-"] > p { line-height: 1.6; }
-.page-surface[data-page="control"] .magic-card[class*="mn-tone-"] > .flex > span {
-  border: 0;
-  padding: 0;
-  background: transparent;
-  font-weight: 400;
-}
-.page-surface[data-page="control"] > .grid > .grid > .magic-card:nth-child(2) {
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   align-items: center;
+  justify-content: space-between;
+  gap: 12px 24px;
+  padding-block: 8px;
 }
-.page-surface[data-page="control"] > .grid > .grid > .magic-card:nth-child(2) > p {
-  grid-column: 1 / -1;
-  grid-row: 2;
-}
-.page-surface[data-page="control"] > .grid > .grid > .magic-card:nth-child(2) > .mn-button {
-  grid-column: 2;
-  grid-row: 1;
-  width: auto;
-  justify-self: end;
-  min-width: 0;
-  max-width: 100%;
-}
-.page-surface[data-page="control"] > .grid > .grid > .magic-card:nth-child(3) .mn-button {
-  justify-content: flex-start;
-  padding-inline: 0;
-  border-color: transparent;
-  background: transparent;
-}
-.mn-utility-sheet {
-  max-height: calc(100dvh - env(safe-area-inset-top) - 16px);
-  overflow-y: auto;
-  overscroll-behavior: contain;
-}
-.mn-utility-grid { grid-template-columns: minmax(0, 1fr); gap: 0; }
-.mn-utility-grid > .mn-button {
-  min-height: 52px;
-  justify-content: flex-start;
-  border: 0;
-  border-top: 1px solid var(--mn-border);
-  border-radius: 0;
-}
-.mn-easter-egg {
-  max-height: calc(100dvh - 160px - env(safe-area-inset-bottom));
-  overflow-y: auto;
-  border-color: var(--mn-border);
-}
-.mn-easter-copy { min-width: 0; overflow-wrap: anywhere; }
-.mn-visitor-line { flex-wrap: wrap; }
-
-@media (max-width: 899px) {
-  .mn-shell { padding-bottom: calc(112px + env(safe-area-inset-bottom)); }
-  .mn-command-bar { gap: 4px; }
-  .mn-global-actions { gap: 2px; }
-  .mn-workspace-frame { margin-top: 0; }
-  .mn-page-header { gap: 4px; }
-  .mn-page-header > div:first-child { flex-basis: auto; }
-  .mobile-nav { padding-inline: max(12px, env(safe-area-inset-left)) max(12px, env(safe-area-inset-right)); }
-  .mobile-nav button { border-radius: 0; border-top: 2px solid transparent; }
-  .mobile-nav button.mn-nav-active {
-    border-color: transparent !important;
-    border-top-color: var(--mn-primary) !important;
-    background: transparent !important;
-  }
-  .mn-easter-egg { bottom: calc(96px + env(safe-area-inset-bottom)); }
-}
-@media (max-width: 359px) {
-  .mn-brand-lockup { gap: 6px; }
-  .mn-brand-copy h1 { font-size: 1rem; }
-  .mn-section-tabs { gap: 12px; }
-}
-@media (forced-colors: active) {
-  .mobile-nav button.mn-nav-active { border-top-color: Highlight !important; }
-  .mn-utility-grid > .mn-button { border-color: ButtonText; }
-}
-
-/* Match the layer of existing !p-* utilities instead of escalating every rule. */
-@layer utilities {
-  .page-surface[data-page="control"] > .grid > .grid > .magic-card { padding: 16px 0 !important; }
-}
-.page-surface[data-page="control"] .mn-page-header p,
-.page-surface[data-page="control"] .mn-page-actions > span { display: none; }
-
-/* Intrinsic form widths must not force a wider page when text is enlarged. */
+.mn-page-header > div:first-child { flex: 1 1 20rem; overflow-wrap: anywhere; }
+.mn-page-header > .mn-page-actions { flex: 0 1 auto; margin: 0; }
+.mn-page-header h2 { letter-spacing: -0.04em; }
+.mn-button { white-space: normal; overflow-wrap: anywhere; text-align: center; }
+.mn-button svg { flex-shrink: 0; }
 .page-surface :where(.grid, .flex) > * { min-width: 0; }
 .page-surface :where(input, select, textarea) { max-width: 100%; }
 .page-surface :where(p, code, dd) { overflow-wrap: anywhere; }
 .page-surface .mn-segmented { flex-wrap: wrap; }
 .page-surface[data-page="health"] .magic-card > .flex > .flex,
 .page-surface[data-page="tools"] .magic-card > .flex { flex-wrap: wrap; }
+.magic-card[class*="mn-tone-"] { border-color: var(--mn-border); border-inline-start: 3px solid var(--mn-current-tone-ink); background: var(--mn-surface-raised); }
+.magic-card[class*="mn-tone-"] > p { color: var(--mn-ink-soft); }
+
+/* The control page has one leading status, one primary control, then disclosures.
+   Explicit component classes keep runtime conditions from changing layout semantics. */
+.page-surface[data-page="control"] { padding-top: 10px; }
+.mn-control-page { min-width: 0; }
+.mn-control-layout { display: grid; gap: 32px; }
+.mn-control-overview { min-width: 0; }
+.mn-runtime-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
+.mn-control-eyebrow { display: flex; align-items: center; gap: 9px; margin: 0 0 16px; color: var(--mn-ink-muted); font-size: 0.75rem; font-weight: 500; }
+.mn-control-eyebrow > span { width: 7px; height: 7px; box-shadow: none; }
+.mn-runtime-heading h2 { margin: 0; font-size: clamp(2.1rem, 9vw, 3.1rem); line-height: 1.2; font-weight: 600; letter-spacing: -0.055em; overflow-wrap: anywhere; }
+.mn-runtime-heading > .mn-button { margin-top: -12px; }
+.mn-control-insight { margin-block: 12px 16px; border: 0; background: transparent; }
+.mn-control-insight > summary { display: flex; min-height: 44px; align-items: center; justify-content: space-between; gap: 12px; color: var(--mn-current-tone-ink); font-size: 0.8125rem; font-weight: 500; cursor: pointer; list-style: none; }
+.mn-control-insight > summary::-webkit-details-marker { display: none; }
+.mn-control-insight > summary:focus-visible { outline: 2px solid var(--mn-focus); outline-offset: 4px; }
+.mn-control-insight[open] > summary svg { transform: rotate(180deg); }
+.mn-control-insight > p { margin: 4px 0 12px; color: var(--mn-ink-muted); font-size: 0.8125rem; line-height: 1.8; }
+.mn-insight-actions { display: flex; flex-wrap: wrap; gap: 4px 16px; margin: 0; padding: 0; list-style: none; color: var(--mn-ink-muted); font-size: 0.75rem; line-height: 1.7; }
+.mn-insight-actions li::before { content: "↳"; margin-inline-end: 5px; color: var(--mn-ink-faint); }
+.mn-service-toggle { width: 100%; min-height: 60px; padding: 14px 18px; border-color: var(--mn-control-ink); background: var(--mn-control-ink); color: var(--mn-control-text); border-radius: 12px; }
+.mn-service-toggle:hover { border-color: var(--mn-control-ink); background: var(--mn-control-ink); filter: brightness(1.12); }
+.mn-service-toggle > span { display: flex; width: 100%; justify-content: flex-start; gap: 14px; }
+.mn-service-toggle > span > span { flex: 1; text-align: left; font-size: 0.9375rem; font-weight: 500; }
+.mn-service-toggle > span > svg:last-child { opacity: 0.6; }
+.mn-service-actions { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 4px; margin-top: 12px; }
+.mn-service-actions .mn-button { min-height: 72px; padding: 10px 2px; border: 0; background: transparent; color: var(--mn-ink-soft); }
+.mn-service-actions .mn-button > span { flex-direction: column; gap: 9px; font-size: 0.6875rem; font-weight: 500; }
+.mn-service-actions .mn-button:hover { background: var(--mn-carrier); }
+.mn-control-settings { min-width: 0; }
+.mn-settings-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 8px; }
+.mn-settings-heading h3 { margin: 0; font-size: 0.75rem; font-weight: 500; color: var(--mn-ink-muted); }
+.mn-settings-heading .mn-button { padding-inline: 0; color: var(--mn-primary-strong); font-size: 0.75rem; font-weight: 500; }
+.mn-setting { min-width: 0; border-bottom: 1px solid var(--mn-border); }
+.mn-setting > summary { display: flex; min-height: 76px; align-items: center; gap: 16px; padding: 16px 0; list-style: none; cursor: pointer; border-radius: 6px; }
+.mn-setting > summary::-webkit-details-marker { display: none; }
+.mn-setting > summary::marker { content: ""; }
+.mn-setting > summary > svg:first-child { flex-shrink: 0; color: var(--mn-ink-soft); }
+.mn-setting > summary > span { flex: 1; min-width: 0; overflow-wrap: anywhere; }
+.mn-setting strong { display: block; font-size: 0.9375rem; font-weight: 550; }
+.mn-setting small { display: block; margin-top: 4px; color: var(--mn-ink-muted); font-size: 0.6875rem; line-height: 1.5; }
+.mn-disclosure-arrow { flex-shrink: 0; color: var(--mn-ink-faint); transition: transform 160ms ease; }
+.mn-setting[open] > summary .mn-disclosure-arrow { transform: rotate(180deg); }
+.mn-setting > summary:hover { background: var(--mn-carrier); }
+.mn-setting > summary:focus-visible { outline: 2px solid var(--mn-focus); outline-offset: 4px; }
+.mn-setting-body { display: grid; min-width: 0; gap: 16px; padding: 10px 0 24px; }
+.mn-setting-body .mn-card-title { font-size: 1rem; }
+.mn-setting-error { margin: 10px 0; padding-inline-start: 12px; border-inline-start: 2px solid var(--mn-danger); color: var(--mn-danger); font-size: 0.8125rem; }
+.mn-panel-entry { display: grid; gap: 4px; margin-top: 24px; padding: 8px 12px; border: 1px solid var(--mn-border); border-radius: 12px; background: var(--mn-surface-raised); }
+.mn-panel-entry-link { min-height: 70px; justify-content: flex-start; padding: 6px 4px; border: 0; }
+.mn-panel-entry-link > span { width: 100%; justify-content: space-between; text-align: left; }
+.mn-panel-entry-link strong { display: block; font-size: 0.875rem; font-weight: 550; }
+.mn-panel-entry-link small { display: block; margin-top: 6px; color: var(--mn-ink-muted); font-size: 0.6875rem; font-weight: 400; }
+.mn-panel-entry > .mn-button:last-child { justify-self: start; padding-inline: 4px; font-size: 0.75rem; font-weight: 400; }
+
+/* Global operation feedback is kept in document flow, including on the home page. */
+.mn-runtime-brief { display: flex; flex-wrap: wrap; gap: 8px 12px; margin-block: 12px 20px; padding: 14px 0; border: 0; border-top: 1px solid var(--mn-border); border-radius: 0; background: transparent; box-shadow: none; }
+.mn-runtime-brief[data-state] { border-inline-start: 0; }
+.mn-runtime-brief > p { flex: 1 1 10rem; white-space: normal; overflow: visible; overflow-wrap: anywhere; }
+.mn-runtime-state strong { white-space: normal; font-size: 0.75rem; font-weight: 500; }
+.mn-runtime-mode { border: 0; background: transparent; font-weight: 400; }
+.mn-runtime-brief:has(button) { position: sticky; bottom: calc(86px + env(safe-area-inset-bottom)); z-index: 25; background: var(--mn-ivory); }
+.mn-utility-sheet { max-height: calc(100dvh - env(safe-area-inset-top) - 16px); overflow-y: auto; overscroll-behavior: contain; padding-inline: 24px; border-radius: 20px 20px 0 0; }
+.mn-utility-grid { grid-template-columns: minmax(0, 1fr); gap: 0; }
+.mn-utility-grid > .mn-button { min-height: 60px; justify-content: flex-start; border: 0; border-bottom: 1px solid var(--mn-border); border-radius: 0; font-weight: 500; }
+.mn-easter-egg { max-height: calc(100dvh - 160px - env(safe-area-inset-bottom)); overflow-y: auto; border-color: var(--mn-border); }
+
+/* The base navigation has important state colors. Override only those state
+   declarations; layout and all new page components use ordinary specificity. */
+.mobile-nav { gap: 8px; padding: 9px max(16px, env(safe-area-inset-right)) calc(9px + env(safe-area-inset-bottom)) max(16px, env(safe-area-inset-left)); background: var(--mn-ivory); }
+.mobile-nav button { position: relative; gap: 6px; }
+.mobile-nav button span { font-size: 0.6875rem; font-weight: 500; }
+.mobile-nav button.mn-nav-active { border-color: transparent !important; background: transparent !important; color: var(--mn-primary-strong) !important; }
+.mobile-nav button.mn-nav-active::after { content: ""; position: absolute; bottom: 0; width: 4px; height: 4px; border-radius: 50%; background: currentColor; }
+
+@media (max-width: 359px) {
+  .mn-shell { padding-inline: 18px; }
+  .mn-command-bar { margin-inline: -18px; padding-inline: 18px; }
+  .mn-brand-lockup { gap: 2px; }
+  .mn-brand-copy h1 { font-size: 16px; }
+  .mn-global-actions > .mn-button { width: 40px; }
+  .mn-section-tabs { gap: 16px; }
+}
+@media (max-width: 899px) {
+  .mn-shell { padding-bottom: calc(110px + env(safe-area-inset-bottom)); }
+  .mn-runtime-brief > p { grid-row: 2; white-space: normal; }
+}
+@media (min-width: 900px) {
+  .mn-shell { padding: 20px 36px 32px; }
+  .mn-command-bar { margin: 0; padding: 0 0 20px; border-radius: 0; border-bottom: 1px solid var(--mn-border); }
+  .mn-workspace-frame { grid-template-columns: 148px minmax(0, 1fr); gap: 48px; margin-top: 40px; }
+  .desktop-rail { padding: 0; border: 0; background: transparent; box-shadow: none; }
+  .desktop-rail nav { gap: 8px; }
+  .desktop-rail nav button { min-height: 48px; }
+  .mn-rail-label { margin-bottom: 12px; }
+  .mn-rail-foot { margin-top: 24px; line-height: 1.8; }
+  .mn-workspace-header { padding: 0; }
+  .mn-control-layout { grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr); gap: 44px; align-items: start; }
+  .mn-control-settings { padding-inline-start: 36px; border-inline-start: 1px solid var(--mn-border); }
+  .mn-control-insight { margin-block: 28px; }
+  .mn-runtime-brief:has(button) { bottom: 0; }
+}
+@media (prefers-contrast: more) {
+  :root, html[data-theme] { --mn-border: var(--mn-border-strong); }
+}
+@media (forced-colors: active) {
+  .mn-section-tabs button.is-active { border-bottom-color: Highlight; }
+  .mn-service-toggle, .mn-setting, .mn-panel-entry { border: 1px solid ButtonText; }
+  .mn-setting > summary:focus-visible { outline-color: Highlight; }
+  .mobile-nav button.mn-nav-active { outline: 2px solid Highlight; }
+}
+
+pre, .mn-code-block, code.mn-code-block, .mn-confirm-code { color: #edf0e7; }
+
+.mn-runtime-brief[data-busy="true"] { position: fixed; z-index: 35; right: 16px; bottom: calc(84px + env(safe-area-inset-bottom)); left: 16px; margin: 0; padding: 12px 16px; border: 1px solid var(--mn-border); border-radius: 12px; background: var(--mn-surface-raised); }
+@media (min-width: 900px) { .mn-runtime-brief[data-busy="true"] { right: 32px; bottom: 24px; left: auto; width: min(540px, calc(100vw - 64px)); } }


### PR DESCRIPTION
## 来源与范围

按用户要求应用上一轮评审包 `MagicNet-network-utility-review.zip` 中的 `MagicNet-network-utility.patch`。

这是叠加在 #153 上的独立 PR；#153 继续依赖 #152。当前没有合并任何 PR，也没有发布模块。选择原补丁基线，避免重复引入前两轮界面修改或覆盖主线。

- 原补丁基线：`ca988c8d4f3d544c0dc8f032853ba6db32500740`
- 本次提交：`ec04de02e4e654ef08480cc88a6136cb93cd485e`
- 修改 6 个文件，新增 640 行，删除 822 行，净减少 182 行。
- 六个文件与评审包 `changed-source/` **逐字节一致**；没有新增运行时依赖，没有更换 Logo，没有修改设备命令实现或透明代理模式约束。

## 界面改动

- 首页以单一运行状态、主启停按钮、四项维护操作建立层次，移除重复页面标题和卡片堆叠。
- 透明代理、Wi-Fi、热点使用原生 `details/summary` 展开设置；配置模式、生效模式、错误信息和操作入口保留。
- 应用暖灰背景、石墨绿服务按钮、陶土色交互标记；桌面采用控制区与设置区双列布局，手机保留四个工作区导航。
- 保留五次点击 Logo 的 GPT-6 彩蛋、原有模型轮播、危险操作确认、任务互斥、快照脱敏、菜单焦点管理和竖屏约束。
- 同步样式契约测试、布局测试与设计说明。设计文档继续标为 proposal，不把提交 PR 等同于审美认可。

## 本轮完整性校验

- 本地 `git apply --reverse --check`、`git apply --check`、`git diff --check` 通过。
- 对补丁还原的 6 个基线文件核对 Git blob SHA，正向应用后逐字节对照评审包源码。
- 远端按预期的六个新 blob SHA 重建得到同一代码树 `a284398614321181b307a16682125f94a746084b`。
- 远端按原始 blob SHA 反向还原得到原基线代码树 `c6add620475a38de4a7ccc3d3812fb23586063b3`。这同时确认了完整补丁被应用，且其他路径未改变。

## 本轮构建验证：WebUI CI 已通过

验证提交：`ec04de02e4e654ef08480cc88a6136cb93cd485e`。

GitHub Actions WebUI： https://github.com/LIghtJUNction/MagicNet/actions/runs/33947325382

`npm ci` 和 `npm run check` 均已成功。`check` 实际执行 `npm run test && npm run typecheck && npm run build`，涵盖项目测试、`tsc --noEmit` 和 Vite 构建。本次源码快照及新构建产物上传步骤也成功。完整检查于 2026-09-05 05:29:31 UTC 完成。

本地环境无法通过 DNS 直连 GitHub 拉取完整仓库，本轮完整构建实际在 GitHub Actions 的完整仓库中完成。没有以旧预览或语法解析替代本次构建结果。

## 验证边界

评审包中先前的 12 项源码检查、140 组设计稿浏览器检查属于上一轮记录，不冒充本轮重新执行的结果。此前 HTML 是旧构建叠加 DOM 重排的设计稿，不是本提交新源码的构建产物；本轮未对新的 CI 构建产物重跑浏览器布局检查。

最近一次检查时，Code Quality、Validate Kam Module、Build Kam Module 仍在运行；不能将 WebUI 构建通过表述为所有检查已通过。

Android / KernelSU 真机验证尚未完成；本 PR 不直接发布模块。

## Sourcery 摘要

重新设计 WebUI 网络控制界面，使其以运行状态和服务控制为核心，并将网络策略整理为清晰、易访问的设置区域。

新功能：
- 重构网络控制首页，突出显示 sing-box 运行状态、主要服务控制和维护操作。
- 将透明代理、Wi-Fi 策略和热点策略改为可展开的原生设置区域，同时保留现有配置和操作能力。

改进：
- 更新 WebUI 的整体视觉方向，采用暖灰色背景、石墨绿色服务控制和陶土色交互强调色，并优化桌面端双列布局与移动端导航布局。
- 保留现有状态反馈、危险操作确认、快照脱敏、任务互斥、品牌彩蛋和可访问性行为，同时减少首页中的重复信息和卡片堆叠。

文档：
- 将设计说明更新为第三版视觉提案，并明确说明该提案尚未获得审美审批。

测试：
- 更新布局和样式契约测试，覆盖主题对比度、原生设置展开区域、首页状态层级以及现有工作区访问能力。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重塑 WebUI 网络控制界面，使其以运行状态和服务控制为核心，并将网络策略整理为清晰、可访问的设置区。

New Features:
- 重构网络控制首页，突出 sing-box 运行状态、主服务控制和维护操作。
- 将透明代理、Wi-Fi 策略和热点策略改为可展开的原生设置区，并保留现有配置与操作能力。

Enhancements:
- 更新 WebUI 的整体视觉方向，采用暖灰背景、石墨绿服务控制和陶土色交互强调，并优化桌面双列与移动端导航布局。
- 保留现有状态反馈、危险操作确认、快照脱敏、任务互斥、品牌彩蛋和可访问性行为，同时减少首页重复信息与卡片堆叠。

Documentation:
- 将设计说明更新为第三版视觉提案，并明确其尚未获得审美审批。

Tests:
- 更新布局与样式契约测试，覆盖主题对比度、原生设置展开区、首页状态层级和既有工作区访问能力。

</details>