### PR TITLE
fix(ci): 恢复 bump 选项，自动创建版本与发布 PR

### DIFF
--- a/.github/workflows/README-CN.md
+++ b/.github/workflows/README-CN.md
@@ -22,20 +22,42 @@ kam check
 `exec.yml` 用于构建模块。触发方式包括 `push`、`pull_request` 和手动
 `workflow_dispatch`。
 
-新版本通过 PR 准备：同步更新 `kam.toml`、`src/MagicNet/module.prop` 和
-`update.json` 中的 `version` 和 `versionCode`。
-工作流构建已提交的版本，不会自行提交或向受保护分支推送版本变更。
+在 `main` 上手动运行工作流时，可通过 `bump` 自动准备版本 PR：
+
+| 输入 | 行为 |
+| --- | --- |
+| `none` | 构建当前已提交版本；勾选 `release` 可直接发布该版本 |
+| `patch` | 补丁号加一，例如 `v1.3.9` → `v1.3.10` |
+| `minor` | 次版本号加一并清零补丁号，例如 `v1.3.9` → `v1.4.0` |
+| `major` | 主版本号加一并清零其余两位，例如 `v1.3.9` → `v2.0.0` |
+
+选择升级时，工作流同步更新 `kam.toml`、`src/MagicNet/module.prop` 和
+`update.json`，将 `versionCode` 加一，然后创建版本 PR，本次运行不执行模块构建。
+同时勾选 `release` 会写入发布请求，PR 合并后自动构建并发布；`prerelease`
+也会保存在请求中，且要求同时勾选 `release`。仅升级版本的 PR 合并后只构建。
+
+同一目标版本使用固定的 `automation/release-vX.Y.Z` 分支，重复运行会更新
+同一个 PR；不要手动编辑该自动化分支。若主分支已前进，旧运行重跑会拒绝操作，
+请重新从 `main` 发起工作流。版本更新始终通过 PR，不直接推送受保护分支。
+
+自动创建 PR 使用内置 `GITHUB_TOKEN`，需要 `contents: write`、
+`pull-requests: write`（工作流已声明），以及仓库允许 Actions 创建 PR。
+若创建失败，检查原始错误与 `Settings → Actions → General → Allow GitHub Actions
+to create and approve pull requests`；工作流摘要提供恢复链接，不会自动修改设置。
+机器人创建的 PR 检查可能等待批准，请由有写权限的成员在 PR 页面批准并正常合并。
+工作流不会自动批准或合并 PR。
 
 审查后可通过两种方式发布：
 
-- 在版本 PR 中同时添加或更新 `.github/release-request`，内容为单行精确版本号，
+- 在版本 PR 中同时添加或更新 `.github/release-request`，首行为精确版本号，
   例如 `v1.3.9`。合并到 `main` 后，仅当该文件在本次 push 的 `before..sha`
   范围内发生变更时，才请求发布。文件会保留在仓库中；后续未修改它的 push
   不会重复请求发布。发布下一版时，将它更新为下一版的精确版本号。
-  旧的 `patch` 标记不再支持。
+  预发布可增加第二行 `prerelease=true`；省略时为正式发布。
+  旧的单行版本标记继续兼容，旧的 `patch` 标记不再支持。
 - 合并版本 PR 后，在 `main` 上手动运行 `exec.yml`，选择 `release=true`。
   手动发布时可选择 `prerelease=true`，将 Release 标记为预发布。
-  `bump` 输入已移除。
+  此时 `bump` 保持 `none`，且当前版本标签必须尚不存在。
 
 普通 push 和 pull request 只构建并上传 workflow artifact；如果存在
 `KAM_PRIVATE_KEY`，上传内容也会包含模块签名旁路文件。

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,22 +24,44 @@ top-level `kam.sh` when they exist.
 `exec.yml` builds the module. It runs on `push`, `pull_request`, and manual
 `workflow_dispatch`.
 
-Prepare a new version in a pull request: update `kam.toml`,
-`src/MagicNet/module.prop`, and `update.json` together, including `version` and
-`versionCode`. The workflow builds the committed
-version and never commits or pushes version changes to the protected branch.
+Dispatch on `main` with `bump=patch`, `minor`, or `major` to prepare a version PR.
+For example, `v1.3.9` becomes `v1.3.10`, `v1.4.0`, or `v2.0.0`, respectively.
+All three metadata files (`kam.toml`, `src/MagicNet/module.prop`, `update.json`)
+are updated together and `versionCode` increases by one. This run creates the PR
+without building the module. With `bump=none`, the workflow builds the existing
+committed version and can publish it when `release=true`.
+
+With a bump, `release=true` adds a release request so merging the PR builds and
+publishes it. `prerelease=true` is preserved in that request and requires
+`release=true`. A version-only PR builds without publishing after merge.
+
+Each target version uses a dedicated `automation/release-vX.Y.Z` branch. Repeated
+requests update the same PR; do not edit that generated branch manually. Reruns
+whose original commit is no longer the head of main fail and require a new
+dispatch. Version updates never push directly to the protected branch.
+
+PR creation uses `GITHUB_TOKEN` with job-scoped `contents: write` and
+`pull-requests: write`. The repository must allow Actions to create pull requests.
+On failure, inspect the original action error and Settings → Actions → General →
+Allow GitHub Actions to create and approve pull requests. The run summary offers
+a recovery link; repository settings are never changed automatically. Bot-created
+PR workflow runs may await approval by someone with write access. Approve pending
+runs on the PR page, review, and merge normally; this workflow does not approve
+or merge its own PRs.
 
 There are two ways to publish after review:
 
 - Include `.github/release-request` in the version PR, with the exact version
-  on one line, for example `v1.3.9`. Merging it into `main` requests a release
+  on the first line, for example `v1.3.9`. Merging it into `main` requests a release
   only when that file changed in the triggering push's `before..sha` range.
   The file remains in the repository; later pushes that leave it unchanged
   do not request another release. Update it to the next exact version for
-  the next release. The previous `patch` marker is no longer supported.
+  the next release. An optional second line, `prerelease=true`, requests a
+  prerelease. Single-line version markers remain supported; the previous `patch`
+  marker is no longer supported.
 - Merge the version PR, then dispatch `exec.yml` on `main` with `release=true`.
   Set `prerelease=true` to mark a manually requested release as a prerelease.
-  The `bump` input has been removed.
+  Keep `bump=none`; the committed version tag must not already exist.
 
 Pull requests and ordinary pushes build and upload workflow artifacts without
 publishing a release. When `KAM_PRIVATE_KEY` is available, the uploaded artifact

--- a/.github/workflows/exec.yml
+++ b/.github/workflows/exec.yml
@@ -3,8 +3,18 @@ name: Build Kam Module
 on:
   workflow_dispatch:
     inputs:
+      bump:
+        description: Prepare a version PR (merge it before publishing)
+        required: false
+        type: choice
+        options:
+          - none
+          - patch
+          - minor
+          - major
+        default: none
       release:
-        description: Create GitHub release and upload artifacts
+        description: Publish after the version PR merges, or publish current version with bump=none
         required: false
         type: boolean
         default: false
@@ -30,7 +40,72 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  version-pr:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.bump != 'none' && inputs.bump != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: magicnet-version-pr
+      cancel-in-progress: false
+    steps:
+      - name: Checkout release base
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Prepare version metadata
+        id: version
+        env:
+          BUMP_KIND: ${{ inputs.bump }}
+          RELEASE_INPUT: ${{ inputs.release }}
+          PRERELEASE_INPUT: ${{ inputs.prerelease }}
+        run: |
+          # Keep the original main checkout as the PR base. A detached checkout
+          # makes the PR action rebase with "theirs" onto a newer remote main.
+          git checkout -B main "$GITHUB_SHA"
+          python3 scripts/prepare-release.py --bump "$BUMP_KIND"
+
+      - name: Create version pull request
+        id: pr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          base: main
+          branch: automation/release-${{ steps.version.outputs.version }}
+          add-paths: |
+            kam.toml
+            src/MagicNet/module.prop
+            update.json
+            .github/release-request
+          commit-message: "chore(release): prepare ${{ steps.version.outputs.version }}"
+          title: "chore(release): prepare ${{ steps.version.outputs.version }}"
+          body: |
+            Prepares ${{ steps.version.outputs.version }} with synchronized module metadata.
+
+            Publish after merge: `${{ inputs.release }}`. Prerelease: `${{ inputs.prerelease }}`.
+            Review and merge this PR into main. Approve any pending workflow runs on the PR page.
+            This automation branch is regenerated when the same version is requested again; avoid editing it directly.
+
+      - name: Report version PR
+        if: ${{ always() && steps.version.outcome == 'success' }}
+        env:
+          PR_URL: ${{ steps.pr.outputs.pull-request-url }}
+          PR_OUTCOME: ${{ steps.pr.outcome }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if [ "$PR_OUTCOME" = success ] && [ -n "$PR_URL" ]; then
+            printf 'Version PR: %s\n\nApprove pending PR workflow runs, then review and merge.\n' "$PR_URL" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '::error::Version PR was not created. Check the action error and Settings > Actions > General > Allow GitHub Actions to create and approve pull requests, then rerun. Repository settings were not changed.'
+            printf 'Version PR creation failed. Recovery: %s/compare/main...automation/release-%s\n' "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" "$VERSION" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
   build:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.bump == 'none' || inputs.bump == '' }}
     runs-on: ubuntu-latest
     env:
       KAM_PRIVATE_KEY_AVAILABLE: ${{ secrets.KAM_PRIVATE_KEY != '' && '1' || '0' }}
@@ -50,6 +125,7 @@ jobs:
       - name: Validate release request
         env:
           RELEASE_INPUT: ${{ inputs.release }}
+          PRERELEASE_INPUT: ${{ inputs.prerelease }}
           PUSH_BEFORE: ${{ github.event.before }}
         run: python3 scripts/prepare-release.py
 
@@ -174,7 +250,7 @@ jobs:
         if: ${{ env.RELEASE_REQUESTED == '1' }}
         shell: bash
         env:
-          PRERELEASE_REQUESTED: ${{ inputs.prerelease }}
+          PRERELEASE_REQUESTED: ${{ env.RELEASE_PRERELEASE }}
         run: |
           set -euo pipefail
           git diff --exit-code HEAD -- kam.toml src/MagicNet/module.prop update.json

--- a/scripts/prepare-release.py
+++ b/scripts/prepare-release.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Validate committed metadata and resolve an explicit release request."""
 
+import argparse
 import json
 import os
 from pathlib import Path
@@ -13,7 +14,7 @@ def git(*args):
     return subprocess.check_output(["git", *args], text=True).strip()
 
 
-def prepare():
+def read_metadata():
     prop = tomllib.loads(Path("kam.toml").read_text())["prop"]
     module = dict(
         line.split("=", 1)
@@ -29,35 +30,110 @@ def prepare():
     for metadata in (module, update):
         if metadata["version"] != version or str(metadata["versionCode"]) != str(code):
             raise ValueError("Version metadata differs; update all three files in a PR")
+    return version, code
+
+
+def require_main_checkout():
+    if os.environ.get("GITHUB_REF") != "refs/heads/main":
+        raise ValueError("Releases must use main after the version PR is merged")
+    if git("rev-parse", "HEAD") != os.environ["GITHUB_SHA"]:
+        raise ValueError("Checkout differs from the requested release commit")
+
+
+def require_new_tag(version):
+    if git("ls-remote", "--tags", "origin", f"refs/tags/{version}"):
+        raise ValueError(f"Tag {version} already exists; refusing to replace a release")
+
+
+def bump(kind):
+    version, code = read_metadata()
+    require_main_checkout()
+    if os.environ.get("GITHUB_EVENT_NAME") != "workflow_dispatch":
+        raise ValueError("Version bumps require workflow_dispatch")
+    remote = git("ls-remote", "origin", "refs/heads/main").split()
+    if not remote or remote[0] != os.environ["GITHUB_SHA"]:
+        raise ValueError("Remote main changed; start a new workflow run")
+    if git("status", "--porcelain"):
+        raise ValueError("Version bump requires a clean checkout")
+    release = os.environ.get("RELEASE_INPUT") == "true"
+    prerelease = os.environ.get("PRERELEASE_INPUT") == "true"
+    if prerelease and not release:
+        raise ValueError("prerelease requires release=true")
+    parts = list(map(int, version[1:].split(".")))
+    index = ("major", "minor", "patch").index(kind)
+    parts[index] += 1
+    parts[index + 1:] = [0] * (2 - index)
+    version = "v" + ".".join(map(str, parts))
+    require_new_tag(version)
+    code += 1
+
+    def replace_fields(text, values):
+        for key, value in values.items():
+            text, count = re.subn(rf"(?m)^({key}[ \t]*=[ \t]*)[^\n]*$",
+                                 lambda match: match[1] + value, text)
+            if count != 1:
+                raise ValueError(f"Expected exactly one {key} field")
+        return text
+
+    toml = Path("kam.toml").read_text()
+    prop = re.search(r"(?ms)^\[prop\][^\n]*\n(.*?)(?=^\[|\Z)", toml)
+    if prop is None:
+        raise ValueError("Missing [prop] section")
+    replacement = replace_fields(prop[1], {"version": json.dumps(version), "versionCode": str(code)})
+    module = replace_fields(Path("src/MagicNet/module.prop").read_text(),
+                            {"version": version, "versionCode": str(code)})
+    update = json.loads(Path("update.json").read_text())
+    update.update(version=version, versionCode=code)
+    # Calculate and validate every replacement before changing the checkout.
+    Path("kam.toml").write_text(toml[:prop.start(1)] + replacement + toml[prop.end(1):])
+    Path("src/MagicNet/module.prop").write_text(module)
+    Path("update.json").write_text(json.dumps(update, ensure_ascii=False, indent=2) + "\n")
+    if release:
+        marker = Path(".github/release-request")
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(version + ("\nprerelease=true\n" if prerelease else "\n"))
+    read_metadata()
+    with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+        output.write(f"version={version}\n")
+    print(f"Prepared {version} (versionCode={code}); release after merge: {release}")
+
+
+def prepare():
+    version, code = read_metadata()
 
     event = os.environ.get("GITHUB_EVENT_NAME", "")
     ref = os.environ.get("GITHUB_REF", "")
     requested = event == "workflow_dispatch" and os.environ.get("RELEASE_INPUT") == "true"
+    prerelease = os.environ.get("PRERELEASE_INPUT") == "true"
     marker = Path(".github/release-request")
     if event == "push" and ref == "refs/heads/main" and marker.exists():
         changed = git("diff", "--name-only", os.environ["PUSH_BEFORE"],
                       os.environ["GITHUB_SHA"], "--", str(marker))
         if changed:
-            if marker.read_text().strip() != version:
+            request = marker.read_text().strip().splitlines()
+            if not request or request[0] != version:
                 raise ValueError("Release request must equal the committed module version")
+            if request[1:] not in ([], ["prerelease=true"]):
+                raise ValueError("Invalid release request options")
+            prerelease = request[1:] == ["prerelease=true"]
             requested = True
     if not requested:
         print(f"Validated {version}; build only")
         return
-    if ref != "refs/heads/main":
-        raise ValueError("Releases must use main after the version PR is merged")
-    if git("rev-parse", "HEAD") != os.environ["GITHUB_SHA"]:
-        raise ValueError("Checkout differs from the requested release commit")
-    if git("ls-remote", "--tags", "origin", f"refs/tags/{version}"):
-        raise ValueError(f"Tag {version} already exists; refusing to replace a release")
+    require_main_checkout()
+    require_new_tag(version)
     with open(os.environ["GITHUB_ENV"], "a") as output:
         output.write(f"RELEASE_REQUESTED=1\nRELEASE_VERSION={version}\n")
         output.write(f"RELEASE_VERSION_CODE={code}\nMAGICNET_SIGN_REQUIRED=1\n")
+        output.write(f"RELEASE_PRERELEASE={str(prerelease).lower()}\n")
     print(f"Release requested: {version} at {os.environ['GITHUB_SHA']}")
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bump", choices=("patch", "minor", "major"))
+    args = parser.parse_args()
     try:
-        prepare()
+        bump(args.bump) if args.bump else prepare()
     except (KeyError, ValueError, OSError, subprocess.CalledProcessError) as error:
         raise SystemExit(f"::error::{error}") from error

--- a/scripts/test-release-workflow.py
+++ b/scripts/test-release-workflow.py
@@ -7,10 +7,13 @@ from pathlib import Path
 import subprocess
 import sys
 import tempfile
+import tomllib
 import unittest
 
 
 SCRIPT = Path(__file__).with_name("prepare-release.py").resolve()
+VERSION_FILES = ("kam.toml", "src/MagicNet/module.prop", "update.json")
+RELEASE_MARKER = ".github/release-request"
 
 
 class ReleaseWorkflowTest(unittest.TestCase):
@@ -27,11 +30,21 @@ class ReleaseWorkflowTest(unittest.TestCase):
         self.git("config", "tag.gpgsign", "false")
         self.git("init", "--bare", str(self.root / "origin.git"))
         self.git("remote", "add", "origin", str(self.root / "origin.git"))
-        self.write("kam.toml", '[prop]\nversion = "v1.2.3"\nversionCode = 123\n')
-        self.write("src/MagicNet/module.prop", "version=v1.2.3\nversionCode=123\n")
-        self.write("update.json", json.dumps({"version": "v1.2.3", "versionCode": 123}))
+        self.write("kam.toml", '[prop]\nid = "MagicNet"\nversion = "v1.2.3"\n'
+                   'versionCode = 123\nauthor = "Release test"\n'
+                   '[kam.build]\noutput_file = "{{id}}"\n')
+        self.write("src/MagicNet/module.prop", "id=MagicNet\nversion=v1.2.3\n"
+                   "versionCode=123\ndescription=Keep this description.\n")
+        self.write("update.json", json.dumps({
+            "version": "v1.2.3", "versionCode": 123,
+            "zipUrl": "https://example.invalid/releases/latest/MagicNet.zip",
+            "changelog": "https://example.invalid/CHANGELOG.md",
+        }))
+        self.write("README.md", "Release fixture.\n")
         self.before = self.commit()
+        self.git("push", "origin", "main")
         self.output = self.root / "github-env"
+        self.step_output = self.root / "github-output"
 
     def git(self, *args):
         return subprocess.check_output(
@@ -50,33 +63,190 @@ class ReleaseWorkflowTest(unittest.TestCase):
         self.git("commit", "-m", "Fixture commit")
         return self.git("rev-parse", "HEAD")
 
-    def run_workflow(self, **overrides):
+    def run_workflow(self, bump=None, **overrides):
         self.output.unlink(missing_ok=True)
+        self.step_output.unlink(missing_ok=True)
         env = dict(os.environ, GITHUB_EVENT_NAME="push", GITHUB_REF="refs/heads/main",
                    GITHUB_SHA=self.git("rev-parse", "HEAD"), PUSH_BEFORE=self.before,
-                   RELEASE_INPUT="false", GITHUB_ENV=str(self.output))
+                   RELEASE_INPUT="false", PRERELEASE_INPUT="false",
+                   GITHUB_ENV=str(self.output), GITHUB_OUTPUT=str(self.step_output))
         env.update(overrides)
+        command = [sys.executable, str(SCRIPT)]
+        if bump is not None:
+            command.extend(["--bump", bump])
         return subprocess.run(
-            [sys.executable, str(SCRIPT)], cwd=self.repo, env=env,
+            command, cwd=self.repo, env=env,
             text=True, capture_output=True, check=False,
         )
+
+    def run_bump(self, kind="patch", **overrides):
+        return self.run_workflow(bump=kind, **{
+            "GITHUB_EVENT_NAME": "workflow_dispatch", **overrides,
+        })
+
+    def snapshot(self):
+        return {
+            name: (self.repo / name).read_bytes() if (self.repo / name).exists() else None
+            for name in (*VERSION_FILES, RELEASE_MARKER)
+        }
+
+    def metadata(self):
+        return (
+            tomllib.loads((self.repo / "kam.toml").read_text())["prop"],
+            dict(line.split("=", 1) for line in
+                 (self.repo / "src/MagicNet/module.prop").read_text().splitlines()
+                 if "=" in line and not line.startswith("#")),
+            json.loads((self.repo / "update.json").read_text()),
+        )
+
+    def assert_bump(self, result, version):
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for metadata in self.metadata():
+            self.assertEqual(metadata["version"], version)
+            self.assertEqual(str(metadata["versionCode"]), "124")
+        self.assertEqual(self.step_output.read_text().splitlines(), [f"version={version}"])
+        self.assertFalse(self.output.exists(), "A bump must wait for the version PR to merge")
+
+    def assert_bump_rejected(self, **overrides):
+        before = self.snapshot()
+        self.assert_rejected(self.run_bump(**overrides))
+        self.assertEqual(self.snapshot(), before, "Rejected bump changed release files")
+        self.assertFalse(self.step_output.exists())
 
     def assert_build_only(self, result):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("build only", result.stdout)
         self.assertFalse(self.output.exists())
 
-    def assert_release(self, result):
+    def assert_release(self, result, version="v1.2.3", code=123, prerelease=False):
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(self.output.read_text().splitlines(), [
-            "RELEASE_REQUESTED=1", "RELEASE_VERSION=v1.2.3",
-            "RELEASE_VERSION_CODE=123", "MAGICNET_SIGN_REQUIRED=1",
-        ])
+        self.assertEqual(dict(line.split("=", 1) for line in self.output.read_text().splitlines()), {
+            "RELEASE_REQUESTED": "1", "RELEASE_VERSION": version,
+            "RELEASE_VERSION_CODE": str(code), "MAGICNET_SIGN_REQUIRED": "1",
+            "RELEASE_PRERELEASE": str(prerelease).lower(),
+        })
 
-    def assert_rejected(self, result, message):
+    def assert_rejected(self, result, message=None):
         self.assertNotEqual(result.returncode, 0, result.stdout)
-        self.assertIn(message, result.stderr)
+        self.assertTrue(result.stderr)
+        if message:
+            self.assertIn(message, result.stderr)
         self.assertFalse(self.output.exists())
+
+    def test_three_bump_kinds_keep_metadata_in_sync(self):
+        for kind, version in (("patch", "v1.2.4"), ("minor", "v1.3.0"), ("major", "v2.0.0")):
+            with self.subTest(kind=kind):
+                self.git("reset", "--hard", self.before)
+                self.assert_bump(self.run_bump(kind), version)
+                self.assertFalse((self.repo / RELEASE_MARKER).exists())
+
+    def test_no_bump_keeps_committed_files_unchanged(self):
+        before = self.snapshot()
+        self.assert_build_only(self.run_workflow(GITHUB_EVENT_NAME="workflow_dispatch"))
+        self.assertEqual(self.snapshot(), before)
+        self.assertEqual(self.git("status", "--porcelain"), "")
+        self.assertFalse(self.step_output.exists())
+
+    def test_bump_preserves_non_version_fields(self):
+        original = self.metadata()
+        original_build = tomllib.loads((self.repo / "kam.toml").read_text())["kam"]
+        self.assert_bump(self.run_bump(), "v1.2.4")
+        for before, after in zip(original, self.metadata()):
+            self.assertEqual(
+                {key: value for key, value in before.items() if key not in {"version", "versionCode"}},
+                {key: value for key, value in after.items() if key not in {"version", "versionCode"}},
+            )
+        self.assertEqual(tomllib.loads((self.repo / "kam.toml").read_text())["kam"], original_build)
+
+    def test_repeating_same_base_produces_identical_bump(self):
+        self.assert_bump(self.run_bump(RELEASE_INPUT="true", PRERELEASE_INPUT="true"), "v1.2.4")
+        first = self.snapshot()
+        self.git("reset", "--hard", self.before)
+        self.git("clean", "-fd")
+        self.assert_bump(self.run_bump(RELEASE_INPUT="true", PRERELEASE_INPUT="true"), "v1.2.4")
+        self.assertEqual(self.snapshot(), first)
+
+    def test_bump_rejects_invalid_kind(self):
+        self.assert_bump_rejected(kind="nightly")
+
+    def test_bump_requires_main_workflow_dispatch(self):
+        for overrides in (
+            {"GITHUB_EVENT_NAME": "push"},
+            {"GITHUB_EVENT_NAME": "pull_request", "GITHUB_REF": "refs/pull/42/merge"},
+            {"GITHUB_REF": "refs/heads/feature"},
+        ):
+            with self.subTest(**overrides):
+                self.assert_bump_rejected(**overrides)
+
+    def test_bump_rejects_stale_checkout_sha(self):
+        self.commit("README.md", "Another committed change.\n")
+        self.git("push", "origin", "main")
+        self.assert_bump_rejected(GITHUB_SHA=self.before)
+
+    def test_bump_rejects_remote_main_advancing(self):
+        self.commit("README.md", "Remote main advanced after workflow started.\n")
+        self.git("push", "origin", "main")
+        self.git("reset", "--hard", self.before)
+        self.assert_bump_rejected()
+
+    def test_bump_rejects_dirty_worktree(self):
+        for kind in ("tracked", "staged", "untracked"):
+            with self.subTest(kind=kind):
+                self.git("reset", "--hard", self.before)
+                self.git("clean", "-fd")
+                self.write("notes.txt" if kind == "untracked" else "README.md", "Keep this edit.\n")
+                if kind == "staged":
+                    self.git("add", "README.md")
+                self.assert_bump_rejected()
+
+    def test_bump_rejects_inconsistent_metadata(self):
+        self.commit("src/MagicNet/module.prop", "version=v1.2.3\nversionCode=125\n")
+        self.git("push", "origin", "main")
+        self.assert_bump_rejected()
+
+    def test_bump_rejects_existing_target_tag(self):
+        self.git("tag", "v1.2.4")
+        self.git("push", "origin", "refs/tags/v1.2.4")
+        self.git("tag", "-d", "v1.2.4")
+        self.assert_bump_rejected()
+
+    def test_prerelease_bump_requires_release(self):
+        self.assert_bump_rejected(PRERELEASE_INPUT="true")
+
+    def test_bump_release_runs_only_after_merge_and_preserves_prerelease(self):
+        for prerelease in (False, True):
+            with self.subTest(prerelease=prerelease):
+                self.git("reset", "--hard", self.before)
+                self.git("clean", "-fd")
+                self.git("checkout", "-B", "version-pr", self.before)
+                self.assert_bump(self.run_bump(
+                    RELEASE_INPUT="true", PRERELEASE_INPUT=str(prerelease).lower()), "v1.2.4")
+                self.assertEqual((self.repo / RELEASE_MARKER).read_text().splitlines(),
+                                 ["v1.2.4"] + (["prerelease=true"] if prerelease else []))
+                self.commit()
+                self.assert_build_only(self.run_workflow(
+                    GITHUB_EVENT_NAME="pull_request", GITHUB_REF="refs/pull/42/merge"))
+                self.git("checkout", "main")
+                self.git("merge", "--no-ff", "version-pr", "-m", "Merge version PR")
+                self.assert_release(self.run_workflow(), "v1.2.4", 124, prerelease)
+
+    def test_bump_without_release_merges_as_build_only(self):
+        self.git("checkout", "-b", "version-pr")
+        self.assert_bump(self.run_bump(), "v1.2.4")
+        self.assertFalse((self.repo / RELEASE_MARKER).exists())
+        self.commit()
+        self.git("checkout", "main")
+        self.git("merge", "--no-ff", "version-pr", "-m", "Merge version PR")
+        self.assert_build_only(self.run_workflow())
+
+    def test_bump_without_release_preserves_previous_release_marker(self):
+        marker = "v1.2.3\nprerelease=true\n"
+        self.before = self.commit(RELEASE_MARKER, marker)
+        self.git("push", "origin", "main")
+        self.assert_bump(self.run_bump(), "v1.2.4")
+        self.assertEqual((self.repo / RELEASE_MARKER).read_text(), marker)
+        self.commit()
+        self.assert_build_only(self.run_workflow())
 
     def test_pull_request_marker_does_not_release(self):
         self.commit(".github/release-request", "v1.2.3\n")
@@ -91,6 +261,13 @@ class ReleaseWorkflowTest(unittest.TestCase):
     def test_marker_version_mismatch_is_rejected(self):
         self.commit(".github/release-request", "v1.2.4\n")
         self.assert_rejected(self.run_workflow(), "Release request must equal")
+
+    def test_unsupported_release_marker_options_are_rejected(self):
+        for option in ("prerelease=false", "prerelease=true\nextra=true"):
+            with self.subTest(option=option):
+                self.git("reset", "--hard", self.before)
+                self.commit(RELEASE_MARKER, f"v1.2.3\n{option}\n")
+                self.assert_rejected(self.run_workflow(), "Invalid release request options")
 
     def test_main_push_without_marker_does_not_release(self):
         self.commit("README.md", "Ordinary change.\n")


### PR DESCRIPTION
修复 #155 引入的自动版本升级功能回退。原来的 main 直推步骤被移除后，手动构建失去了 bump 入口，用户只能手动修改三份版本元数据。

恢复 Build Kam Module 的 none / patch / minor / major 输入。选择升级后同步更新三份版本元数据，versionCode 加一，并通过固定提交的 create-pull-request v8.1.1 创建版本 PR。勾选 release 会同时写入发布请求，正常合并到 main 后自动构建发布；prerelease 选项也保存在发布请求中。bump=none 沿用当前构建和发布路径。

重复请求同一目标版本会更新其自动化 PR。远程 main 已前进、工作区不干净、版本元数据不一致或目标标签已存在时拒绝升级。固定原始提交并使用本地 main 分支，防止 PR Action 在 detached HEAD 下把旧版本修改以 theirs 策略重放到新版主线。

版本任务只获 contents/pull-requests 写权限，不直接推送 main、不自动合并，也不更改仓库设置。内置 GITHUB_TOKEN 创建的 PR 检查可能等待批准；创建失败保留原始错误，并在运行摘要给出 Actions 设置提示及恢复链接。专用自动化分支会在重跑时重新生成，应避免人工修改。

验证：26 项真实隔离 Git 仓库测试通过，覆盖三种递增、确定性重跑、各类拒绝边界、旧标记兼容，以及真实合并后的正式发布、预发布和仅构建行为。YAML 解析与 diff 检查通过；已独立审查 Action 固定版本源码和 GitHub 当前权限规则。

本 PR 恢复工作流能力，不递增当前仓库版本，也不触发新版本发布。

## Sourcery 摘要

通过拉取请求恢复安全的自动版本准备流程，同时保留未变更版本现有的构建和发布路径。

新功能：
- 恢复手动输入补丁版本、小版本和大版本升级，同步模块元数据并创建版本拉取请求。
- 支持将版本升级中的发布和预发布请求在合并后继续传递至自动发布流程。

错误修复：
- 通过拒绝已变更的主分支、存在未提交更改的工作树、不一致的元数据、已存在的目标标签以及不受支持的发布标记，防止过时、不安全或无效的版本升级。
- 保留主分支构建的发布验证，同时正确处理预发布请求和现有发布标记的兼容性。

增强：
- 使用按版本确定性的自动化分支，使重复请求能够更新同一个版本拉取请求，而不会直接修改受保护的分支。
- 使用英文和中文记录恢复后的版本准备与发布流程。

CI：
- 将版本自动化权限限制为仓库内容和拉取请求访问权限，固定拉取请求操作的版本，并为 GitHub Actions 的拉取请求限制提供可执行的失败处理指导。

文档：
- 更新工作流文档，说明版本升级输入、发布和预发布行为、自动化分支处理、权限以及恢复流程。

测试：
- 扩展隔离的 Git 工作流测试，覆盖升级类型、确定性重复运行、验证边界、发布标记兼容性，以及合并后的构建、发布和预发布行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore safe automated version preparation through pull requests while retaining the existing build and release paths for unchanged versions.

New Features:
- Restore manual patch, minor, and major version bump inputs that synchronize module metadata and create a version pull request.
- Support carrying release and prerelease requests from version bumps through merge to automated publishing.

Bug Fixes:
- Prevent stale, unsafe, or invalid version bumps by rejecting changed main branches, dirty worktrees, inconsistent metadata, existing target tags, and unsupported release markers.
- Preserve release validation for main-branch builds while correctly handling prerelease requests and existing release-marker compatibility.

Enhancements:
- Use deterministic per-version automation branches so repeated requests update the same version pull request without directly modifying protected branches.
- Document the restored version preparation and release workflow in English and Chinese.

CI:
- Scope version automation permissions to repository contents and pull-request access, pin the pull-request action, and provide actionable failure guidance for GitHub Actions PR restrictions.

Documentation:
- Update workflow documentation to describe version bump inputs, release and prerelease behavior, automation branch handling, permissions, and recovery procedures.

Tests:
- Expand isolated Git workflow coverage for bump types, deterministic reruns, validation boundaries, release-marker compatibility, and post-merge build, release, and prerelease behavior.

</details>