### PR TITLE
fix(webui): preserve newer drafts and complete background tracking

### DIFF
--- a/webui/background-tasks.test.mjs
+++ b/webui/background-tasks.test.mjs
@@ -42,10 +42,6 @@ assert.match(
 );
 assert.match(
   useMagicNetSource,
-  /async function startBackgroundCli[\s\S]*?const operationId = createBackgroundOperationId\(\);[\s\S]*?refreshSubs\(true\)/,
-);
-assert.match(
-  useMagicNetSource,
   /const\s+ownsForegroundUi\s*=\s*\(\):\s*boolean\s*=>\s*foregroundUiGate\.owns\(\s*foregroundToken\s*\);[\s\S]*?if\s*\(\s*!ownsForegroundUi\(\)\s*\)[\s\S]*?followBackgroundLogs\(/,
 );
 assert.match(

--- a/webui/composable-concurrency.test.mjs
+++ b/webui/composable-concurrency.test.mjs
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import vm from "node:vm";
+import ts from "typescript";
+import * as background from "./src/composables/backgroundTasks.ts";
+import { parseSubs, subscriptionDefaults } from "./src/composables/parsers.ts";
+import { execFailed } from "./src/utils.ts";
+
+// Execute the production functions with deferred device I/O and manual timers.
+const source = ts.createSourceFile(
+  "useMagicNet.ts",
+  readFileSync(new URL("./src/composables/useMagicNet.ts", import.meta.url), "utf8"),
+  ts.ScriptTarget.Latest,
+  true,
+);
+const names = [
+  "configDraftMatches", "loadConfig", "saveConfig", "syncConfigTemplate",
+  "startBackgroundCli", "followBackgroundLogs",
+  "refreshSubs", "canUpdateRefreshUi", "startForegroundCommand",
+];
+const functions = source.statements
+  .filter((node) => ts.isFunctionDeclaration(node) && names.includes(node.name?.text))
+  .map((node) => node.getText(source)).join("\n");
+const code = ts.transpileModule(functions, {
+  compilerOptions: { target: ts.ScriptTarget.ES2022 },
+}).outputText;
+
+function fixture() {
+  let resolve;
+  const pending = new Promise((done) => { resolve = done; });
+  const state = { config: { target: "sing-box", text: "original draft", dirty: true, status: "", validation: {} } };
+  const context = vm.createContext({
+    state, Date, Math,
+    MODULE_DIR: "/module", shellQuote: (value) => `'${value}'`, redactedCliPreview: (value) => value,
+    foregroundUiGate: { current: () => 1, owns: () => true },
+    runCli: () => pending,
+    execFailed: () => false, parseConfigValidation: () => ({ summary: "" }),
+    stagePrivatePayload: async () => ({ basename: "payload", path: "/private/payload" }),
+    runPrivateCli: () => pending,
+    removePrivatePayload: async () => true,
+  });
+  vm.runInContext(code, context);
+  return { context, state, resolve };
+}
+
+function backgroundFixture() {
+  let token = 1;
+  let resolve;
+  const pending = new Promise((done) => { resolve = done; });
+  const timers = [];
+  const state = {
+    backgroundTask: { id: "operation", status: "running" },
+    subscriptions: { ...subscriptionDefaults }, runtime: {},
+    output: "new foreground output", notice: "new notice", phase: "done",
+  };
+  const context = vm.createContext({
+    ...background, state, Date, backgroundLogTimer: 0,
+    window: { setTimeout: (callback) => { timers.push(callback); return timers.length; } },
+    foregroundUiGate: { begin: () => ++token, current: () => token, owns: (value) => value === token },
+    nextTick: async () => {}, nextFrame: async () => {}, stopBackgroundLogFollow: () => {},
+    createBackgroundOperationId: () => "operation", trackRedactedOperation: () => 1,
+    redactedCliPreview: (value) => value,
+    runShellOutcome: () => pending,
+    runShell: async () => "[launch] id=operation label=restart\n[exit] id=operation status=0",
+    runCli: async () => "status", parseSubs, execFailed,
+    parseRuntime: (_, runtime) => runtime,
+    publishTrackedOperation: (_, phase, notice, output) => { Object.assign(state, { phase, notice, output }); return true; },
+  });
+  vm.runInContext(code, context);
+  return { context, state, timers, resolve, supersede: () => ++token };
+}
+
+test("late config reads preserve edits entered while loading", async () => {
+  const { context, state, resolve } = fixture();
+  const loading = context.loadConfig();
+  state.config.text = "new draft";
+  resolve("device config");
+  await loading;
+  assert.equal(state.config.text, "new draft");
+  assert.equal(state.config.dirty, true);
+});
+
+test("saving a submitted snapshot leaves newer edits dirty and unvalidated", async () => {
+  const { context, state, resolve } = fixture();
+  const saving = context.saveConfig();
+  state.config.text = "new unsaved draft";
+  resolve({ ok: true, stdout: "[info] Saved and validated" });
+  await saving;
+  assert.equal(state.config.text, "new unsaved draft");
+  assert.equal(state.config.dirty, true);
+  assert.equal(state.config.validation.status, "idle");
+});
+
+test("unchanged submitted drafts become clean after a confirmed save", async () => {
+  const { context, state, resolve } = fixture();
+  const saving = context.saveConfig();
+  resolve({ ok: true, stdout: "[info] Saved and validated" });
+  await saving;
+  assert.equal(state.config.dirty, false);
+  assert.equal(state.config.validation.status, "ok");
+});
+
+test("template synchronization preserves edits entered while it was running", async () => {
+  const { context, state, resolve } = fixture();
+  const syncing = context.syncConfigTemplate();
+  state.config.text = "new draft";
+  resolve("template synced");
+  await syncing;
+  assert.equal(state.config.text, "new draft");
+  assert.equal(state.config.dirty, true);
+  assert.equal(state.config.validation.status, "idle");
+});
+
+test("foreground commands do not strand a completed background task", async () => {
+  const { context, state, timers, supersede } = backgroundFixture();
+  context.followBackgroundLogs("/task.log", "restart", "service restart", "operation", 1, 1);
+  supersede();
+  await timers.shift()();
+  assert.equal(state.backgroundTask.status, "done");
+  assert.equal(state.output, "new foreground output");
+});
+
+test("launch acknowledgment still starts polling after foreground ownership changes", async () => {
+  const { context, state, timers, resolve, supersede } = backgroundFixture();
+  state.backgroundTask.status = "idle";
+  const launching = context.startBackgroundCli("service restart");
+  supersede();
+  resolve({ ok: true, stdout: "[accepted] id=operation", text: "accepted" });
+  await launching;
+  assert.equal(timers.length, 1);
+  await timers.shift()();
+  assert.equal(state.backgroundTask.status, "done");
+  assert.equal(state.output, "new foreground output");
+});
+
+test("stale poll results do not complete a different background operation", async () => {
+  const { context, state, timers } = backgroundFixture();
+  context.followBackgroundLogs("/task.log", "restart", "service restart", "operation", 1, 1);
+  state.backgroundTask.id = "replacement";
+  await timers.shift()();
+  assert.equal(state.backgroundTask.status, "running");
+  assert.equal(state.output, "new foreground output");
+});
+
+test("background polling continues until completion after a foreground change", async () => {
+  const { context, state, timers, supersede } = backgroundFixture();
+  const completedLog = context.runShell;
+  context.runShell = async () => "[launch] id=operation label=restart";
+  context.followBackgroundLogs("/task.log", "restart", "service restart", "operation", 1, 1);
+  supersede();
+  await timers.shift()();
+  assert.equal(state.backgroundTask.status, "running");
+  assert.equal(timers.length, 1);
+  context.runShell = completedLog;
+  await timers.shift()();
+  assert.equal(state.backgroundTask.status, "done");
+  assert.equal(state.output, "new foreground output");
+});
+
+test("subscription polling failures preserve newer foreground feedback and keep tracking", async () => {
+  const { context, state, timers, supersede } = backgroundFixture();
+  Object.assign(state.backgroundTask, {
+    subscriptionBaselineKnown: true, subscriptionBaselineAttemptEpoch: 1,
+    subscriptionBaselineGenerationId: "old-generation", subscriptionBaselineResult: "success",
+  });
+  context.runCli = async () => "[error] errno=1 subscription read failed";
+  context.followBackgroundLogs("/task.log", "update", "sub update-all", "operation", 1, 1);
+  supersede();
+  await timers.shift()();
+  assert.equal(state.output, "new foreground output");
+  assert.equal(state.notice, "new notice");
+  assert.equal(state.phase, "done");
+  assert.equal(state.backgroundTask.status, "running");
+
+  context.runCli = async (args) => args === "sub status"
+    ? "last_result=success\nlast_attempt_epoch=2\nlast_generation_id=new-generation"
+    : "";
+  await timers.shift()();
+  assert.equal(state.backgroundTask.status, "done");
+  assert.equal(state.output, "new foreground output");
+});
+
+test("subscription launch waits for its lifecycle baseline before changing the device", async () => {
+  const { context, state } = backgroundFixture();
+  state.backgroundTask.status = "idle";
+  let resolveBaseline;
+  let launched = false;
+  const baseline = new Promise((resolve) => { resolveBaseline = resolve; });
+  context.runCli = () => baseline;
+  context.runShellOutcome = async () => {
+    launched = true;
+    return { ok: true, stdout: "[accepted] id=operation", text: "accepted" };
+  };
+  const launching = context.startBackgroundCli("sub update-all");
+  await Promise.resolve();
+  assert.equal(launched, false);
+  resolveBaseline("last_attempt_epoch=1\nlast_generation_id=old\nlast_result=success");
+  await launching;
+  assert.equal(launched, true);
+  assert.equal(state.backgroundTask.subscriptionBaselineKnown, true);
+  assert.equal(state.backgroundTask.subscriptionBaselineAttemptEpoch, 1);
+  assert.equal(state.backgroundTask.subscriptionBaselineGenerationId, "old");
+});

--- a/webui/composable-concurrency.test.mjs
+++ b/webui/composable-concurrency.test.mjs
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import vm from "node:vm";
 import ts from "typescript";
 import * as background from "./src/composables/backgroundTasks.ts";
-import { parseSubs, subscriptionDefaults } from "./src/composables/parsers.ts";
+import { invalidateTransparentRuntime, parseRuntime, parseSubs, runtimeDefaults, subscriptionDefaults } from "./src/composables/parsers.ts";
 import { execFailed } from "./src/utils.ts";
 
 // Execute the production functions with deferred device I/O and manual timers.
@@ -18,10 +18,21 @@ const names = [
   "configDraftMatches", "loadConfig", "saveConfig", "syncConfigTemplate",
   "startBackgroundCli", "followBackgroundLogs",
   "refreshSubs", "canUpdateRefreshUi", "startForegroundCommand",
+  "refreshAll",
+  "refreshStatus", "markQuietFailure",
 ];
+const controlSource = ts.createSourceFile(
+  "ControlPage.ts",
+  readFileSync(new URL("./src/components/pages/ControlPage.vue", import.meta.url), "utf8")
+    .split('<script setup lang="ts">')[1].split("</script>")[0],
+  ts.ScriptTarget.Latest,
+  true,
+);
 const functions = source.statements
   .filter((node) => ts.isFunctionDeclaration(node) && names.includes(node.name?.text))
-  .map((node) => node.getText(source)).join("\n");
+  .map((node) => node.getText(source)).join("\n") + "\n" + controlSource.statements
+  .find((node) => ts.isFunctionDeclaration(node) && node.name?.text === "rebuildNodeCache")
+  .getText(controlSource);
 const code = ts.transpileModule(functions, {
   compilerOptions: { target: ts.ScriptTarget.ES2022 },
 }).outputText;
@@ -51,7 +62,7 @@ function backgroundFixture() {
   const timers = [];
   const state = {
     backgroundTask: { id: "operation", status: "running" },
-    subscriptions: { ...subscriptionDefaults }, runtime: {},
+    subscriptions: { ...subscriptionDefaults }, runtime: { ...runtimeDefaults },
     output: "new foreground output", notice: "new notice", phase: "done",
   };
   const context = vm.createContext({
@@ -63,8 +74,13 @@ function backgroundFixture() {
     redactedCliPreview: (value) => value,
     runShellOutcome: () => pending,
     runShell: async () => "[launch] id=operation label=restart\n[exit] id=operation status=0",
-    runCli: async () => "status", parseSubs, execFailed,
-    parseRuntime: (_, runtime) => runtime,
+    runCli: async () => "status", parseSubs, execFailed, parseRuntime, invalidateTransparentRuntime,
+    withAction: async (_, action) => action(),
+    refreshApps: async () => true,
+    refreshBlock: async () => true, refreshDns: async () => true,
+    refreshWarp: async () => true, refreshWifiPolicy: async () => true,
+    refreshMcp: async () => true, refreshHealth: async () => true,
+    refreshAllNotice: (completed, notice) => completed ? "panel refreshed" : notice,
     publishTrackedOperation: (_, phase, notice, output) => { Object.assign(state, { phase, notice, output }); return true; },
   });
   vm.runInContext(code, context);
@@ -201,4 +217,125 @@ test("subscription launch waits for its lifecycle baseline before changing the d
   assert.equal(state.backgroundTask.subscriptionBaselineKnown, true);
   assert.equal(state.backgroundTask.subscriptionBaselineAttemptEpoch, 1);
   assert.equal(state.backgroundTask.subscriptionBaselineGenerationId, "old");
+});
+
+for (const failedRead of ["sub list", "sub status"]) {
+  test(`failed ${failedRead} baseline stops the launch and permits a retry`, async () => {
+    const { context, state } = backgroundFixture();
+    state.backgroundTask.status = "idle";
+    let launches = 0;
+    context.runCli = async (args) => args === failedRead ? "[error] errno=1 read failed" : "";
+    context.runShellOutcome = async () => {
+      launches += 1;
+      return { ok: true, stdout: "[accepted] id=operation", text: "accepted" };
+    };
+    const result = await context.startBackgroundCli("sub update-all", "更新订阅");
+    assert.equal(launches, 0);
+    assert.equal(execFailed(result), true);
+    assert.equal(state.backgroundTask.status, "idle");
+    assert.equal(background.backgroundTaskBlocksLaunch(state.backgroundTask), false);
+    assert.equal(state.phase, "error");
+    assert.match(state.notice, /未执行/);
+    assert.match(state.output, /重试/);
+
+    context.runCli = async () => "last_attempt_epoch=1\nlast_generation_id=old\nlast_result=success";
+    await context.startBackgroundCli("sub update-all", "更新订阅");
+    assert.equal(launches, 1);
+    assert.equal(state.backgroundTask.subscriptionBaselineKnown, true);
+  });
+}
+
+test("a superseded baseline failure leaves the newer foreground feedback untouched", async () => {
+  const { context, state, supersede } = backgroundFixture();
+  state.backgroundTask.status = "idle";
+  let resolveRead;
+  const pendingRead = new Promise((resolve) => { resolveRead = resolve; });
+  context.runCli = () => pendingRead;
+  context.runShellOutcome = () => assert.fail("a failed baseline must never launch");
+  const launching = context.startBackgroundCli("sub update-all");
+  supersede();
+  resolveRead("[error] errno=1 read failed");
+  await launching;
+  assert.equal(state.output, "new foreground output");
+  assert.equal(state.notice, "new notice");
+  assert.equal(state.phase, "done");
+});
+
+test("ControlPage completion does not begin a foreground refresh over a newer action", async () => {
+  const { context, state, timers, supersede } = backgroundFixture();
+  state.backgroundTask.status = "idle";
+  let attempt = 1;
+  context.runCli = async (args) => args === "sub status"
+    ? `last_attempt_epoch=${attempt}\nlast_generation_id=generation-${attempt}\nlast_result=success`
+    : "";
+  context.runShellOutcome = async () => ({ ok: true, stdout: "[accepted] id=operation", text: "accepted" });
+  await context.rebuildNodeCache();
+  const foregroundToken = supersede();
+  attempt = 2;
+  while (timers.length) await timers.shift()();
+  assert.equal(state.backgroundTask.status, "done");
+  assert.equal(state.subscriptions.lastAttemptEpoch, 2);
+  assert.equal(context.foregroundUiGate.current(), foregroundToken);
+  assert.equal(state.output, "new foreground output");
+  assert.equal(state.notice, "new notice");
+});
+
+const serviceSnapshot = "sing-box: running\nfswatch: running";
+const transparentSnapshot = "mode=ebpf\neffective_mode=hybrid\ncapability=ok\nlocal_cgroup=attached\nshared_tc=attached\nshared_interfaces=wlan2\ntransition=idle";
+
+test("completed background tasks quietly refresh complete runtime after foreground ownership changes", async () => {
+  const { context, state, timers, supersede } = backgroundFixture();
+  state.runtime.singBoxState = "stopped";
+  state.busy = true;
+  context.runCli = async (args) => args === "service status" ? serviceSnapshot : transparentSnapshot;
+  context.followBackgroundLogs("/task.log", "restart", "service restart", "operation", 1, 1);
+  supersede();
+  await timers.shift()();
+  assert.equal(state.backgroundTask.status, "done");
+  assert.equal(state.runtime.singBoxState, "sing-box");
+  assert.equal(state.runtime.transparentMode, "ebpf");
+  assert.equal(state.runtime.transparentEffectiveMode, "hybrid");
+  assert.equal(state.runtime.transparentLocalCgroup, "attached");
+  assert.equal(state.runtime.transparentSharedTc, "attached");
+  assert.deepEqual(state.runtime.transparentSharedInterfaces, ["wlan2"]);
+  assert.equal(state.output, "new foreground output");
+  assert.equal(state.notice, "new notice");
+  assert.equal(state.phase, "done");
+  assert.equal(state.busy, true);
+});
+
+test("completion refresh discards a runtime snapshot superseded while its reads were pending", async () => {
+  const { context, state, timers, supersede } = backgroundFixture();
+  let resolveRead, startRead;
+  const pending = new Promise((resolve) => { resolveRead = resolve; });
+  const started = new Promise((resolve) => { startRead = resolve; });
+  context.runCli = async (args) => {
+    startRead();
+    await pending;
+    return args === "service status" ? serviceSnapshot : transparentSnapshot;
+  };
+  context.followBackgroundLogs("/task.log", "restart", "service restart", "operation", 1, 1);
+  const polling = timers.shift()();
+  await started;
+  supersede();
+  const newerRuntime = parseRuntime("sing-box: stopped\nmode=tun\neffective_mode=tun", runtimeDefaults);
+  state.runtime = newerRuntime;
+  resolveRead();
+  await polling;
+  assert.equal(state.backgroundTask.status, "done");
+  assert.equal(state.runtime, newerRuntime);
+  assert.equal(state.output, "new foreground output");
+  assert.equal(state.notice, "new notice");
+});
+
+test("failed completion status reads preserve newer foreground feedback", async () => {
+  const { context, state, timers, supersede } = backgroundFixture();
+  context.runCli = async () => "[error] errno=1 status read failed";
+  context.followBackgroundLogs("/task.log", "restart", "service restart", "operation", 1, 1);
+  supersede();
+  await timers.shift()();
+  assert.equal(state.backgroundTask.status, "done");
+  assert.equal(state.output, "new foreground output");
+  assert.equal(state.notice, "new notice");
+  assert.equal(state.phase, "done");
 });

--- a/webui/src/components/pages/ControlPage.vue
+++ b/webui/src/components/pages/ControlPage.vue
@@ -204,19 +204,8 @@ function requestTransparentMode(mode: TransparentMode, event: MouseEvent): void 
 
 async function rebuildNodeCache(): Promise<void> {
   await withAction("rebuild-node-cache", async () => {
-    const launch = await startBackgroundCli("sub update sing-box", "重建 sing-box 节点缓存");
-    if (execFailed(launch)) return;
-    const operationId = state.backgroundTask.id;
-    const refreshWhenComplete = (): void => {
-      if (state.backgroundTask.id !== operationId) return;
-      if (state.backgroundTask.status === "done") {
-        void refreshAll();
-        return;
-      }
-      if (state.backgroundTask.status === "error" || state.backgroundTask.status === "timeout") return;
-      window.setTimeout(refreshWhenComplete, 500);
-    };
-    window.setTimeout(refreshWhenComplete, 1600);
+    // The background follower refreshes subscriptions and service status.
+    await startBackgroundCli("sub update sing-box", "重建 sing-box 节点缓存");
   });
 }
 

--- a/webui/src/components/pages/NodeDelayPanel.vue
+++ b/webui/src/components/pages/NodeDelayPanel.vue
@@ -163,7 +163,7 @@ const { target: visibilityTarget } = useVisibilityTask(refreshCurrentNode);
     />
 
     <div v-if="entries.length" class="rounded-md border border-[color-mix(in_srgb,var(--mn-heather)_55%,transparent)] bg-[color-mix(in_srgb,var(--mn-heather)_40%,var(--mn-carrier))] p-3">
-      <p class="text-sm font-semibold text-[var(--mn-info)]">测速健康摘要</p>
+      <p class="text-sm font-semibold text-[var(--mn-info)]">测速结果</p>
       <p class="mt-1 text-sm leading-6 text-[var(--mn-info)]">{{ healthText }}</p>
     </div>
 
@@ -177,10 +177,10 @@ const { target: visibilityTarget } = useVisibilityTask(refreshCurrentNode);
 
     <div class="grid gap-2 sm:grid-cols-5">
       <StatTile label="已测" :value="stats.tested" />
-      <StatTile label="可用" :value="stats.usable" />
+      <StatTile label="有响应" :value="stats.usable" />
       <StatTile label="失败" :value="stats.failed" />
       <StatTile label="平均" :value="delayLabel(stats.averageMillis)" />
-      <StatTile label="中位/解析可用率" :value="`${delayLabel(stats.medianMillis)} · ${stats.usablePercent}%`" />
+      <StatTile label="中位/响应率" :value="`${delayLabel(stats.medianMillis)} · ${stats.usablePercent}%`" />
     </div>
 
     <div v-if="stats.fastest || stats.slowest" class="grid gap-2 sm:grid-cols-2">

--- a/webui/src/composables/nodeDelayParsers.ts
+++ b/webui/src/composables/nodeDelayParsers.ts
@@ -91,10 +91,7 @@ export function buildNodeDelayStats(entries: NodeDelayEntry[]): NodeDelayStats {
 export function nodeDelayHealthText(stats: NodeDelayStats): string {
   if (!stats.tested) return "还没有测速结果。";
   if (!stats.usable) return "全部节点测速失败，先检查订阅、网络或 sing-box 运行状态。";
-  if (stats.usablePercent < 50) return `解析可用率 ${stats.usablePercent}%，节点池不稳定，不建议只按最快节点切换。`;
-  if (stats.medianMillis !== null && stats.medianMillis <= FAST_MAX_MS) return `中位延迟 ${stats.medianMillis}ms，解析可用率 ${stats.usablePercent}%，节点池状态良好。`;
-  if (stats.medianMillis !== null && stats.medianMillis <= NORMAL_MAX_MS) return `中位延迟 ${stats.medianMillis}ms，解析可用率 ${stats.usablePercent}%，可优先使用最快节点。`;
-  return `中位延迟 ${stats.medianMillis ?? "未知"}ms，解析可用率 ${stats.usablePercent}%，建议继续筛选更低延迟节点。`;
+  return `${stats.usable}/${stats.tested} 个节点返回延迟，中位 ${stats.medianMillis ?? "未知"}ms。测速未验证 HTTP 状态码或登录结果，低延迟不代表目标网站允许访问。`;
 }
 
 export function nodeDelayQualityLabel(quality: NodeDelayQuality): string {

--- a/webui/src/composables/useMagicNet.ts
+++ b/webui/src/composables/useMagicNet.ts
@@ -522,13 +522,11 @@ async function startBackgroundCli(
     true,
     previewOverride,
   );
-  if (!ownsForegroundUi()) {
-    return outcome.text;
-  }
+  if (state.backgroundTask.id !== operationId) return outcome.text;
   const accepted =
     outcome.ok && backgroundAccepted(outcome.stdout, operationId);
   if (accepted || outcome.timedOut) {
-    if (outcome.timedOut) {
+    if (outcome.timedOut && ownsForegroundUi()) {
       const output = redactOutput
         ? `${label} 的投递确认超时；这不代表设备侧任务失败。正在继续跟踪安全状态。`
         : `${label} 的投递确认超时；这不代表设备侧任务失败。正在继续跟踪后台日志。`;
@@ -556,12 +554,14 @@ async function startBackgroundCli(
     const output = redactOutput
       ? `${label} 未投递到后台；私有命令详情已隐藏。请检查设备状态后重试。`
       : `${label} 未投递到后台。\n\n${outcome.text || "[error] accepted marker missing"}`;
-    publishTrackedOperation(
-      operationSequence,
-      "error",
-      `投递失败：${label}`,
-      output,
-    );
+    if (ownsForegroundUi()) {
+      publishTrackedOperation(
+        operationSequence,
+        "error",
+        `投递失败：${label}`,
+        output,
+      );
+    }
   }
   if (outcome.timedOut) {
     return `[warning] background launch confirmation timed out; reconciliation continues in ${log}`;
@@ -608,7 +608,7 @@ function followBackgroundLogs(
   backgroundLogTimer = window.setTimeout(
     async () => {
       const subscriptionTask = isSubscriptionBackgroundArgs(args)
-        ? refreshSubs(true)
+        ? refreshSubs(true, undefined, false)
         : Promise.resolve(true);
       const [logs, status] = await Promise.all([
         runShell(
@@ -619,12 +619,9 @@ function followBackgroundLogs(
         runCli("service status", "刷新状态", true),
         subscriptionTask,
       ]);
-      if (
-        state.backgroundTask.id !== operationId ||
-        !foregroundUiGate.owns(foregroundToken)
-      )
-        return;
-      if (!execFailed(status)) {
+      if (state.backgroundTask.id !== operationId) return;
+      const ownsForegroundUi = foregroundUiGate.owns(foregroundToken);
+      if (ownsForegroundUi && !execFailed(status)) {
         state.runtime = parseRuntime(status, state.runtime);
       }
       const logCompletion = parseBackgroundCompletion(logs, operationId);
@@ -647,8 +644,10 @@ function followBackgroundLogs(
         ? "私有后台日志已隐藏。"
         : logs || "等待日志输出...";
       const output = `${done ? "后台任务完成" : failed ? "后台任务失败" : "后台任务运行中"}：${label}\n\n${visibleLogs}`;
-      if (
-        !publishTrackedOperation(
+      // Foreground ownership controls output only. The background operation
+      // must still finish and release its launch lock after another UI action.
+      if (ownsForegroundUi) {
+        publishTrackedOperation(
           operationSequence,
           done ? "done" : failed ? "error" : "running",
           done
@@ -657,9 +656,8 @@ function followBackgroundLogs(
               ? `失败：${label}`
               : `正在执行：${label}`,
           output,
-        )
-      )
-        return;
+        );
+      }
       state.backgroundTask.status = done
         ? "done"
         : failed
@@ -689,12 +687,14 @@ function followBackgroundLogs(
             (redactOutput
               ? "\n\n[warn] 安全状态跟踪已超时，但这不代表任务失败。请刷新订阅状态完成对账。"
               : "\n\n[warn] 日志跟踪已超时，但这不代表任务失败。请刷新订阅状态或查看完整日志以完成对账。");
-          publishTrackedOperation(
-            operationSequence,
-            "running",
-            `${label} 仍在后台运行或等待对账`,
-            timeoutOutput,
-          );
+          if (ownsForegroundUi) {
+            publishTrackedOperation(
+              operationSequence,
+              "running",
+              `${label} 仍在后台运行或等待对账`,
+              timeoutOutput,
+            );
+          }
         }
       }
     },
@@ -919,6 +919,7 @@ async function refreshBlock(
 async function refreshSubs(
   quiet = false,
   foregroundToken?: number,
+  reportFailure = true,
 ): Promise<boolean> {
   const listCommand = startForegroundCommand(
     "sub list",
@@ -945,7 +946,7 @@ async function refreshSubs(
     execFailed(statusText) ? "订阅状态" : "",
   ].filter(Boolean);
   if (failed.length) {
-    if (canUpdateRefreshUi(uiToken, allowBusy)) {
+    if (reportFailure && canUpdateRefreshUi(uiToken, allowBusy)) {
       state.phase = "error";
       state.notice = "订阅刷新不完整";
       state.output = `读取${failed.join("和")}失败，旧数据已保留。\n\n${[listText, statusText].filter(execFailed).join("\n")}`;
@@ -1092,8 +1093,15 @@ async function refreshSysroute(): Promise<void> {
   if (foregroundUiGate.owns(command.token)) state.sysroute = text;
 }
 
+function configDraftMatches(
+  snapshot: { target: ConfigEditorTarget; text: string },
+): boolean {
+  return state.config.target === snapshot.target && state.config.text === snapshot.text;
+}
+
 async function loadConfig(): Promise<void> {
-  const target = state.config.target;
+  const snapshot = { target: state.config.target, text: state.config.text };
+  const { target } = snapshot;
   const command = startForegroundCommand(
     `config-editor get ${target}`,
     `加载 ${target} 配置`,
@@ -1106,6 +1114,10 @@ async function loadConfig(): Promise<void> {
   }
   const text = await command.promise;
   if (!foregroundUiGate.owns(command.token)) return;
+  if (!configDraftMatches(snapshot)) {
+    state.config.status = "已保留加载期间的修改";
+    return;
+  }
   if (execFailed(text)) {
     state.config.status = "加载失败";
     state.notice = `${target} 配置加载失败`;
@@ -1128,12 +1140,14 @@ async function loadConfig(): Promise<void> {
 }
 
 async function saveConfig(): Promise<void> {
+  const snapshot = { target: state.config.target, text: state.config.text };
+  const { target } = snapshot;
   const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  const basename = `config-editor-${state.config.target}-${stamp}.tmp`;
+  const basename = `config-editor-${target}-${stamp}.tmp`;
   const stagePromise = stagePrivatePayload(
     "tmp",
     basename,
-    state.config.text,
+    snapshot.text,
     "配置私有载荷",
   );
   const stageToken = foregroundUiGate.current();
@@ -1159,29 +1173,34 @@ async function saveConfig(): Promise<void> {
   let uiToken = stageToken;
   try {
     const commandPromise = runPrivateCli(
-      `config-editor save-file ${state.config.target} ${shellQuote(staged.path)}`,
-      `校验并保存 ${state.config.target}`,
+      `config-editor save-file ${target} ${shellQuote(staged.path)}`,
+      `校验并保存 ${target}`,
       redactedCliPreview(
-        `config-editor save-file ${state.config.target} [private-payload]`,
+        `config-editor save-file ${target} [private-payload]`,
       ),
     );
     uiToken = foregroundUiGate.current();
     const outcome = await commandPromise;
     if (!foregroundUiGate.owns(uiToken)) return;
+    if (state.config.target !== target) return;
     const saved =
       outcome.ok && /\[info\]\s+Saved and validated/i.test(outcome.stdout);
+    const currentDraft = configDraftMatches(snapshot);
     state.config.validation = {
-      status: saved ? "ok" : "error",
-      summary: saved ? "配置已通过校验并保存。" : "配置校验失败，未保存。",
+      status: currentDraft ? (saved ? "ok" : "error") : "idle",
+      summary: !currentDraft
+        ? "当前修改尚未校验。"
+        : saved ? "配置已通过校验并保存。" : "配置校验失败，未保存。",
       checkedAt: new Date().toLocaleTimeString(),
     };
     state.config.status = saved ? "校验通过，已保存" : "校验失败，未保存";
+    if (!currentDraft) state.config.status += "；当前修改未保存";
     state.phase = saved ? "done" : "error";
     state.notice = saved
       ? `${state.config.target} 配置已保存`
       : `${state.config.target} 配置未保存`;
     state.output = state.config.status;
-    if (saved) state.config.dirty = false;
+    if (saved && currentDraft) state.config.dirty = false;
   } finally {
     const cleaned = await removePrivatePayload(
       "tmp",
@@ -1203,13 +1222,15 @@ async function saveConfig(): Promise<void> {
 }
 
 async function syncConfigTemplate(): Promise<void> {
-  const target = state.config.target;
+  const snapshot = { target: state.config.target, text: state.config.text };
+  const { target } = snapshot;
   const command = startForegroundCommand(
     `config-editor sync-template ${target}`,
     `同步 ${target} 配置仓库模板`,
   );
   const text = await command.promise;
   if (!foregroundUiGate.owns(command.token)) return;
+  if (state.config.target !== target) return;
   const failed = execFailed(text);
   const validation = parseConfigValidation(text);
   state.config.status = failed ? "同步失败" : "已同步配置仓库模板";
@@ -1219,7 +1240,13 @@ async function syncConfigTemplate(): Promise<void> {
     checkedAt: new Date().toLocaleTimeString(),
   };
   if (!failed) {
-    state.config.dirty = false;
+    if (!configDraftMatches(snapshot)) {
+      state.config.status = "已同步模板；当前修改已保留";
+      state.config.validation = {
+        status: "idle", summary: "当前修改尚未校验。", checkedAt: "",
+      };
+      return;
+    }
     await loadConfig();
   }
 }

--- a/webui/src/composables/useMagicNet.ts
+++ b/webui/src/composables/useMagicNet.ts
@@ -480,10 +480,17 @@ async function startBackgroundCli(
   const redactOutput = Boolean(previewOverride);
   const subscriptionTask = isSubscriptionBackgroundArgs(lifecycleArgs);
   const subscriptionBaselineKnown = subscriptionTask
-    ? await refreshSubs(true)
+    ? await refreshSubs(true, foregroundToken, false)
     : false;
   if (!ownsForegroundUi()) {
     return `[warning] ${label} superseded by a newer foreground operation`;
+  }
+  if (subscriptionTask && !subscriptionBaselineKnown) {
+    const text = "[error] unavailable: 读取订阅基线失败，任务未启动。请确认设备连接后重试。";
+    state.phase = "error";
+    state.notice = `未执行：${label}`;
+    state.output = text;
+    return text;
   }
   const operationId = createBackgroundOperationId();
   const log = backgroundLogPath(label, operationId);
@@ -610,20 +617,15 @@ function followBackgroundLogs(
       const subscriptionTask = isSubscriptionBackgroundArgs(args)
         ? refreshSubs(true, undefined, false)
         : Promise.resolve(true);
-      const [logs, status] = await Promise.all([
+      const [logs] = await Promise.all([
         runShell(
           backgroundLogCommand(log, args, operationId),
           `跟踪 ${label}`,
           true,
         ),
-        runCli("service status", "刷新状态", true),
         subscriptionTask,
       ]);
       if (state.backgroundTask.id !== operationId) return;
-      const ownsForegroundUi = foregroundUiGate.owns(foregroundToken);
-      if (ownsForegroundUi && !execFailed(status)) {
-        state.runtime = parseRuntime(status, state.runtime);
-      }
       const logCompletion = parseBackgroundCompletion(logs, operationId);
       const subscriptionCompletion = isSubscriptionBackgroundArgs(args)
         ? reconcileSubscriptionCompletion(
@@ -639,6 +641,11 @@ function followBackgroundLogs(
             : "running";
       const done = completion === "done";
       const failed = completion === "error";
+      if (done || failed) {
+        await refreshStatus(foregroundUiGate.current(), false);
+        if (state.backgroundTask.id !== operationId) return;
+      }
+      const ownsForegroundUi = foregroundUiGate.owns(foregroundToken);
       const now = Date.now();
       const visibleLogs = redactOutput
         ? "私有后台日志已隐藏。"
@@ -725,7 +732,10 @@ function markQuietFailure(
   return true;
 }
 
-async function refreshStatus(foregroundToken?: number): Promise<boolean> {
+async function refreshStatus(
+  foregroundToken?: number,
+  reportFailure = true,
+): Promise<boolean> {
   const serviceCommand = startForegroundCommand(
     "service status",
     "刷新服务状态",
@@ -766,7 +776,7 @@ async function refreshStatus(foregroundToken?: number): Promise<boolean> {
     }
   }
   if (failure) {
-    markQuietFailure("刷新状态", failure, uiToken, allowBusy);
+    if (reportFailure) markQuietFailure("刷新状态", failure, uiToken, allowBusy);
     return false;
   }
   return true;


### PR DESCRIPTION
Late config reads could overwrite edits entered while loading, and saving an older snapshot could mark newer edits as saved. Changing the foreground action could also strand a device task in the running state; a failed background subscription refresh could replace the new action's feedback.

Snapshot the config target and draft for loading/saving/template sync. Reconcile background tasks using their operation ID while requiring foreground ownership for output changes. Background subscription-read failures remain silent and later successful polls can still complete the task. Manual refresh keeps its failure feedback.

Add ten behavioral regressions that execute production functions with deferred device I/O. The subscription failure case includes the real refresh/parser/ownership functions and checks output, notice, phase, and recovery. Replace one misleading cross-function regex assertion with a behavioral baseline-order test.

Latency copy now describes responses and timing without claiming HTTP or login success; the underlying HEAD measurement does not validate status codes. This is not a confirmed fix for the reported ChatGPT authentication-page failure.

Validation: all 78 frontend tests, TypeScript checks, and the Vite production build pass. Independent review verified the foreground/background error path. Most added lines are regression coverage; no new dependencies. Browser and Android-device behavior have not been exercised in this environment.

GitHub CI passed WebUI, Code Quality, repository validation, and the [complete module build with installation smoke checks](https://github.com/LIghtJUNction/MagicNet/actions/runs/33966946264).

Merge-review follow-up: a failed subscription baseline now rejects the launch with a retryable message. ControlPage no longer starts a separate foreground refresh on background completion. The background follower instead reads complete service and transparent state quietly on completion, preserves current feedback, and rejects snapshots superseded while reading. This also removes redundant service-only polling that reset transparent details.

All 85 frontend tests, type checks, and the production build pass locally. Behavioral regressions use the real ControlPage action, background follower, refreshStatus/refreshSubs and runtime parser; they cover baseline read failure/retry, complete eBPF status refresh, a newer foreground operation during that read, and silent failure. Independent review reran all 17 concurrency cases successfully. CI is rerunning for this follow-up.

## Sourcery 总结

保护较新的用户编辑，并优先显示前台反馈，同时确保后台操作可靠完成并进行协调。

Bug 修复：
- 当异步加载、保存或模板同步完成时，保留较新的配置编辑。
- 即使前台操作发生变化，也持续跟踪后台操作直至完成，同时不覆盖较新的前台反馈。
- 允许后台订阅刷新静默失败，同时保留手动刷新错误，并支持后续恢复。
- 在后台操作完成后刷新运行时状态，同时避免将过时结果应用到较新的状态上。

增强功能：
- 明确节点延迟消息，用于描述响应时间，但不暗示 HTTP 状态或身份验证成功。
- 统一处理节点缓存重建的后台完成逻辑。

测试：
- 增加针对配置并发、前台/后台所有权、订阅生命周期恢复、运行时刷新以及过时结果保护的行为回归测试覆盖。
- 将脆弱的跨函数源代码断言替换为行为测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Protect newer user edits and foreground feedback while ensuring background operations complete and reconcile reliably.

Bug Fixes:
- Preserve newer configuration edits when asynchronous loads, saves, or template synchronization complete.
- Keep background operations tracked to completion after foreground actions change, without overwriting newer foreground feedback.
- Allow background subscription refreshes to fail silently while retaining manual refresh errors and supporting later recovery.
- Refresh runtime state after background completion without applying stale results over newer state.

Enhancements:
- Clarify node latency messaging to describe response timing without implying HTTP status or authentication success.
- Consolidate background completion handling for node cache rebuilds.

Tests:
- Add behavioral regression coverage for configuration concurrency, foreground/background ownership, subscription lifecycle recovery, runtime refreshes, and stale result protection.
- Replace a brittle cross-function source assertion with behavioral coverage.

</details>