### PR TITLE
fix(webui): restore native proxy group members

### DIFF
--- a/webui/proxy-groups.test.mjs
+++ b/webui/proxy-groups.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseProxyGroupsSnapshot } from "./src/composables/proxyGroupParsers.ts";
+import { buildProxySelectionPlan } from "./src/components/pages/proxySelectionPlan.ts";
+
+test("native /proxies groups expose all members for selection and group testing", () => {
+  const snapshot = parseProxyGroupsSnapshot(JSON.stringify({
+    proxies: {
+      proxy: { type: "Selector", now: "auto", all: ["auto", "US node", "日本"] },
+      auto: { type: "URLTest", now: "US node", all: ["US node", "日本"] },
+      "US node": { type: "Shadowsocks", history: [] },
+      direct: { type: "Direct" },
+    },
+  }));
+  assert.deepEqual(snapshot.groups, [
+    { name: "proxy", type: "Selector", now: "auto", proxies: ["auto", "US node", "日本"] },
+    { name: "auto", type: "URLTest", now: "US node", proxies: ["US node", "日本"] },
+  ]);
+  const plan = buildProxySelectionPlan(snapshot.groups[0], "US node", [{
+    node: "US node", summary: "40ms", delayMillis: 40, quality: "fast",
+  }]);
+  assert.equal(plan.status, "ready");
+  assert.deepEqual(plan.warnings, []);
+});
+
+test("provider and legacy group responses retain proxies member support", () => {
+  const group = { name: "provider", type: "provider", now: "", proxies: ["one", "two"] };
+  const source = { proxies: ["one", { name: "two" }, null, 12, {}] };
+  assert.deepEqual(
+    parseProxyGroupsSnapshot(JSON.stringify({ providers: { provider: source } })).groups,
+    [group],
+  );
+  assert.deepEqual(parseProxyGroupsSnapshot(JSON.stringify({ provider: source })).groups, [group]);
+});
+
+test("native all members take precedence, including an explicitly empty list", () => {
+  const snapshot = parseProxyGroupsSnapshot(JSON.stringify({
+    proxies: {
+      proxy: { now: "active", all: ["active"], proxies: ["stale"] },
+      empty: { now: "previous", all: [], proxies: ["stale"] },
+    },
+  }));
+  assert.deepEqual(snapshot.groups.map((group) => group.proxies), [["active"], []]);
+});
+
+test("invalid snapshot roots are rejected while an empty proxies map is valid", () => {
+  for (const source of ["null", "false", "42", '"text"', "[]", "not json"]) {
+    assert.equal(parseProxyGroupsSnapshot(source), null, source);
+  }
+  assert.deepEqual(parseProxyGroupsSnapshot('{"proxies":{}}'), { groups: [] });
+});

--- a/webui/src/composables/proxyGroupParsers.ts
+++ b/webui/src/composables/proxyGroupParsers.ts
@@ -13,7 +13,8 @@ export type ProxyGroupsSnapshot = {
 
 export function parseProxyGroupsSnapshot(text: string): ProxyGroupsSnapshot | null {
   try {
-    const root = JSON.parse(text) as Record<string, unknown>;
+    const root = objectValue(JSON.parse(text));
+    if (!root) return null;
     const groups = [
       ...parseProxyGroupObject(objectValue(root.proxies)),
       ...parseProxyGroupObject(objectValue(root.providers))
@@ -37,8 +38,10 @@ function parseProxyGroupObject(source: Record<string, unknown> | null): ProxyGro
 
 function parseProxyGroup(key: string, item: Record<string, unknown> | null): ProxyGroupSummary | null {
   if (!item) return null;
-  const proxies = Array.isArray(item.proxies)
-    ? item.proxies.map(proxyName).filter((name): name is string => Boolean(name))
+  // /proxies selectors use `all`; provider responses use `proxies`.
+  const members = Array.isArray(item.all) ? item.all : item.proxies;
+  const proxies = Array.isArray(members)
+    ? members.map(proxyName).filter((name): name is string => Boolean(name))
     : [];
   if (!proxies.length && !stringValue(item.now)) return null;
   return {


### PR DESCRIPTION
## 问题

WebUI 读取 CLI 原样返回的 `/proxies` 响应时，仅解析 `proxies` 成员字段。sing-box 的 Selector/URLTest 使用 `all`，因此真实代理组的节点列表为空，影响节点选择和组测速。

## 修改

- 优先读取原生 `all`，包括显式空列表；继续兼容 provider 和旧格式的 `proxies`。
- 拒绝数组、标量等非对象响应。
- 新增 4 个行为回归用例，覆盖实际响应形状、节点选择计划、兼容格式与字段优先级。

## 验证

- 原实现运行新增测试：3/4 失败，确认复现。
- `cd webui && npm run check`：121/121 测试通过，Vue 类型检查和 Vite 构建通过。
- `git diff --check`：通过。

修改限于响应解析与测试，无界面样式或设备执行路径改动。

## Sourcery 总结

恢复对原生、提供商和旧版响应格式中代理组成员关系的准确解析。

Bug 修复：
- 通过解析 `all` 字段恢复原生代理组成员列表，同时保留对提供商和旧版 `proxies` 字段的兼容性。
- 拒绝无效的非对象代理快照响应，而不是尝试解析它们。

增强功能：
- 优先使用原生成员列表，包括显式为空的列表，而不是旧版字段。

测试：
- 增加对原生组响应、选择计划、兼容格式、字段优先级以及无效响应根节点的回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore accurate proxy group membership parsing across native, provider, and legacy response formats.

Bug Fixes:
- Restore native proxy group member lists by parsing the `all` field while preserving provider and legacy `proxies` compatibility.
- Reject invalid non-object proxy snapshot responses instead of attempting to parse them.

Enhancements:
- Prioritize native member lists, including explicitly empty lists, over legacy fields.

Tests:
- Add regression coverage for native group responses, selection plans, compatibility formats, field precedence, and invalid response roots.

</details>