### PR TITLE
fix(mcp): reject FIFOs before reading files and logs

### DIFF
--- a/crates/magicnet-mcp-server/src/files.rs
+++ b/crates/magicnet-mcp-server/src/files.rs
@@ -1,5 +1,6 @@
 use std::fs;
-use std::io::Read;
+use std::io::{self, Read};
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Component, Path};
 
 use crate::Server;
@@ -42,7 +43,7 @@ pub(crate) fn file_read(server: &Server, rel: &str) -> String {
         Ok(path) => path,
         Err(err) => return err,
     };
-    let file = match fs::File::open(&path) {
+    let file = match open_regular_file(&path) {
         Ok(file) => file,
         Err(err) => return format!("not a file: {rel}: {err}"),
     };
@@ -58,6 +59,23 @@ pub(crate) fn file_read(server: &Server, rel: &str) -> String {
         .take(240)
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+pub(crate) fn open_regular_file(path: &Path) -> io::Result<fs::File> {
+    let invalid_type = || io::Error::new(io::ErrorKind::InvalidInput, "not a regular file");
+    if !fs::symlink_metadata(path)?.is_file() {
+        return Err(invalid_type());
+    }
+    // A FIFO substituted after the metadata check must not block a worker in open().
+    // Both callers have already resolved in-module symlinks to their target paths.
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NONBLOCK | libc::O_NOFOLLOW)
+        .open(path)?;
+    if !file.metadata()?.is_file() {
+        return Err(invalid_type());
+    }
+    Ok(file)
 }
 
 fn module_path(server: &Server, rel: &str) -> Result<std::path::PathBuf, String> {
@@ -84,9 +102,14 @@ fn module_path(server: &Server, rel: &str) -> Result<std::path::PathBuf, String>
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::CString;
     use std::fs;
-    use std::os::unix::fs::symlink;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::{symlink, OpenOptionsExt};
     use std::path::PathBuf;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
 
     use super::*;
 
@@ -135,5 +158,55 @@ mod tests {
         assert!(result.starts_with("file too large: large"));
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    fn assert_fifo_rejected(name: &str, read: fn(&Server) -> String) {
+        let (server, root) = test_server(name);
+        fs::create_dir_all(root.join(".log")).unwrap();
+        let fifo = root.join(".log/pipe.log");
+        let fifo_name = CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
+        let (sender, receiver) = mpsc::channel();
+        let worker = thread::spawn(move || {
+            let _ = sender.send(read(&server));
+        });
+        let result = receiver.recv_timeout(Duration::from_secs(2));
+        if result.is_err() {
+            // Unblock the old blocking open/read so a regression cannot hang the suite.
+            let _ = fs::OpenOptions::new()
+                .write(true)
+                .custom_flags(libc::O_NONBLOCK)
+                .open(&fifo);
+        }
+        fs::remove_dir_all(root).unwrap();
+        let result = result.expect("FIFO reads must finish without a writer");
+        worker.join().unwrap();
+        assert!(result.contains("not a regular file"), "{result}");
+    }
+
+    #[test]
+    fn file_read_rejects_fifo_without_waiting_for_a_writer() {
+        assert_fifo_rejected("file-fifo", |server| file_read(server, ".log/pipe.log"));
+    }
+
+    #[test]
+    fn log_read_rejects_fifo_without_waiting_for_a_writer() {
+        assert_fifo_rejected("log-fifo", |server| {
+            crate::logs::log_read(server, "pipe", 10, false)
+        });
+    }
+
+    #[test]
+    fn file_and_log_reads_preserve_regular_file_contents() {
+        let (server, root) = test_server("regular");
+        fs::create_dir_all(root.join(".log")).unwrap();
+        fs::write(root.join(".log/example.log"), "first\nsecond\nthird\n").unwrap();
+        symlink(root.join(".log/example.log"), root.join("internal-link")).unwrap();
+        assert_eq!(file_read(&server, "internal-link"), "first\nsecond\nthird");
+        assert_eq!(
+            crate::logs::log_read(&server, "example", 2, false),
+            "second\nthird"
+        );
+        fs::remove_dir_all(root).unwrap();
     }
 }

--- a/crates/magicnet-mcp-server/src/logs.rs
+++ b/crates/magicnet-mcp-server/src/logs.rs
@@ -1,8 +1,9 @@
-use std::fs::{self, File};
+use std::fs;
 use std::io::{Read, Seek, SeekFrom};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::files::open_regular_file;
 use crate::{run_cli, Server};
 
 const MAX_LOG_READ_BYTES: u64 = 1024 * 1024;
@@ -76,8 +77,8 @@ pub(crate) fn log_read(server: &Server, source: &str, lines: usize, redact: bool
     }
 }
 
-fn read_bounded_tail(path: &PathBuf) -> std::io::Result<String> {
-    let file = File::open(path)?;
+fn read_bounded_tail(path: &Path) -> std::io::Result<String> {
+    let file = open_regular_file(path)?;
     let len = file.metadata()?.len();
     read_log_snapshot(file, len)
 }
@@ -226,6 +227,7 @@ fn redact_token(token: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs::File;
     use std::io::Write;
     use std::os::unix::fs::symlink;
     use std::path::PathBuf;


### PR DESCRIPTION
## 问题

MCP 文件和日志读取直接调用阻塞式 `File::open`。模块的订阅下载会创建 `.stream`、`.headers` FIFO；读取没有写端的 FIFO 会永久占用连接线程，重复请求可耗尽 32 个连接配额，读取活动 FIFO 还可能消费下载数据。

## 修改

- 文件和日志读取共用普通文件打开函数。
- 打开前检查类型，使用 `O_NONBLOCK | O_NOFOLLOW`，打开后检查实际文件描述符类型。
- 保留模块内软链接解析、1 MiB 读取上限和日志尾部行为。
- 增加两个 FIFO 行为回归及普通文件/内部软链接/日志兼容测试，失败时有超时保护。

## 验证

- 原实现两个 FIFO 用例均超时失败；修复后通过。
- `cargo test -p magicnet-mcp-server`：42/42 通过。
- `cargo clippy -p magicnet-mcp-server --all-targets -- -D warnings`：通过。
- `cargo fmt --all -- --check` 与 `git diff --check`：通过。
- 独立交叉审查：无阻断项。

GitHub [Code Quality](https://github.com/LIghtJUNction/MagicNet/actions/runs/34190164822) 已通过 Rust、Shell 和 WebUI 全部检查；模块配置验证已通过。

本地完整 Rust 工作区测试有 2 个依赖 `/proc` 的进程身份用例受执行环境编号视图不匹配影响（其余 CLI 387 项通过）；远程完整测试已通过。

## Sourcery 摘要

防止 MCP 文件和日志读取在订阅 FIFO 上发生阻塞，同时保留现有的读取行为。

错误修复：
- 在文件或日志读取可能发生阻塞或消耗流数据之前，拒绝 FIFO 和其他非普通文件。

增强功能：
- 为文件和日志读取共享普通文件验证，同时保留内部符号链接处理、有界读取和日志尾部读取行为。

测试：
- 增加对 FIFO 拒绝的回归测试，以及对普通文件、内部符号链接和日志尾部读取兼容性的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent MCP file and log reads from blocking on subscription FIFOs while preserving existing read behavior.

Bug Fixes:
- Reject FIFO and other non-regular files before file or log reads can block or consume stream data.

Enhancements:
- Share regular-file validation for file and log reads while preserving internal symlink handling, bounded reads, and log tail behavior.

Tests:
- Add regression coverage for FIFO rejection and compatibility coverage for regular files, internal symlinks, and log tails.

</details>