### PR TITLE
fix(release): verify signatures after final ZIP sanitization

### DIFF
--- a/.github/workflows/exec.yml
+++ b/.github/workflows/exec.yml
@@ -129,6 +129,14 @@ jobs:
           PUSH_BEFORE: ${{ github.event.before }}
         run: python3 scripts/prepare-release.py
 
+      - name: Prepare signing verification key
+        if: ${{ env.MAGICNET_SIGN_ENABLED == '1' }}
+        env:
+          SIGNING_KEY_PEM: ${{ secrets.KAM_PRIVATE_KEY }}
+        run: |
+          printf '%s' "$SIGNING_KEY_PEM" | openssl pkey -pubout \
+            -out "$RUNNER_TEMP/magicnet-signing-public.pem"
+
       - name: Setup Go for forked sing-box
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
@@ -231,7 +239,8 @@ jobs:
           test -n "$module_id"
           test -f "dist/${module_id}.zip"
           if [ "${MAGICNET_SIGN_ENABLED}" = "1" ]; then
-            test -f "dist/${module_id}.zip.sig"
+            scripts/verify-artifact-signature.sh "dist/${module_id}.zip" \
+              "$RUNNER_TEMP/magicnet-signing-public.pem"
           fi
           unzip -Z1 "dist/${module_id}.zip" | grep -Fx 'module.prop'
           unzip -Z1 "dist/${module_id}.zip" | grep -Fx 'cli'

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -47,3 +47,4 @@ jobs:
           kam check
           python3 scripts/test-release-workflow.py
           bash scripts/test-subscription-usage.sh
+          bash scripts/test-artifact-signature.sh

--- a/hooks/post-build/7900.sanitize_zip.sh
+++ b/hooks/post-build/7900.sanitize_zip.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Complete archive changes before the base 8000 signing hook runs.
 # shellcheck source=hooks/lib/utils.sh
 . "$KAM_HOOKS_ROOT/lib/utils.sh"
 

--- a/scripts/prepare-release.py
+++ b/scripts/prepare-release.py
@@ -121,6 +121,8 @@ def prepare():
         print(f"Validated {version}; build only")
         return
     require_main_checkout()
+    if os.environ.get("KAM_PRIVATE_KEY_AVAILABLE") != "1":
+        raise ValueError("Publishing requires the KAM_PRIVATE_KEY signing secret")
     require_new_tag(version)
     with open(os.environ["GITHUB_ENV"], "a") as output:
         output.write(f"RELEASE_REQUESTED=1\nRELEASE_VERSION={version}\n")

--- a/scripts/test-artifact-signature.sh
+++ b/scripts/test-artifact-signature.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+export KAM_PROJECT_ROOT="$test_root/project"
+export KAM_HOOKS_ROOT="$test_root/hooks"
+mkdir -p "$KAM_PROJECT_ROOT/dist" "$KAM_PROJECT_ROOT/scripts" "$KAM_HOOKS_ROOT/lib" \
+    "$test_root/source/lib/kamfw" "$test_root/source/.config/sing-box"
+printf '[prop]\nid = "MagicNet"\n' > "$KAM_PROJECT_ROOT/kam.toml"
+printf 'fixture\n' > "$test_root/source/lib/kamfw/__singbox__.sh"
+printf '{}\n' > "$test_root/source/.config/sing-box/.dns-test.json"
+cat > "$KAM_HOOKS_ROOT/lib/utils.sh" <<'SH'
+log_info() { :; }
+require_command() { command -v "$1" >/dev/null; }
+SH
+printf '#!/bin/bash\nexit 0\n' > "$KAM_PROJECT_ROOT/scripts/package-smoke.sh"
+chmod +x "$KAM_PROJECT_ROOT/scripts/package-smoke.sh"
+openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out "$test_root/key.pem" 2>/dev/null
+openssl pkey -in "$test_root/key.pem" -pubout -out "$test_root/public.pem"
+artifact="$KAM_PROJECT_ROOT/dist/MagicNet.zip"
+sanitize_hooks=("$repo_root"/hooks/post-build/*.sanitize_zip.sh)
+test "${#sanitize_hooks[@]}" -eq 1
+sanitize_hook="${sanitize_hooks[0]}"
+
+make_archive() {
+    rm -f "$artifact" "${artifact}.sig"
+    (cd "$test_root/source" && zip -qr "$artifact" .)
+}
+sign_archive() {
+    openssl dgst -sha256 -sign "$test_root/key.pem" -out "$test_root/signature.der" "$artifact"
+    openssl base64 -A -in "$test_root/signature.der" -out "${artifact}.sig"
+}
+verify_archive() {
+    "$repo_root/scripts/verify-artifact-signature.sh" "$artifact" "$test_root/public.pem" >/dev/null 2>&1
+}
+
+# Reproduce the original failure: a valid signature becomes invalid after cleanup.
+make_archive
+sign_archive
+verify_archive
+bash "$sanitize_hook"
+if verify_archive; then
+    echo 'Post-sign cleanup must invalidate the original signature' >&2
+    exit 1
+fi
+
+# KAM merges base and overlay hooks in filename order; exercise that order.
+make_archive
+while IFS= read -r hook; do
+    case "$hook" in
+        8000.SIGN_IF_ENABLE.sh) sign_archive ;;
+        *) bash "$sanitize_hook" ;;
+    esac
+done < <(printf '%s\n' "${sanitize_hook##*/}" 8000.SIGN_IF_ENABLE.sh | LC_ALL=C sort)
+verify_archive
+if unzip -Z1 "$artifact" | grep -Fq '.dns-test.json'; then
+    echo 'Archive cleanup did not remove its fixture' >&2
+    exit 1
+fi
+
+# The final artifact check must reject later mutation and a missing signature.
+printf 'changed\n' >> "$artifact"
+if verify_archive; then
+    echo 'Modified archive passed signature verification' >&2
+    exit 1
+fi
+rm "${artifact}.sig"
+if verify_archive; then
+    echo 'Unsigned archive passed signature verification' >&2
+    exit 1
+fi
+printf 'Artifact signing order and integrity checks passed\n'

--- a/scripts/test-release-integrity.sh
+++ b/scripts/test-release-integrity.sh
@@ -206,4 +206,5 @@ assert_failure hook_preflight_archive "$TEST_ROOT/link.zip"
 printf 'not an archive\n' >"$TEST_ROOT/invalid.archive"
 assert_failure hook_preflight_archive "$TEST_ROOT/invalid.archive"
 
+bash "$ROOT/scripts/test-artifact-signature.sh"
 printf 'release integrity test passed\n'

--- a/scripts/test-release-workflow.py
+++ b/scripts/test-release-workflow.py
@@ -69,6 +69,7 @@ class ReleaseWorkflowTest(unittest.TestCase):
         env = dict(os.environ, GITHUB_EVENT_NAME="push", GITHUB_REF="refs/heads/main",
                    GITHUB_SHA=self.git("rev-parse", "HEAD"), PUSH_BEFORE=self.before,
                    RELEASE_INPUT="false", PRERELEASE_INPUT="false",
+                   KAM_PRIVATE_KEY_AVAILABLE="1",
                    GITHUB_ENV=str(self.output), GITHUB_OUTPUT=str(self.step_output))
         env.update(overrides)
         command = [sys.executable, str(SCRIPT)]
@@ -282,6 +283,23 @@ class ReleaseWorkflowTest(unittest.TestCase):
         self.assert_build_only(self.run_workflow(GITHUB_EVENT_NAME="workflow_dispatch"))
         self.assert_release(self.run_workflow(
             GITHUB_EVENT_NAME="workflow_dispatch", RELEASE_INPUT="true"))
+
+    def test_releases_require_a_signing_key_before_exporting_release_state(self):
+        self.commit(RELEASE_MARKER, "v1.2.3\n")
+        for event in ("push", "workflow_dispatch"):
+            with self.subTest(event=event):
+                self.assert_rejected(self.run_workflow(
+                    GITHUB_EVENT_NAME=event, RELEASE_INPUT="true",
+                    KAM_PRIVATE_KEY_AVAILABLE="0"), "KAM_PRIVATE_KEY")
+
+    def test_builds_without_release_do_not_require_a_signing_key(self):
+        self.commit(RELEASE_MARKER, "v1.2.3\n")
+        for event, ref in (("workflow_dispatch", "refs/heads/main"),
+                           ("pull_request", "refs/pull/42/merge")):
+            with self.subTest(event=event):
+                self.assert_build_only(self.run_workflow(
+                    GITHUB_EVENT_NAME=event, GITHUB_REF=ref,
+                    KAM_PRIVATE_KEY_AVAILABLE="0"))
 
     def test_manual_release_from_another_branch_is_rejected(self):
         self.git("checkout", "-b", "feature")

--- a/scripts/verify-artifact-signature.sh
+++ b/scripts/verify-artifact-signature.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+artifact="${1:?Usage: verify-artifact-signature.sh ZIP PUBLIC_KEY}"
+public_key="${2:?Usage: verify-artifact-signature.sh ZIP PUBLIC_KEY}"
+test -s "$artifact"
+test -s "${artifact}.sig"
+signature="$(mktemp)"
+trap 'rm -f "$signature"' EXIT
+
+# kam sign writes a base64-encoded SHA-256 signature beside the archive.
+openssl base64 -d -A -in "${artifact}.sig" -out "$signature"
+openssl dgst -sha256 -verify "$public_key" -signature "$signature" "$artifact"


### PR DESCRIPTION
The custom ZIP sanitizer ran at 9000, after the base 8000 signing hook. Any sanitizer change to the archive then invalidated its signature, while the workflow only checked that a .sig file existed.

Move sanitization to 7900 and cryptographically verify the final ZIP before upload. The workflow derives a temporary public key from KAM_PRIVATE_KEY via stdin; only the public key is written to disk. Missing signing credentials fail early for publishing; ordinary unsigned builds remain allowed.

Add a real OpenSSL regression reproducing the old sign-then-modify failure and checking the corrected hook order, later tampering, and missing signatures. Run it in PR validation and the existing release-integrity suite.

Validation: 28 release-workflow tests, artifact signing regression, ShellCheck and shell syntax pass. Independent review checked KAM's filename ordering and SHA-256/Base64 signature implementation. This demonstrates an ordering defect; it does not establish that an existing published artifact has an invalid signature. The complete PR build also passes: KAM 0.6.12 ran 7900 before 8000, final ZIP verification reported Verified OK, and package/install/fake-Magisk smoke checks succeeded. See [build 33966981617](https://github.com/LIghtJUNction/MagicNet/actions/runs/33966981617). The release step was skipped for the PR event.

Separate existing release concerns: the latest version-PR run is blocked by GitHub's repository setting that forbids Actions from creating PRs; this patch does not alter repository permissions. The stable update.json feed still shares planned build metadata and needs a separate compatibility-preserving publication change.

Review verification: version-PR preparation invokes `--bump` and calls `bump()` directly; the signing-key requirement is scoped to `prepare()` for actual publishing. Isolated git-fixture checks confirmed `--bump patch` with `release=true` succeeds without available signing credentials for both stable and prerelease requests, and emits only the intended version-PR marker. No production change is needed for that review concern.