### PR TITLE
fix(runtime): reject incomplete configuration fingerprints

### DIFF
--- a/scripts/test-host.sh
+++ b/scripts/test-host.sh
@@ -78,6 +78,7 @@ bash scripts/test-transparent-mode-config-safety.sh
 bash scripts/test-ebpf-transparent-mode.sh
 bash scripts/test-config-permissions.sh
 bash scripts/test-config-lock-safety.sh
+sh scripts/test-runtime-fingerprint-safety.sh
 if [ "$with_routing_assets" -eq 1 ]; then
     bash scripts/test-dns-profile-safety.sh
 fi

--- a/scripts/test-runtime-fingerprint-safety.sh
+++ b/scripts/test-runtime-fingerprint-safety.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+fixture=$(mktemp -d "${TMPDIR:-/tmp}/magicnet-runtime-fingerprint.XXXXXX")
+trap 'rm -rf "$fixture"' 0
+export MODDIR="$fixture/module"
+REAL_JQ=$(command -v jq)
+FAIL_STAGE=''
+export REAL_JQ FAIL_STAGE
+mkdir -p "$MODDIR/bin" "$MODDIR/.config/sing-box/rules"
+. "$ROOT/src/MagicNet/lib/magicnet/runtime_config.sh"
+
+cat >"$MODDIR/bin/jq" <<'SH'
+#!/bin/sh
+if [ "$FAIL_STAGE" = jq ]; then
+    for arg do
+        if [ "$arg" = -S ]; then
+            printf '%s\n' '{"partial":true}'
+            exit 1
+        fi
+    done
+fi
+exec "$REAL_JQ" "$@"
+SH
+chmod +x "$MODDIR/bin/jq"
+
+find() { [ "$FAIL_STAGE" != find ] && command find "$@"; }
+sort() { [ "$FAIL_STAGE" != sort ] && command sort; }
+cksum() {
+    [ "$FAIL_STAGE" != checksum ] || return 1
+    if [ "$FAIL_STAGE" = rule ] && [ "$#" -gt 0 ]; then return 1; fi
+    if [ "$FAIL_STAGE" = final-checksum ] && [ "$#" -eq 0 ]; then
+        input=$(cat)
+        case "$input" in
+        '{'*) printf '%s\n' "$input" | command cksum; return ;;
+        *) return 1 ;;
+        esac
+    fi
+    command cksum "$@"
+}
+fail() { printf 'runtime fingerprint safety: %s\n' "$*" >&2; exit 1; }
+assert_failure() {
+    if magicnet_singbox_runtime_fingerprint >"$fixture/result" 2>/dev/null; then
+        fail "$1 produced a successful fingerprint"
+    fi
+    [ ! -s "$fixture/result" ] || fail "$1 exposed a partial fingerprint"
+    if magicnet_singbox_runtime_fingerprint_matches 2>/dev/null; then
+        fail "$1 matched the running configuration"
+    fi
+    if magicnet_singbox_record_runtime_fingerprint 2>/dev/null; then
+        fail "$1 recorded a failed fingerprint"
+    fi
+    [ "$(cat "$stored")" = "$baseline" ] || fail "$1 replaced the last good fingerprint"
+    [ ! -e "$stored.new.$$" ] || fail "$1 leaked a staging file"
+}
+
+config="$MODDIR/.config/sing-box/config.json"
+auth="$MODDIR/.config/sing-box/tailscale-auth.json"
+rule="$MODDIR/.config/sing-box/rules/test.srs"
+printf '%s\n' '{"route":{"final":"direct"},"inbounds":[]}' >"$config"
+printf '%s\n' '{"tailscale":"test-key"}' >"$auth"
+printf '%s\n' 'initial rule' >"$rule"
+baseline=$(magicnet_singbox_runtime_fingerprint)
+# Preserve existing checksum framing to avoid a restart after this upgrade.
+expected=$(
+    {
+        printf '%s\n' '{"inbounds":[],"route":{"final":"direct"}}' | cksum
+        printf '%s\n' '{"tailscale":"test-key"}' | cksum
+        cksum "$rule"
+    } | cksum | awk '{ print $1 ":" $2 }'
+)
+[ "$baseline" = "$expected" ] || fail 'checksum framing changed'
+magicnet_singbox_record_runtime_fingerprint
+stored=$(magicnet_singbox_runtime_fingerprint_file)
+magicnet_singbox_runtime_fingerprint_matches
+
+# JSON formatting and mutable UI/cache data must keep long-lived sockets intact.
+printf '%s\n' '{ "inbounds": [], "route": { "final": "direct" } }' >"$config"
+printf '%s\n' 'mutable cache' >"$MODDIR/.config/sing-box/cache.db"
+[ "$(magicnet_singbox_runtime_fingerprint)" = "$baseline" ] || fail 'equivalent inputs changed the fingerprint'
+printf '%s\n' 'updated rule' >"$rule"
+[ "$(magicnet_singbox_runtime_fingerprint)" != "$baseline" ] || fail 'changed rule was ignored'
+printf '%s\n' 'initial rule' >"$rule"
+
+cp "$config" "$fixture/good-config"
+for invalid in '{invalid' ''; do
+    printf '%s' "$invalid" >"$config"
+    assert_failure 'invalid/empty config'
+done
+cp "$fixture/good-config" "$config"
+printf '%s\n' '{invalid' >"$auth"
+assert_failure 'invalid authentication JSON'
+printf '%s\n' '{"tailscale":"test-key"}' >"$auth"
+for FAIL_STAGE in jq find sort checksum rule final-checksum; do
+    assert_failure "$FAIL_STAGE failure"
+done
+FAIL_STAGE=''
+magicnet_singbox_runtime_fingerprint_matches
+printf '%s\n' 'runtime fingerprint safety test passed'

--- a/src/MagicNet/lib/magicnet/runtime_config.sh
+++ b/src/MagicNet/lib/magicnet/runtime_config.sh
@@ -153,25 +153,31 @@ magicnet_singbox_runtime_fingerprint() (
     command -v find >/dev/null 2>&1 || return 1
     command -v sort >/dev/null 2>&1 || return 1
 
-    {
+    # Check each producer before hashing its output: Android sh does not
+    # guarantee pipefail, so a trailing checksum can hide a failed reader.
+    _runtime_input=$(
         # Runtime materializers may emit equivalent JSON with a different key
         # order or whitespace.  sing-box sees the same configuration in that
         # case, so hash a stable representation instead of the file bytes.
-        "$_runtime_jq" -e . "$_runtime_config" >/dev/null || exit 1
-        "$_runtime_jq" -S -c . "$_runtime_config" | cksum || exit 1
-        if [ -f "${_runtime_root}/tailscale-auth.json" ]; then
-            "$_runtime_jq" -e . "${_runtime_root}/tailscale-auth.json" >/dev/null || exit 1
-            "$_runtime_jq" -S -c . "${_runtime_root}/tailscale-auth.json" | cksum || exit 1
-        fi
+        for _runtime_json_file in "$_runtime_config" "${_runtime_root}/tailscale-auth.json"; do
+            [ "$_runtime_json_file" = "$_runtime_config" ] || [ -f "$_runtime_json_file" ] || continue
+            _runtime_json=$("$_runtime_jq" -e -S -c . "$_runtime_json_file") || exit 1
+            [ -n "$_runtime_json" ] || exit 1
+            printf '%s\n' "$_runtime_json" | cksum || exit 1
+        done
         if [ -d "${_runtime_root}/rules" ]; then
-            find "${_runtime_root}/rules" -type f -name '*.srs' -print 2>/dev/null |
-                sort |
-                while IFS= read -r _runtime_rule || [ -n "$_runtime_rule" ]; do
-                    [ -n "$_runtime_rule" ] || continue
-                    cksum "$_runtime_rule" || exit 1
-                done
+            _runtime_rules=$(find "${_runtime_root}/rules" -type f -name '*.srs' -print 2>/dev/null) || exit 1
+            _runtime_rules=$(printf '%s\n' "$_runtime_rules" | sort) || exit 1
+            while IFS= read -r _runtime_rule || [ -n "$_runtime_rule" ]; do
+                [ -n "$_runtime_rule" ] || continue
+                cksum "$_runtime_rule" || exit 1
+            done <<EOF
+$_runtime_rules
+EOF
         fi
-    } | cksum | awk '{ print $1 ":" $2 }'
+    ) || return 1
+    _runtime_checksum=$(printf '%s\n' "$_runtime_input" | cksum) || return 1
+    printf '%s\n' "$_runtime_checksum" | awk '{ print $1 ":" $2 }'
 )
 
 magicnet_singbox_record_runtime_fingerprint() {


### PR DESCRIPTION
## 问题

运行配置指纹由多级管道生成。Android sh 没有可靠的 pipefail，jq/find/规则读取失败可能被后面的 cksum/awk 成功状态吞掉。实测非法 JSON 仍返回成功并记录 `4294967295:0`，可能将失效输入误判为配置未变化。

## 修改

- 分步检查 JSON 规范化、规则枚举/排序、规则校验和及最终校验和的状态。
- 失败时不输出或保存不完整指纹，保留最后一次有效记录并清理临时文件。
- 保持正常输入的指纹字节格式，避免升级产生无谓重启。
- 新增专用行为回归并接入 `scripts/test-host.sh`。

## 验证

- 新回归测试在原实现上失败，修复后通过。
- `sh scripts/test-runtime-fingerprint-safety.sh`：通过，覆盖非法/空配置、非法认证 JSON、各阶段失败、旧记录保留、规则变更及成功格式兼容。
- 有/无 auth、rules 四种组合均与原实现生成相同的有效指纹。
- `bash scripts/test-subscription-transaction-atomicity.sh`：五类事务回归通过。
- 仓库 ShellCheck、新增脚本 ShellCheck（沿用 SC1091 排除）和 `git diff --check`：通过。
- 独立交叉审查：无阻断项。

GitHub [Code Quality](https://github.com/LIghtJUNction/MagicNet/actions/runs/34190267255) 已通过 Rust、Shell 和 WebUI（含移动端回归）全部检查；模块配置验证已通过。

本地完整 host 回归受 `/proc` 进程编号视图不匹配影响；fake-Magisk smoke 在独立 HEAD 基线（重新编译 CLI/MCP）上同样失败，错误为模拟核心无法访问其 `/proc/<pid>/comm`。远程 host 回归已通过，Android 真机未验证。

## Sourcery 总结

使运行时配置指纹生成在发生错误时安全失败，而不是接受不完整的结果。

错误修复：
- 当 JSON 规范化、规则发现、规则校验和计算或最终校验和计算失败时，拒绝不完整的运行时配置指纹。
- 在指纹生成错误后保留最后一个有效的已记录指纹，并避免暴露或持久化部分结果。

增强功能：
- 对于有效配置，保留现有的指纹格式，以避免不必要的重启。

测试：
- 增加运行时指纹安全回归测试，覆盖无效输入、分阶段失败、记录保留、规则变更和输出兼容性。
- 从主机回归测试套件中运行运行时指纹安全测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make runtime configuration fingerprint generation fail safely instead of accepting incomplete results.

Bug Fixes:
- Reject incomplete runtime configuration fingerprints when JSON normalization, rule discovery, rule checksumming, or final checksumming fails.
- Preserve the last valid recorded fingerprint and avoid exposing or persisting partial results after fingerprint generation errors.

Enhancements:
- Retain the existing fingerprint format for valid configurations to prevent unnecessary restarts.

Tests:
- Add runtime fingerprint safety regression coverage for invalid inputs, staged failures, record preservation, rule changes, and output compatibility.
- Run the runtime fingerprint safety test from the host regression suite.

</details>