### PR TITLE
refactor(webui): centralize subscription lifecycle status

### DIFF
--- a/webui/src/components/pages/subscriptions/SubscriptionLifecycleRecord.vue
+++ b/webui/src/components/pages/subscriptions/SubscriptionLifecycleRecord.vue
@@ -2,10 +2,7 @@
 import { locale, t } from "@/i18n";
 import { computed } from "vue";
 import { useMagicNet } from "@/composables/useMagicNet";
-import {
-  isSubscriptionBackgroundArgs,
-  subscriptionLifecycleRunning,
-} from "@/composables/backgroundTasks";
+import { subscriptionLifecycleStatus } from "@/composables/backgroundTasks";
 
 const props = defineProps<{
   configured: boolean;
@@ -13,13 +10,7 @@ const props = defineProps<{
 
 const { state } = useMagicNet();
 
-const lifecycleStatus = computed(() => {
-  if (subscriptionLifecycleRunning(state.backgroundTask, state.subscriptions.updateRunning)) return "running";
-  if (state.backgroundTask.status === "timeout" && isSubscriptionBackgroundArgs(state.backgroundTask.args)) return "timeout";
-  if (state.subscriptions.lastResult === "success") return "done";
-  if (["failed", "interrupted"].includes(state.subscriptions.lastResult)) return "error";
-  return props.configured ? "idle" : "empty";
-});
+const lifecycleStatus = computed(() => subscriptionLifecycleStatus(state, props.configured));
 
 function formatEpoch(epoch: number): string {
   if (!epoch) return t("尚无记录");

--- a/webui/src/components/pages/subscriptions/SubscriptionLifecycleStrip.vue
+++ b/webui/src/components/pages/subscriptions/SubscriptionLifecycleStrip.vue
@@ -2,10 +2,7 @@
 import { t } from "@/i18n";
 import { computed } from "vue";
 import { useMagicNet } from "@/composables/useMagicNet";
-import {
-  isSubscriptionBackgroundArgs,
-  subscriptionLifecycleRunning,
-} from "@/composables/backgroundTasks";
+import { subscriptionLifecycleStatus } from "@/composables/backgroundTasks";
 
 const props = defineProps<{
   configured: boolean;
@@ -13,13 +10,7 @@ const props = defineProps<{
 
 const { state } = useMagicNet();
 
-const lifecycleStatus = computed(() => {
-  if (subscriptionLifecycleRunning(state.backgroundTask, state.subscriptions.updateRunning)) return "running";
-  if (state.backgroundTask.status === "timeout" && isSubscriptionBackgroundArgs(state.backgroundTask.args)) return "timeout";
-  if (state.subscriptions.lastResult === "success") return "done";
-  if (["failed", "interrupted"].includes(state.subscriptions.lastResult)) return "error";
-  return props.configured ? "idle" : "empty";
-});
+const lifecycleStatus = computed(() => subscriptionLifecycleStatus(state, props.configured));
 
 const lifecycleLabel = computed(() => ({
   empty: t("等待首次配置"),

--- a/webui/src/composables/backgroundTasks.ts
+++ b/webui/src/composables/backgroundTasks.ts
@@ -183,3 +183,19 @@ export function subscriptionLifecycleRunning(
 ): boolean {
   return isActiveSubscriptionBackgroundTask(task) || deviceUpdateRunning;
 }
+
+type SubscriptionLifecycleState = {
+  backgroundTask: Pick<BackgroundTaskState, "status" | "args">;
+  subscriptions: { updateRunning: boolean; lastResult: string };
+};
+
+export function subscriptionLifecycleStatus(
+  state: SubscriptionLifecycleState,
+  configured: boolean,
+): BackgroundTaskStatus | "empty" {
+  if (subscriptionLifecycleRunning(state.backgroundTask, state.subscriptions.updateRunning)) return "running";
+  if (state.backgroundTask.status === "timeout" && isSubscriptionBackgroundArgs(state.backgroundTask.args)) return "timeout";
+  if (state.subscriptions.lastResult === "success") return "done";
+  if (["failed", "interrupted"].includes(state.subscriptions.lastResult)) return "error";
+  return configured ? "idle" : "empty";
+}


### PR DESCRIPTION
## Problem

The subscription record and lifecycle strip independently implemented the same six-state lifecycle decision tree. Keeping two copies makes it easy for one view to drift when timeout or completion rules change.

## Change

Move the shared decision tree into `subscriptionLifecycleStatus()` and have both components call it. Existing lower-level helpers remain unchanged.

## Behavior preservation

The conditions and their order are unchanged:

1. active subscription task or device update → `running`
2. timed-out subscription task → `timeout`
3. successful result → `done`
4. failed/interrupted result → `error`
5. configured/unconfigured fallback → `idle`/`empty`

A targeted nine-case check covered each branch, including a non-subscription timeout.

## Validation

- `npm run check` in `webui`
  - Node test suite: 117/117 passed
  - `vue-tsc --noEmit`: passed
  - Vite production build: passed (1,916 modules transformed)
- Targeted lifecycle matrix: 9/9 passed
- `git diff --check`: passed

## Diff

- Additions: 20
- Deletions: 22
- Net: -2 lines
- Files: 3

## Risk

Low. This is a direct extraction of duplicated pure decision logic; public behavior, state mutation, error handling, and component output are unchanged.

## Sourcery 总结

增强功能：
- 在共享辅助函数中集中评估订阅生命周期状态，供两个订阅生命周期视图使用，同时保留现有的状态优先级和行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Centralize subscription lifecycle status evaluation in a shared helper used by both subscription lifecycle views, preserving the existing state precedence and behavior.

</details>