### PR TITLE
fix(shell): preserve subscription cache on prune errors

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -64,30 +64,5 @@ jobs:
       - name: Install ShellCheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
 
-      - name: Lint Bash tooling
-        shell: bash
-        run: |
-          set -euo pipefail
-          mapfile -t files < <(
-            find hooks/pre-build hooks/post-build hooks/lib -type f -name '*.sh' -print
-            find scripts -maxdepth 1 -type f -name '*.sh' -print
-            printf '%s\n' kam.sh
-          )
-          # These exclusions match known baseline patterns in the existing
-          # fixture-heavy shell suite; all other findings remain blocking.
-          shellcheck -s bash \
-            -e SC1091,SC2015,SC2034,SC2059,SC2218,SC2317,SC2329 \
-            "${files[@]}"
-
-      - name: Lint device shell
-        shell: bash
-        run: |
-          set -euo pipefail
-          mapfile -t files < <(
-            find src/MagicNet -maxdepth 1 -type f -name '*.sh' -print
-            find src/MagicNet/system/bin -type f -print 2>/dev/null || true
-            printf '%s\n' src/MagicNet/lib/magicnet.sh
-          )
-          shellcheck -s sh \
-            -e SC1090,SC1091,SC2015,SC2034,SC2059,SC2218,SC2329 \
-            "${files[@]}"
+      - name: Lint host tools and all device shell fragments
+        run: bash scripts/lint-shell.sh

--- a/scripts/lint-shell.sh
+++ b/scripts/lint-shell.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# Use tracked files so submodule code is checked by its own project. NUL
+# delimiters also keep paths with whitespace intact.
+mapfile -d '' -t bash_files < <(git ls-files -z -- 'hooks/*.sh' 'scripts/*.sh' kam.sh)
+mapfile -d '' -t device_files < <(git ls-files -z -- 'src/MagicNet/*.sh' 'src/MagicNet/system/bin/*')
+
+# Fixture-heavy host tests contain intentional cross-function state and mocks.
+shellcheck -s bash \
+    -e SC1091,SC2015,SC2034,SC2059,SC2218,SC2317,SC2329 \
+    "${bash_files[@]}"
+
+# Runtime fragments share variables through the loader. jq programs and
+# deferred shell commands deliberately retain single-quoted dollar expressions.
+shellcheck -s sh \
+    -e SC1090,SC1091,SC2015,SC2016,SC2034,SC2059,SC2218,SC2329 \
+    "${device_files[@]}"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -19,20 +19,7 @@ need cargo
 
 kam validate
 
-mapfile -t bash_shell_files < <(
-    find hooks/pre-build hooks/post-build hooks/lib -type f -name '*.sh' -print
-    find scripts -maxdepth 1 -type f -name '*.sh' -print
-    printf '%s\n' kam.sh
-)
-shellcheck -s bash -e SC1091,SC2317,SC2329,SC2059 "${bash_shell_files[@]}"
-
-mapfile -t posix_shell_files < <(
-    find src/MagicNet -type f \( -name '*.sh' -o -path '*/system/bin/*' \) \
-        -not -path '*/lib/kamfw/*' -print | sort
-)
-# Every first-party runtime fragment is sourced into a privileged Android shell;
-# lint the fragments themselves instead of relying on analysis of the entrypoint.
-shellcheck -s sh -e SC1091,SC1090,SC2016,SC2329,SC2059 "${posix_shell_files[@]}"
+bash scripts/lint-shell.sh
 
 jq empty src/MagicNet/.config/sing-box/config.json
 bash scripts/test-repository-hygiene.sh
@@ -55,6 +42,7 @@ bash scripts/test-chatgpt-voice-rules.sh
 bash scripts/test-rule-hash-retry.sh
 bash scripts/singbox-subscription-protocol-smoke.sh
 bash scripts/test-subscription-fetch-policy.sh
+bash scripts/test-subscription-usage.sh
 bash scripts/test-singbox-pid-discovery.sh
 bash scripts/test-singbox-ownership.sh
 bash scripts/test-singbox-tristate-safety.sh
@@ -79,6 +67,7 @@ bash scripts/test-subscription-update-lock-safety.sh
 bash scripts/test-subscription-transaction-journal-safety.sh
 bash scripts/test-subscription-lifecycle.sh
 bash scripts/test-release-integrity.sh
+python3 scripts/test-release-workflow.py
 
 KAM_HOOKS_ROOT=hooks KAM_MODULE_ROOT=src/MagicNet bash hooks/pre-build/6000.check_config.sh
 MODPATH="$ROOT/src/MagicNet" sh -c '. "$MODPATH/lib/kamfw/.kamfwrc"; import __runtime__; . "$MODPATH/lib/magicnet.sh"; kamfw run post-mount -- smoke'
@@ -87,12 +76,11 @@ if command -v bun >/dev/null 2>&1; then
     (cd webui && bun install --frozen-lockfile && bun run typecheck && bun run build && bun run test)
 else
     need npm
-    (cd webui && npm install && npm run typecheck && npm run build && npm run test)
+    (cd webui && npm ci && npm run check)
 fi
-cargo check -p magicnet-cli
-cargo check -p magicnet-mcp-server
-cargo test -p magicnet-cli --test process_lifecycle
-cargo test -p magicnet-cli --test broken_pipe
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
 if compgen -G "dist/*.zip" >/dev/null; then
     package_zip="$(compgen -G "dist/*.zip" | head -n1)"
     scripts/package-smoke.sh "$package_zip"

--- a/scripts/test-subscription-usage.sh
+++ b/scripts/test-subscription-usage.sh
@@ -125,6 +125,51 @@ magicnet_singbox_persist_subscription_cache "$new_source" "$persisted" "$persist
 test "$(cat "$persisted")" = new-body
 jq -e '.total_bytes == 200 and .updated_epoch == 888' "$persisted.usage.json" >/dev/null
 
+# Cache pruning must never turn incomplete/read-failed keep sets into deletes.
+prune_dir=$(magicnet_singbox_subscription_cache_dir)
+mkdir -p "$prune_dir"
+prune_cache="$prune_dir/$fingerprint.yaml"
+prune_map="$tmp/prune-map"
+printf '%s|%s|%s|%s\n' "$fingerprint.yaml" "$prune_cache" "$prune_cache.identity" "$fingerprint" >"$prune_map"
+for suffix in '' .identity .usage.json; do printf retained >"$prune_cache$suffix"; done
+for fault in missing-map map-read keep-write keep-read; do
+  if (
+    awk() {
+      case "$fault" in
+        map-read) return 2 ;;
+        keep-write) command awk "$@" >/dev/full ;;
+        *) command awk "$@" ;;
+      esac
+    }
+    grep() {
+      if [ "$fault" = keep-read ] && [ "${1:-}" = -F ]; then return 2; fi
+      command grep "$@"
+    }
+    test_map="$prune_map"
+    [ "$fault" != missing-map ] || test_map="$tmp/missing-map"
+    magicnet_singbox_prune_subscription_cache "$test_map"
+  ) 2>/dev/null; then
+    printf 'cache pruning unexpectedly succeeded at %s\n' "$fault" >&2; exit 1
+  fi
+  for suffix in '' .identity .usage.json; do test "$(cat "$prune_cache$suffix")" = retained; done
+  test -z "$(find "$prune_dir" -name '.active-fingerprints.*' -print -quit)"
+done
+# Valid removals still delete stale bodies, sidecars and orphaned metadata.
+removed_id=$(magicnet_singbox_subscription_fingerprint "$other")
+removed_cache="$prune_dir/$removed_id.yaml"
+for suffix in '' .identity .usage.json; do printf stale >"$removed_cache$suffix"; done
+printf orphan >"$prune_dir/orphan.yaml.usage.json"
+magicnet_singbox_prune_subscription_cache "$prune_map"
+for suffix in '' .identity .usage.json; do
+  test -f "$prune_cache$suffix"
+  test ! -e "$removed_cache$suffix"
+done
+test ! -e "$prune_dir/orphan.yaml.usage.json"
+# A deliberately empty, successfully read map (local source mode) clears caches.
+: >"$prune_map"
+magicnet_singbox_prune_subscription_cache "$prune_map"
+for suffix in '' .identity .usage.json; do test ! -e "$prune_cache$suffix"; done
+
 # IPv6 host labels remain URL-safe; orphaned metadata never supplies usage.
 printf '%s\n' 'https://[2606:4700:4700::1111]/sub?token=SECRET' >"$MODDIR/.config/sing-box/subscription.url"
 magicnet_singbox_source_usage_report | sed -n 's/^source_usage_json=//p' |

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/config.sh
@@ -1237,7 +1237,7 @@ magicnet_singbox_google_works() {
 }
 
 magicnet_singbox_verify_subscription_ready() {
-    if magicnet_singbox_is_running; then
+    if magicnet_singbox_is_running "$(magicnet_singbox_subscription_config_file)"; then
         _verify_running_rc=0
     else
         _verify_running_rc=$?

--- a/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
+++ b/src/MagicNet/lib/magicnet/singbox_subscribe/update.sh
@@ -206,43 +206,39 @@ magicnet_singbox_persist_subscription_cache() (
     fi
 )
 
-magicnet_singbox_prune_subscription_cache() {
+magicnet_singbox_prune_subscription_cache() (
     _prune_cache_map="$1"
     _prune_cache_dir=$(magicnet_singbox_subscription_cache_dir)
-    [ -d "$_prune_cache_dir" ] || {
-        unset _prune_cache_map _prune_cache_dir
-        return 0
-    }
-    _prune_expected="${_prune_cache_dir}/.active-fingerprints.$$"
-    : >"$_prune_expected" || return 1
-    if [ -f "$_prune_cache_map" ]; then
-        while IFS='|' read -r _prune_name _prune_file _prune_identity _prune_fingerprint _prune_extra; do
-            [ -z "$_prune_extra" ] || continue
-            printf '%s' "$_prune_fingerprint" | grep -Eq '^[0-9a-f]{64}$' || continue
-            printf '%s\n' "$_prune_fingerprint" >>"$_prune_expected"
-        done <"$_prune_cache_map"
-    fi
+    [ -d "$_prune_cache_dir" ] || return 0
+    _prune_expected=$(mktemp "${_prune_cache_dir}/.active-fingerprints.XXXXXX") || return 1
+    trap 'rm -f "$_prune_expected" 2>/dev/null || true' EXIT
+    # Complete the keep set before deleting anything. Missing/unreadable maps
+    # and disk-full writes must not be mistaken for an empty subscription set.
+    awk -F '|' 'NF == 4 && length($4) == 64 && $4 !~ /[^0-9a-f]/ { print $4 }' \
+        "$_prune_cache_map" >"$_prune_expected" || return 1
     for _prune_file in "$_prune_cache_dir"/*.yaml; do
         [ -f "$_prune_file" ] || continue
         _prune_name=${_prune_file##*/}
         _prune_fingerprint=${_prune_name%.yaml}
         printf '%s' "$_prune_fingerprint" | grep -Eq '^[0-9a-f]{64}$' || continue
-        grep -F -x "$_prune_fingerprint" "$_prune_expected" >/dev/null 2>&1 ||
-            rm -f "$_prune_file" "${_prune_file}.identity" "${_prune_file}.usage.json" 2>/dev/null || true
+        if grep -F -x "$_prune_fingerprint" "$_prune_expected" >/dev/null 2>&1; then
+            continue
+        else
+            # grep returns 1 for a confirmed miss and 2 for a read failure.
+            [ "$?" -eq 1 ] || return 1
+        fi
+        rm -f "$_prune_file" "${_prune_file}.identity" "${_prune_file}.usage.json" || return 1
     done
     for _prune_identity in "$_prune_cache_dir"/*.yaml.identity; do
         [ -f "$_prune_identity" ] || continue
         _prune_file=${_prune_identity%.identity}
-        [ -f "$_prune_file" ] || rm -f "$_prune_identity" 2>/dev/null || true
+        [ -f "$_prune_file" ] || rm -f "$_prune_identity" || return 1
     done
     for _prune_usage in "$_prune_cache_dir"/*.yaml.usage.json; do
         [ -f "$_prune_usage" ] || continue
-        [ -f "${_prune_usage%.usage.json}" ] || rm -f "$_prune_usage" 2>/dev/null || true
+        [ -f "${_prune_usage%.usage.json}" ] || rm -f "$_prune_usage" || return 1
     done
-    rm -f "$_prune_expected" 2>/dev/null || true
-    unset _prune_cache_map _prune_cache_dir _prune_expected _prune_name _prune_file
-    unset _prune_identity _prune_fingerprint _prune_extra _prune_usage
-}
+)
 
 magicnet_singbox_transaction_dir() {
     printf '%s\n' "${MODDIR}/.state/sing-box/subscription-transaction"
@@ -571,6 +567,7 @@ magicnet_singbox_source_usage_report() (
             [ -n "$_usage_url" ] || continue
             _usage_index=$((_usage_index + 1))
             _usage_hostname=
+            _subscription_host=
             if magicnet_singbox_subscription_parse_authority "$_usage_url"; then
                 _usage_hostname=$_subscription_host
                 case "$_usage_hostname" in *:*) _usage_hostname="[$_usage_hostname]" ;; esac


### PR DESCRIPTION
Cache pruning could interpret a missing source map or an I/O failure as an empty subscription set and delete usable offline subscription data. CI also linted only the device entrypoints, leaving nested runtime fragments unchecked.

Build the complete retain set before deleting files; stop on map/read/write errors and distinguish grep's confirmed miss from its read-error result. A subshell and cleanup trap isolate temporary state. Normal pruning and intentional empty-source cleanup remain covered.

Use one tracked-file ShellCheck entrypoint for CI and local checks, covering nested first-party runtime scripts while excluding submodule internals. Local checks now use npm ci and the existing complete frontend/Rust gates, plus subscription-usage and release-workflow regressions.

Validation: missing map, failed map read, disk-full output, and failed grep regressions pass alongside ordinary pruning. Subscription usage, transaction atomicity/recovery, journal safety and activation-order suites pass. ShellCheck passes for 33 device and 73 host scripts in the combined workspace; existing warning exclusions are retained, with SC2016 suppressed for intentional device jq/deferred expressions. Independent review also verified parent variables and EXIT traps remain intact. Full local pre-commit requires KAM; GitHub validation covers that gate.

GitHub CI also passes with Ubuntu's ShellCheck 0.9 after making the readiness configuration argument explicit. The [complete module build](https://github.com/LIghtJUNction/MagicNet/actions/runs/33967062256) passed artifact, installation and simulated Magisk checks.