### PR TITLE
fix(mcp): bound request reads and redact complete credentials

### DIFF
--- a/crates/magicnet-mcp-server/src/http.rs
+++ b/crates/magicnet-mcp-server/src/http.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::rpc::handle_jsonrpc;
 use crate::Server;
@@ -19,14 +19,17 @@ enum RequestError {
     MethodNotAllowed,
     NotFound,
     PayloadTooLarge(&'static str),
+    RequestTimeout,
 }
 
 pub(crate) fn handle_connection(mut stream: TcpStream, server: &Server) -> io::Result<()> {
-    set_read_timeout(&stream, READ_TIMEOUT)?;
+    // Headers and body share one budget; successful partial reads must not
+    // let a slow sender reserve a connection worker indefinitely.
+    let deadline = Instant::now() + READ_TIMEOUT;
     stream.set_write_timeout(Some(READ_TIMEOUT))?;
 
     let mut buffer = Vec::with_capacity(4096);
-    let header_end = match read_headers(&mut stream, &mut buffer) {
+    let header_end = match read_headers(&mut stream, &mut buffer, deadline) {
         Ok(header_end) => header_end,
         Err(error) => return write_request_error(&mut stream, error),
     };
@@ -52,7 +55,9 @@ pub(crate) fn handle_connection(mut stream: TcpStream, server: &Server) -> io::R
         Ok(body) => body,
         Err(error) => return write_request_error(&mut stream, error),
     };
-    read_remaining_body(&mut stream, &mut body, content_length)?;
+    if let Err(error) = read_remaining_body(&mut stream, &mut body, content_length, deadline) {
+        return write_request_error(&mut stream, error);
+    }
     let payload = match String::from_utf8(body) {
         Ok(payload) => payload,
         Err(_) => {
@@ -66,11 +71,29 @@ pub(crate) fn handle_connection(mut stream: TcpStream, server: &Server) -> io::R
     write_json(&mut stream, &response)
 }
 
-fn set_read_timeout(stream: &TcpStream, timeout: Duration) -> io::Result<()> {
-    stream.set_read_timeout(Some(timeout))
+fn read_request_chunk(
+    stream: &mut TcpStream,
+    buffer: &mut [u8],
+    deadline: Instant,
+) -> Result<usize, RequestError> {
+    let remaining = deadline
+        .checked_duration_since(Instant::now())
+        .filter(|timeout| !timeout.is_zero())
+        .ok_or(RequestError::RequestTimeout)?;
+    stream
+        .set_read_timeout(Some(remaining))
+        .and_then(|()| stream.read(buffer))
+        .map_err(|error| match error.kind() {
+            io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock => RequestError::RequestTimeout,
+            _ => RequestError::BadRequest("failed to read request"),
+        })
 }
 
-fn read_headers(stream: &mut TcpStream, buffer: &mut Vec<u8>) -> Result<usize, RequestError> {
+fn read_headers(
+    stream: &mut TcpStream,
+    buffer: &mut Vec<u8>,
+    deadline: Instant,
+) -> Result<usize, RequestError> {
     let mut temp = [0_u8; 4096];
     loop {
         if let Some(header_end) = header_end_or_error(buffer)? {
@@ -86,9 +109,7 @@ fn read_headers(stream: &mut TcpStream, buffer: &mut Vec<u8>) -> Result<usize, R
             return Err(RequestError::PayloadTooLarge("headers too large"));
         }
         let chunk_len = remaining.min(temp.len());
-        let read = stream
-            .read(&mut temp[..chunk_len])
-            .map_err(|_| RequestError::BadRequest("failed to read request headers"))?;
+        let read = read_request_chunk(stream, &mut temp[..chunk_len], deadline)?;
         if read == 0 {
             return Err(RequestError::BadRequest("incomplete request headers"));
         }
@@ -209,17 +230,15 @@ fn read_remaining_body(
     stream: &mut TcpStream,
     body: &mut Vec<u8>,
     content_length: usize,
-) -> io::Result<()> {
+    deadline: Instant,
+) -> Result<(), RequestError> {
     let mut temp = [0_u8; 4096];
     while body.len() < content_length {
         let remaining = content_length - body.len();
         let chunk_len = remaining.min(temp.len());
-        let read = stream.read(&mut temp[..chunk_len])?;
+        let read = read_request_chunk(stream, &mut temp[..chunk_len], deadline)?;
         if read == 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "incomplete request body",
-            ));
+            return Err(RequestError::BadRequest("incomplete request body"));
         }
         body.extend_from_slice(&temp[..read]);
     }
@@ -281,6 +300,11 @@ fn write_request_error(stream: &mut TcpStream, error: RequestError) -> io::Resul
         RequestError::PayloadTooLarge(body) => {
             write_http_error(stream, "413 Payload Too Large", body)
         }
+        RequestError::RequestTimeout => write_http_error(
+            stream,
+            "408 Request Timeout",
+            "request read deadline exceeded",
+        ),
     }
 }
 
@@ -361,7 +385,9 @@ mod tests {
     #[test]
     fn slow_peer_reads_use_a_timeout() {
         let (mut client, mut server) = tcp_pair();
-        set_read_timeout(&server, Duration::from_millis(50)).unwrap();
+        server
+            .set_read_timeout(Some(Duration::from_millis(50)))
+            .unwrap();
 
         let mut byte = [0_u8; 1];
         let error = server.read(&mut byte).unwrap_err();
@@ -370,6 +396,54 @@ mod tests {
             ErrorKind::TimedOut | ErrorKind::WouldBlock
         ));
         let _ = client.write_all(b"x");
+    }
+
+    #[test]
+    fn dripping_headers_cannot_extend_the_request_deadline() {
+        let (client, mut server) = tcp_pair();
+        let sender = drip_bytes(client);
+        let started = std::time::Instant::now();
+        assert_eq!(
+            read_headers(
+                &mut server,
+                &mut Vec::new(),
+                started + Duration::from_millis(80)
+            ),
+            Err(RequestError::RequestTimeout)
+        );
+        assert!(started.elapsed() < Duration::from_millis(300));
+        drop(server);
+        sender.join().unwrap();
+    }
+
+    #[test]
+    fn dripping_body_cannot_extend_the_request_deadline() {
+        let (client, mut server) = tcp_pair();
+        let sender = drip_bytes(client);
+        let started = std::time::Instant::now();
+        assert_eq!(
+            read_remaining_body(
+                &mut server,
+                &mut Vec::new(),
+                100,
+                started + Duration::from_millis(80)
+            ),
+            Err(RequestError::RequestTimeout)
+        );
+        assert!(started.elapsed() < Duration::from_millis(300));
+        drop(server);
+        sender.join().unwrap();
+    }
+
+    fn drip_bytes(mut stream: TcpStream) -> thread::JoinHandle<()> {
+        thread::spawn(move || {
+            for _ in 0..25 {
+                if stream.write_all(b"x").is_err() {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(20));
+            }
+        })
     }
 
     fn tcp_pair() -> (TcpStream, TcpStream) {

--- a/crates/magicnet-mcp-server/src/logs.rs
+++ b/crates/magicnet-mcp-server/src/logs.rs
@@ -182,9 +182,16 @@ fn redact_text(text: &str) -> String {
     text.lines()
         .map(|line| {
             let lower = line.to_ascii_lowercase();
-            let secret_header = ["authorization:", "x-magicnet-mcp-secret:"]
+            let secret_header = ["authorization", "x-magicnet-mcp-secret"]
                 .iter()
-                .filter_map(|header| lower.find(header))
+                .filter_map(|header| {
+                    lower.match_indices(header).find_map(|(index, _)| {
+                        lower[index + header.len()..]
+                            .trim_start()
+                            .starts_with(':')
+                            .then_some(index)
+                    })
+                })
                 .min();
             let prefix = secret_header.map_or(line, |index| &line[..index]);
             let mut tokens = prefix
@@ -251,6 +258,28 @@ mod tests {
                 "请求 failed <redacted-secret>\nnext diagnostic"
             );
         }
+    }
+
+    #[test]
+    fn redacts_header_credentials_with_whitespace_before_the_colon() {
+        for headers in [
+            "Authorization : Bearer example-token",
+            "X-MagicNet-MCP-Secret\t: example-secret",
+            "AUTHORIZATION \t: Bearer example-token X-MagicNet-MCP-Secret : example-secret",
+            "x-magicnet-mcp-secret\u{2003}: example-secret Authorization : Bearer example-token",
+        ] {
+            assert_eq!(
+                redact_text(&format!(
+                    "请求 12:34:56 request: {headers}\nnext diagnostic"
+                )),
+                "请求 12:34:56 request: <redacted-secret>\nnext diagnostic"
+            );
+        }
+        assert_eq!(
+            redact_text("authorization rejected; Authorization : Bearer example-token"),
+            "authorization rejected; <redacted-secret>"
+        );
+        assert_eq!(redact_text("authorization failed"), "authorization failed");
     }
 
     #[test]

--- a/crates/magicnet-mcp-server/src/logs.rs
+++ b/crates/magicnet-mcp-server/src/logs.rs
@@ -77,12 +77,16 @@ pub(crate) fn log_read(server: &Server, source: &str, lines: usize, redact: bool
 }
 
 fn read_bounded_tail(path: &PathBuf) -> std::io::Result<String> {
-    let mut file = File::open(path)?;
+    let file = File::open(path)?;
     let len = file.metadata()?.len();
+    read_log_snapshot(file, len)
+}
+
+fn read_log_snapshot(mut file: impl Read + Seek, len: u64) -> std::io::Result<String> {
     let start = len.saturating_sub(MAX_LOG_READ_BYTES);
     file.seek(SeekFrom::Start(start))?;
     let mut bytes = Vec::with_capacity((len - start) as usize);
-    file.read_to_end(&mut bytes)?;
+    file.take(len - start).read_to_end(&mut bytes)?;
     if start > 0 {
         if let Some(index) = bytes.iter().position(|byte| *byte == b'\n') {
             bytes.drain(..=index);
@@ -177,10 +181,21 @@ fn command_text(program: &str, args: &[&str]) -> String {
 fn redact_text(text: &str) -> String {
     text.lines()
         .map(|line| {
-            line.split_whitespace()
+            let lower = line.to_ascii_lowercase();
+            let secret_header = ["authorization:", "x-magicnet-mcp-secret:"]
+                .iter()
+                .filter_map(|header| lower.find(header))
+                .min();
+            let prefix = secret_header.map_or(line, |index| &line[..index]);
+            let mut tokens = prefix
+                .split_whitespace()
                 .map(redact_token)
-                .collect::<Vec<_>>()
-                .join(" ")
+                .collect::<Vec<_>>();
+            // Header credentials may span several words; discard the rest of this line.
+            if secret_header.is_some() {
+                tokens.push("<redacted-secret>".to_string());
+            }
+            tokens.join(" ")
         })
         .collect::<Vec<_>>()
         .join("\n")
@@ -188,14 +203,13 @@ fn redact_text(text: &str) -> String {
 
 fn redact_token(token: &str) -> String {
     let lower = token.to_ascii_lowercase();
-    if lower.starts_with("http://") || lower.starts_with("https://") {
+    if lower.contains("http://") || lower.contains("https://") {
         return "<redacted-url>".to_string();
     }
     if lower.contains("token=")
         || lower.contains("secret=")
         || lower.contains("password=")
         || lower.contains("passwd=")
-        || lower.contains("authorization:")
     {
         return "<redacted-secret>".to_string();
     }
@@ -209,6 +223,53 @@ mod tests {
     use std::os::unix::fs::symlink;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn redacts_authorization_credentials_across_whitespace() {
+        for header in [
+            "Authorization: Bearer example-access-token",
+            "authorization:\tBasic ZXhhbXBsZTpleGFtcGxl",
+            "AUTHORIZATION: custom example-secret",
+        ] {
+            assert_eq!(
+                redact_text(&format!("request failed {header}\nnext diagnostic")),
+                "request failed <redacted-secret>\nnext diagnostic"
+            );
+        }
+    }
+
+    #[test]
+    fn redacts_mcp_secret_from_the_first_sensitive_header() {
+        for headers in [
+            "X-MagicNet-MCP-Secret: example-mcp-secret",
+            "x-magicnet-mcp-secret:\texample-mcp-secret",
+            "X-MAGICNET-MCP-SECRET: example-mcp-secret Authorization: Bearer example-token",
+            "Authorization: Bearer example-token X-MagicNet-MCP-Secret: example-mcp-secret",
+        ] {
+            assert_eq!(
+                redact_text(&format!("请求 failed {headers}\nnext diagnostic")),
+                "请求 failed <redacted-secret>\nnext diagnostic"
+            );
+        }
+    }
+
+    #[test]
+    fn redacts_urls_embedded_in_fields() {
+        assert_eq!(
+            redact_text("fetch failed source=https://example.invalid/private-value result=timeout"),
+            "fetch failed <redacted-url> result=timeout"
+        );
+        assert_eq!(
+            redact_text(r#"request {"url":"HTTP://example.invalid/private-value"}"#),
+            "request <redacted-url>"
+        );
+    }
+
+    #[test]
+    fn bounded_log_tail_ignores_appends_after_metadata_snapshot() {
+        let file = std::io::Cursor::new(b"old\nappended-after-stat\n");
+        assert_eq!(read_log_snapshot(file, 4).unwrap(), "old\n");
+    }
 
     #[test]
     fn bounded_log_tail_does_not_load_an_unbounded_prefix() {


### PR DESCRIPTION
Slow clients could keep an MCP worker occupied indefinitely by sending a byte before each per-read timeout. Log redaction also left multi-word credentials visible, and concurrent log appends could exceed the intended tail-read budget.

This change gives request headers and bodies one shared five-second deadline, returns HTTP 408 on expiry, caps log reads to their metadata snapshot, and redacts complete Authorization / X-MagicNet-MCP-Secret fields plus embedded HTTP URLs. Tool execution keeps its existing timeout.

Validation: 31 MCP tests pass, including real socket drip-feed and credential regression cases. Workspace formatting and Clippy with warnings denied pass. Full workspace testing in the local runtime reports 426 passes and four unrelated CLI/proc failures: numeric process IDs are not visible under this runtime's /proc mount. [GitHub Code Quality CI](https://github.com/LIghtJUNction/MagicNet/actions/runs/33966866339) subsequently passed the complete Rust workspace suite on Ubuntu. No dependencies changed.

Independent code review covered the read deadline, log-size bound, and both authentication headers.

The [complete module build](https://github.com/LIghtJUNction/MagicNet/actions/runs/33966866321) also passed, including artifact, installation and simulated Magisk checks.

Merge-review follow-up: accepted auth header names with whitespace before the colon are now redacted as well, including tab/Unicode whitespace, time-prefixed log lines, and either ordering of the two sensitive headers. The new regression failed on the previous implementation and all 32 MCP tests plus Clippy pass locally. CI is rerunning for this follow-up commit.

## Sourcery 总结

防止缓慢的 MCP 客户端和并发日志增长绕过请求及日志大小限制，同时确保敏感凭据得到完全脱敏。

错误修复：
- 在同一个共享的五秒截止时间内限制 MCP 请求标头和请求正文的读取，并在截止时间到期时返回 HTTP 408。
- 完整脱敏 Authorization 和 X-MagicNet-MCP-Secret 凭据，包括包含多个单词的值，并隐藏日志字段中嵌入的 URL。
- 防止并发日志追加导致超出预期的有界尾部读取大小。

测试：
- 增加对逐步发送请求超时、凭据脱敏变体、嵌入式 URL 以及日志尾部快照边界的覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent slow MCP clients and concurrent log growth from bypassing request and log-size limits while ensuring sensitive credentials are fully redacted.

Bug Fixes:
- Bound MCP request header and body reads under one shared five-second deadline and return HTTP 408 when the deadline expires.
- Redact complete Authorization and X-MagicNet-MCP-Secret credentials, including multi-word values, and conceal URLs embedded in log fields.
- Prevent concurrent log appends from exceeding the intended bounded tail-read size.

Tests:
- Add coverage for drip-fed request timeouts, credential redaction variants, embedded URLs, and log-tail snapshot bounds.

</details>