### PR TITLE
fix: harden sing-box DNS startup and refresh build submodules

### DIFF
--- a/.github/workflows/exec.yml
+++ b/.github/workflows/exec.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
-          submodules: true
+          submodules: recursive
           fetch-depth: 0
 
       - name: Bump and commit version
@@ -94,6 +94,13 @@ jobs:
           PRERELEASE_INPUT: ${{ inputs.prerelease }}
           PUSH_BEFORE: ${{ github.event.before }}
         run: python3 scripts/prepare-release.py
+
+      - name: Refresh build submodules
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/update-submodules.sh
+          git submodule status --recursive > "$RUNNER_TEMP/build-submodules.txt"
 
       - name: Prepare signing verification key
         if: ${{ env.MAGICNET_SIGN_ENABLED == '1' }}
@@ -244,6 +251,9 @@ jobs:
           find hooks src -type f -name '*.sh' -exec chmod +x {} + 2>/dev/null || true
           rm -rf dist
           kam build
+          git submodule status --recursive > "$RUNNER_TEMP/built-submodules.txt"
+          diff -u "$RUNNER_TEMP/build-submodules.txt" "$RUNNER_TEMP/built-submodules.txt"
+          cp "$RUNNER_TEMP/build-submodules.txt" dist/build-submodules.txt
 
       - name: Verify artifact contents
         shell: bash
@@ -282,7 +292,7 @@ jobs:
           if [ "$PRERELEASE_REQUESTED" = "true" ]; then
             args+=(--prerelease)
           fi
-          gh release create "$RELEASE_VERSION" dist/MagicNet.zip dist/MagicNet.zip.sig "${args[@]}"
+          gh release create "$RELEASE_VERSION" dist/MagicNet.zip dist/MagicNet.zip.sig dist/build-submodules.txt "${args[@]}"
 
       - name: Upload build artifact
         if: always() && hashFiles('dist/*') != ''

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -25,7 +25,10 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
-          submodules: true
+          submodules: recursive
+
+      - name: Refresh build submodules
+        run: bash scripts/update-submodules.sh
 
       - name: Install Rust quality tools
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
@@ -66,7 +69,10 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
-          submodules: true
+          submodules: recursive
+
+      - name: Refresh build submodules
+        run: bash scripts/update-submodules.sh
 
       - name: Install host check dependencies
         run: sudo apt-get update && sudo apt-get install -y shellcheck jq python3-yaml ripgrep

--- a/scripts/build-sing-box.sh
+++ b/scripts/build-sing-box.sh
@@ -34,7 +34,12 @@ if ! grep -Fxq 'module github.com/sagernet/sing-box' "$SOURCE_DIR/go.mod"; then
     exit 1
 fi
 
-if [[ -n "$(git -C "$SOURCE_DIR" status --porcelain --untracked-files=normal)" ]]; then
+# CI deliberately advances nested gitlinks. Check each repository's own files
+# instead, so new dependency revisions are allowed but local edits still fail.
+# shellcheck disable=SC2016
+if [[ -n "$(git -C "$SOURCE_DIR" status --porcelain --untracked-files=normal --ignore-submodules=all)" ]] ||
+    ! git -C "$SOURCE_DIR" submodule foreach --quiet --recursive \
+        'changes=$(git status --porcelain --untracked-files=normal --ignore-submodules=all) && test -z "$changes"'; then
     printf 'sing-box build: source submodule has uncommitted changes: %s\n' "$SOURCE_DIR" >&2
     exit 1
 fi

--- a/scripts/test-app-routing-policy.sh
+++ b/scripts/test-app-routing-policy.sh
@@ -32,6 +32,11 @@ import() { :; }
 magicnet_warn() { :; }
 singbox_prepare_route_config() { :; }
 
+mock_missing_ipv6_tables() {
+  printf '%s\n' 'cannot initialize nat: Table does not exist' >&2
+  return 3
+}
+
 REAL_MV=$(command -v mv)
 FAIL_MV_BIN="$WORK/fail-mv-bin"
 mkdir -p "$FAIL_MV_BIN"
@@ -470,7 +475,7 @@ assert_dns_capture_disable_removes_duplicate_output_jumps() (
       ;;
     esac
   }
-  ip6tables() { return 1; }
+  ip6tables() { mock_missing_ipv6_tables; }
   magicnet_cmd_exists() {
     [ "${1:-}" = iptables ] || [ "${1:-}" = ip6tables ]
   }
@@ -499,7 +504,7 @@ assert_dns_capture_disable_accepts_absent_chain_rc_two() (
     *) return 0 ;;
     esac
   }
-  ip6tables() { return 1; }
+  ip6tables() { mock_missing_ipv6_tables; }
   magicnet_cmd_exists() {
     [ "${1:-}" = iptables ] || [ "${1:-}" = ip6tables ]
   }
@@ -544,7 +549,7 @@ assert_dns_capture_disable_retries_transient_delete_failure() (
       ;;
     esac
   }
-  ip6tables() { return 1; }
+  ip6tables() { mock_missing_ipv6_tables; }
   magicnet_cmd_exists() {
     [ "${1:-}" = iptables ] || [ "${1:-}" = ip6tables ]
   }
@@ -859,6 +864,10 @@ assert_dns_leak_guard_reapply_fails_closed_after_cleanup_failure() (
 
   iptables() {
     case " $* " in
+    *' -S OUTPUT '*)
+      printf '%s\n' '-A OUTPUT -o wlan0 -p udp --dport 53 -j REJECT'
+      return 0
+      ;;
     *' -D OUTPUT '*) return 1 ;;
     *' -C OUTPUT '*) return 2 ;;
     *' -I OUTPUT '*)
@@ -897,6 +906,12 @@ assert_dns_leak_guard_reapply_cleans_old_interfaces() (
 
   iptables() {
     case " $* " in
+    *' -S OUTPUT '*)
+      if [ "$(cat "$stale_guard_count_file")" -gt 0 ]; then
+        printf '%s\n' '-A OUTPUT -o wlan0 -p udp --dport 53 -j REJECT'
+      fi
+      return 0
+      ;;
     *' -D OUTPUT -o wlan0 -p udp --dport 53 -j REJECT '*)
       stale_guard_rule_count="$(cat "$stale_guard_count_file")"
       if [ "$stale_guard_rule_count" -gt 0 ]; then
@@ -942,7 +957,7 @@ assert_ipv4_first_dns_capture_tolerates_missing_ipv6_nat() (
   }
   ip6tables() {
     printf '%s\n' "ip6tables $*" >>"$dns_capture_log"
-    return 1
+    mock_missing_ipv6_tables
   }
   magicnet_cmd_exists() { return 0; }
   magicnet_dns_profile() { printf '%s\n' default; }

--- a/scripts/test-ci-submodules.py
+++ b/scripts/test-ci-submodules.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Offline Git integration checks for CI's moving submodule inputs."""
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class SubmoduleUpdateTests(unittest.TestCase):
+    def test_recursive_remote_branches_and_fetch_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work = Path(tmp)
+            env = dict(os.environ, GIT_ALLOW_PROTOCOL="file",
+                       GIT_AUTHOR_NAME="Test", GIT_COMMITTER_NAME="Test",
+                       GIT_AUTHOR_EMAIL="test@example.invalid",
+                       GIT_COMMITTER_EMAIL="test@example.invalid",
+                       GITHUB_STEP_SUMMARY=str(work / "summary"))
+
+            def git(repo, *args):
+                return subprocess.run(
+                    ["git", "-C", str(repo), *args], env=env, check=True,
+                    text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                ).stdout.strip()
+
+            def commit(repo, text):
+                (repo / "version").write_text(text)
+                git(repo, "add", ".")
+                git(repo, "commit", "-m", text)
+                return git(repo, "rev-parse", "HEAD")
+
+            def init(name):
+                repo = work / name
+                repo.mkdir()
+                git(repo, "init", "-b", "main")
+                commit(repo, "initial")
+                return repo
+
+            child, parent, top = (init(name) for name in ("child", "parent", "top"))
+            git(child, "checkout", "-b", "testing")
+            commit(child, "testing initial")
+            git(child, "checkout", "main")
+            git(parent, "submodule", "add", "-b", "testing", child.as_uri(), "nested")
+            git(parent, "config", "-f", ".gitmodules", "submodule.nested.shallow", "true")
+            commit(parent, "parent pin")
+            git(top, "submodule", "add", "-b", "main", parent.as_uri(), "vendor/parent")
+            git(top, "submodule", "add", child.as_uri(), "vendor/default")
+            (top / "scripts").mkdir()
+            shutil.copyfile(ROOT / "scripts/update-submodules.sh", top / "scripts/update-submodules.sh")
+            commit(top, "top pin")
+
+            expected_default = commit(child, "new default")
+            git(child, "checkout", "testing")
+            expected_nested = commit(child, "new testing")
+            git(child, "checkout", "main")
+            expected_parent = commit(parent, "new parent")
+            runner = work / "runner"
+            git(work, "clone", top.as_uri(), str(runner))
+            git(runner, "submodule", "update", "--init", "--depth", "1")
+            original_head = git(runner, "rev-parse", "HEAD")
+
+            def update():
+                return subprocess.run(
+                    ["bash", str(runner / "scripts/update-submodules.sh")],
+                    cwd=runner, env=env, text=True, stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+
+            result = update()
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(git(runner / "vendor/parent", "rev-parse", "HEAD"), expected_parent)
+            self.assertEqual(git(runner / "vendor/parent/nested", "rev-parse", "HEAD"), expected_nested)
+            self.assertEqual(git(runner / "vendor/default", "rev-parse", "HEAD"), expected_default)
+            self.assertEqual(git(runner, "rev-parse", "HEAD"), original_head)
+            self.assertIn(expected_nested, (work / "summary").read_text())
+
+            # A second invocation must fetch new commits despite initialized submodules.
+            expected_default = commit(child, "newer default")
+            result = update()
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(git(runner / "vendor/default", "rev-parse", "HEAD"), expected_default)
+            # Updated parent configuration must select its child's new branch.
+            git(parent, "config", "-f", ".gitmodules", "submodule.nested.branch", "main")
+            commit(parent, "change nested tracking branch")
+            result = update()
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(git(runner / "vendor/parent/nested", "rev-parse", "HEAD"), expected_default)
+            # An unspecified branch follows a changed remote default as well.
+            git(child, "checkout", "testing")
+            result = update()
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(git(runner / "vendor/default", "rev-parse", "HEAD"), expected_nested)
+            git(runner, "config", "-f", ".gitmodules", "submodule.vendor/parent.branch", "missing-branch")
+            self.assertNotEqual(update().returncode, 0, "stale submodule silently reused")
+
+    def test_workflows_refresh_before_build_inputs(self):
+        # PyYAML is already required by the host regression suite.
+        import yaml
+        build = yaml.safe_load((ROOT / ".github/workflows/exec.yml").read_text())
+        steps = build["jobs"]["build"]["steps"]
+        refresh = next(i for i, step in enumerate(steps) if "bash scripts/update-submodules.sh" in step.get("run", ""))
+        fingerprint = next(i for i, step in enumerate(steps) if step.get("id") == "toolchain")
+        self.assertLess(refresh, fingerprint)
+        quality = yaml.safe_load((ROOT / ".github/workflows/quality.yml").read_text())
+        for job in ("rust", "shell"):
+            self.assertIn("update-submodules.sh", quality["jobs"][job]["steps"][1]["run"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-ci-submodules.py
+++ b/scripts/test-ci-submodules.py
@@ -96,6 +96,68 @@ class SubmoduleUpdateTests(unittest.TestCase):
             git(runner, "config", "-f", ".gitmodules", "submodule.vendor/parent.branch", "missing-branch")
             self.assertNotEqual(update().returncode, 0, "stale submodule silently reused")
 
+    def test_build_allows_updated_gitlinks_but_rejects_file_edits(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work = Path(tmp)
+            env = dict(os.environ, GIT_ALLOW_PROTOCOL="file",
+                       GIT_AUTHOR_NAME="Test", GIT_COMMITTER_NAME="Test",
+                       GIT_AUTHOR_EMAIL="test@example.invalid",
+                       GIT_COMMITTER_EMAIL="test@example.invalid")
+
+            def git(repo, *args):
+                subprocess.run(["git", "-C", str(repo), *args], env=env,
+                               check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+            child, source = work / "child", work / "source"
+            for repo in (child, source):
+                repo.mkdir()
+                git(repo, "init", "-b", "main")
+                (repo / "version").write_text("initial")
+                git(repo, "add", ".")
+                git(repo, "commit", "-m", "initial")
+            git(source, "submodule", "add", child.as_uri(), "nested")
+            (source / "go.mod").write_text("module github.com/sagernet/sing-box\n")
+            (source / "release").mkdir()
+            (source / "release/DEFAULT_BUILD_TAGS_OTHERS").write_text("with_ebpf")
+            (source / "release/LDFLAGS").write_text("-s")
+            git(source, "add", ".")
+            git(source, "commit", "-m", "source")
+            nested = source / "nested"
+            (nested / "version").write_text("updated dependency")
+            git(nested, "add", ".")
+            git(nested, "commit", "-m", "advance nested gitlink")
+
+            (work / "scripts").mkdir()
+            shutil.copyfile(ROOT / "scripts/build-sing-box.sh", work / "scripts/build-sing-box.sh")
+            (work / "sing-box.version").write_text("1.14.0")
+            (work / "bin").mkdir()
+            compiler = work / "bin/go"
+            compiler.write_text(
+                '#!/bin/sh\nwhile [ "$#" -gt 0 ]; do\n'
+                '  if [ "$1" = -o ]; then printf fixture >"$2"; exit 0; fi\n'
+                '  shift\ndone\nexit 1\n')
+            compiler.chmod(0o755)
+            env.update(MAGICNET_SINGBOX_SOURCE_DIR=str(source),
+                       PATH=f"{work / 'bin'}:{env['PATH']}")
+
+            def build():
+                return subprocess.run(
+                    ["bash", str(work / "scripts/build-sing-box.sh"),
+                     "linux", "amd64", str(work / "output")], env=env,
+                    text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+            result = build()
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual((work / "output").read_text(), "fixture")
+            for repo in (source, nested):
+                (repo / "version").write_text("uncommitted edit")
+                result = build()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("uncommitted changes", result.stderr)
+                git(repo, "checkout", "--", "version")
+            (nested / "untracked").write_text("untracked edit")
+            self.assertIn("uncommitted changes", build().stderr)
+
     def test_workflows_refresh_before_build_inputs(self):
         # PyYAML is already required by the host regression suite.
         import yaml

--- a/scripts/test-host.sh
+++ b/scripts/test-host.sh
@@ -83,6 +83,7 @@ if [ "$with_routing_assets" -eq 1 ]; then
     bash scripts/test-dns-profile-safety.sh
 fi
 bash scripts/test-dns-leak-guard-timeout.sh
+sh scripts/test-startup-network-safety.sh
 bash scripts/test-subscription-activation-order.sh
 bash scripts/test-subscription-transaction-atomicity.sh
 bash scripts/test-subscription-update-lock-safety.sh
@@ -91,5 +92,6 @@ bash scripts/test-subscription-lifecycle.sh
 bash scripts/test-subscription-stop-safety.sh
 bash scripts/test-release-integrity.sh
 python3 scripts/test-release-workflow.py
+python3 scripts/test-ci-submodules.py
 
 printf 'host regression suite passed\n'

--- a/scripts/test-startup-network-safety.sh
+++ b/scripts/test-startup-network-safety.sh
@@ -1,0 +1,130 @@
+#!/bin/sh
+set -eu
+
+ROOT="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+MODDIR="$WORK/module"
+MOCK_CALLS="$WORK/calls"
+MOCK_RULES="$WORK/rules"
+export MODDIR MOCK_CALLS MOCK_RULES
+mkdir -p "$WORK/bin" "$MODDIR/.state"
+: >"$MOCK_CALLS"
+: >"$MOCK_RULES"
+
+# Executable fixtures exercise the real timeout/wait wrappers, not the
+# function-double shortcut in magicnet_xtables_available.
+cat >"$WORK/bin/iptables" <<'MOCK'
+#!/bin/sh
+printf '%s %s\n' "${0##*/}" "$*" >>"$MOCK_CALLS"
+[ "${1:-}" != -w ] || shift 2
+case "$*" in
+'-t nat '*)
+    if [ "$*" = '-t nat -L -n' ] && [ "${MOCK_PROBE_RC:-0}" -ne 0 ]; then
+        echo 'xtables lock/permission failure' >&2
+        exit "$MOCK_PROBE_RC"
+    fi
+    if [ "${MOCK_NAT:-missing}" = missing ] || [ "${0##*/}" = ip6tables ]; then
+        echo "cannot initialize nat: Table does not exist" >&2
+        exit 3
+    fi ;;
+esac
+case "$*" in
+'-t nat -L -n') exit 0 ;;
+'-L') exit 0 ;;
+'-S OUTPUT') cat "$MOCK_RULES"; exit 0 ;;
+'-t nat -L magicnet-dns-output') exit 1 ;;
+'-t nat -N '*|'-t nat -F '*|'-t nat -X '*|'-t nat -I '*|'-t nat -A '*)
+    [ "${MOCK_WRITE_RC:-0}" -eq 0 ] || echo 'fixture write permission denied' >&2
+    exit "${MOCK_WRITE_RC:-0}" ;;
+'-t nat -C '*|'-t nat -D '*) exit 1 ;;
+'-D OUTPUT '*)
+    if [ "${MOCK_DELETE_RC:-0}" -ne 0 ]; then
+        echo 'fixture delete permission denied' >&2
+        exit "$MOCK_DELETE_RC"
+    fi
+    # All four guard protocols/ports are tried; only this fixture rule exists.
+    case "$*" in *'-o rmnet0 -p udp --dport 53 -j REJECT') : >"$MOCK_RULES" ;; esac
+    exit 0 ;;
+'-C OUTPUT '*) [ -s "$MOCK_RULES" ]; exit $? ;;
+esac
+exit 0
+MOCK
+chmod +x "$WORK/bin/iptables"
+ln -s iptables "$WORK/bin/ip6tables"
+PATH="$WORK/bin:$PATH"
+export PATH
+# shellcheck disable=SC1091
+. "$ROOT/src/MagicNet/lib/magicnet/network.sh"
+magicnet_cmd_exists() { command -v "$1" >/dev/null 2>&1; }
+magicnet_warn() { printf '%s\n' "$*" >&2; }
+magicnet_log() { :; }
+magicnet_transparent_mode() { printf '%s\n' "${TEST_MODE:-tun}"; }
+magicnet_ipv6_mode() { printf '%s\n' "${TEST_IPV6:-prefer_ipv4}"; }
+magicnet_dns_profile() { echo google; }
+magicnet_dns_capture_singbox_mark() { echo 255; }
+magicnet_dns_capture_singbox_udp_marked() { return 1; }
+magicnet_hotspot_reconcile() { :; }
+magicnet_collect_physical_egress_ifaces() { echo rmnet0; }
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+state="$MODDIR/.state/dns-leak-guard.ifaces"
+
+# No NAT table and an obsolete saved interface must not abort TUN startup.
+printf '%s\n' wlan0 >"$state"
+magicnet_after_kernel_start_unlocked >"$WORK/log" 2>&1 || fail 'optional absent NAT/empty guard blocked startup'
+[ ! -e "$state" ] || fail 'empty guard retained obsolete state'
+! grep -q ' -D OUTPUT' "$MOCK_CALLS" || fail 'empty scan issued speculative deletes'
+grep -q 'TUN DNS only' "$WORK/log" || fail 'degraded capture was not disclosed'
+MAGIC_DNS_CAPTURE=0 magicnet_enable_dns_capture >/dev/null 2>&1 || fail 'disabled capture cleanup failed without NAT'
+TEST_MODE=ebpf magicnet_enable_dns_capture >/dev/null 2>&1 || fail 'eBPF stale cleanup required NAT'
+if TEST_IPV6=prefer_ipv6 magicnet_enable_dns_capture >/dev/null 2>&1; then
+    fail 'required IPv6 capture silently degraded'
+fi
+
+# Lock/permission failures are indeterminate, not an unsupported table.
+for MOCK_PROBE_RC in 4 124; do
+    export MOCK_PROBE_RC
+    if magicnet_enable_dns_capture >"$WORK/log" 2>&1; then fail 'probe failure hidden'; fi
+    if magicnet_disable_dns_capture >/dev/null 2>&1; then fail 'uncertain cleanup reported success'; fi
+    grep -q "exit=$MOCK_PROBE_RC" "$WORK/log" || fail 'probe exit status missing'
+done
+unset MOCK_PROBE_RC
+MOCK_NAT=available
+export MOCK_NAT
+magicnet_enable_dns_capture >/dev/null 2>&1 || fail 'IPv4 capture rejected absent IPv6 NAT'
+if MOCK_WRITE_RC=4 magicnet_enable_dns_capture >"$WORK/log" 2>&1; then fail 'write failure hidden'; fi
+grep -q 'fixture write permission denied' "$WORK/log" || fail 'write stderr lost'
+
+# A fresh scan finds a different interface; failed deletion must keep retry state.
+printf '%s\n' '-A OUTPUT -o rmnet0 -p udp --dport 53 -j REJECT' >"$MOCK_RULES"
+printf '%s\n' wlan0 >"$state"
+if MOCK_DELETE_RC=4 magicnet_disable_dns_leak_guard >"$WORK/log" 2>&1; then fail 'delete failure hidden'; fi
+[ -e "$state" ] || fail 'failed cleanup removed retry state'
+grep -q 'fixture delete permission denied' "$WORK/log" || fail 'delete stderr lost'
+magicnet_disable_dns_leak_guard || fail 'discovered rules were not cleaned'
+[ ! -s "$MOCK_RULES" ] && [ ! -e "$state" ] || fail 'successful cleanup incomplete'
+grep -q '^iptables -w 1 ' "$MOCK_CALLS" || fail 'IPv4 bounded lock wait missing'
+grep -q '^ip6tables -w 1 ' "$MOCK_CALLS" || fail 'IPv6 bounded lock wait missing'
+
+# Startup errors must describe the failed phase, not falsely claim no binary.
+(
+    # shellcheck disable=SC1091
+    . "$ROOT/src/MagicNet/lib/magicnet/core.sh"
+    magicnet_detach_pid_from_app_cgroup() { :; }
+    magicnet_kernel_start_preamble() { :; }
+    magicnet_kernel_running() { return 1; }
+    magicnet_require_subscription_or_stop() { :; }
+    magicnet_start_singbox_ready() { return 1; }
+    magicnet_cmd_exists() { return 0; }
+    magicnet_disable_dns_capture() { :; }
+    magicnet_disable_dns_leak_guard() { :; }
+    if magicnet_start_kernel >"$WORK/log" 2>&1; then fail 'failed start reported success'; fi
+    grep -q 'preceding core or network error' "$WORK/log" || fail 'misleading startup diagnostic'
+    magicnet_start_singbox_unlocked() { :; }
+    magicnet_after_kernel_start_unlocked() { return 1; }
+    import() { :; }
+    singbox_stop() { : >"$WORK/stopped"; }
+    if magicnet_start_singbox_ready_unlocked >/dev/null 2>&1; then fail 'rollback reported success'; fi
+    [ -f "$WORK/stopped" ] || fail 'genuine post-start failure did not stop the core'
+)
+printf '%s\n' 'startup network safety regressions passed'

--- a/scripts/update-submodules.sh
+++ b/scripts/update-submodules.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+case "${1:-}" in
+"")
+    cd "$ROOT"
+    MAGICNET_SUBMODULE_UPDATE_SCRIPT="$ROOT/scripts/update-submodules.sh"
+    export MAGICNET_SUBMODULE_UPDATE_SCRIPT
+    ;;
+--nested) ;;
+*) printf 'usage: bash scripts/update-submodules.sh\n' >&2; exit 64 ;;
+esac
+
+# Update one level at a time: a parent's new .gitmodules may change child
+# URLs/branches. Initialize children only after checking out that parent.
+git submodule sync
+git submodule update --init --checkout --no-single-branch
+git submodule foreach '
+    set -eu
+    # Shallow checkout can otherwise fetch only the default branch, leaving
+    # a configured non-default branch such as sing-box/testing unresolved.
+    git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+    git fetch --prune origin
+    git remote set-head origin --auto
+'
+# Every child was just fetched; resolve .gitmodules branches or remote HEAD.
+# A fetch failure above aborts the run rather than building a stale revision.
+git submodule update --remote --no-fetch --checkout
+git submodule foreach --quiet 'bash "$MAGICNET_SUBMODULE_UPDATE_SCRIPT" --nested'
+
+if [[ $# -eq 0 ]]; then
+    git submodule status --recursive
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        {
+            printf '\n### Build submodule revisions\n\n```text\n'
+            git submodule status --recursive
+            printf '```\n'
+        } >>"$GITHUB_STEP_SUMMARY"
+    fi
+fi

--- a/scripts/update-submodules.sh
+++ b/scripts/update-submodules.sh
@@ -21,12 +21,14 @@ git submodule foreach '
     # Shallow checkout can otherwise fetch only the default branch, leaving
     # a configured non-default branch such as sing-box/testing unresolved.
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-    git fetch --prune origin
+    git fetch --no-recurse-submodules --prune origin
     git remote set-head origin --auto
 '
 # Every child was just fetched; resolve .gitmodules branches or remote HEAD.
 # A fetch failure above aborts the run rather than building a stale revision.
 git submodule update --remote --no-fetch --checkout
+# Expand the exported path inside each child shell, preserving spaces.
+# shellcheck disable=SC2016
 git submodule foreach --quiet 'bash "$MAGICNET_SUBMODULE_UPDATE_SCRIPT" --nested'
 
 if [[ $# -eq 0 ]]; then

--- a/src/MagicNet/lib/magicnet/core.sh
+++ b/src/MagicNet/lib/magicnet/core.sh
@@ -248,7 +248,13 @@ magicnet_start_kernel() {
 
     command -v magicnet_hotspot_startup_snapshot_clear >/dev/null 2>&1 &&
         magicnet_hotspot_startup_snapshot_clear
-    magicnet_warn "No supported sing-box core found or starting is disabled."
+    if ! magicnet_cmd_exists sing-box; then
+        magicnet_warn "sing-box executable was not found."
+    elif [ "${MAGIC_SINGBOX:-1}" -eq 0 ]; then
+        magicnet_warn "sing-box startup is disabled by configuration."
+    else
+        magicnet_warn "sing-box startup failed; see the preceding core or network error."
+    fi
     return 1
 }
 

--- a/src/MagicNet/lib/magicnet/network.sh
+++ b/src/MagicNet/lib/magicnet/network.sh
@@ -47,7 +47,7 @@ magicnet_iptables_cmd() {
         return $?
     fi
     if magicnet_cmd_exists timeout; then
-        timeout "$(magicnet_xtables_timeout)" iptables "$@"
+        timeout "$(magicnet_xtables_timeout)" iptables -w 1 "$@"
     else
         # All supported Android builds ship toybox timeout.  Keep a bounded
         # xtables wait even on a minimal test/runtime image without it.
@@ -61,7 +61,7 @@ magicnet_ip6tables_cmd() {
         return $?
     fi
     if magicnet_cmd_exists timeout; then
-        timeout "$(magicnet_xtables_timeout)" ip6tables "$@"
+        timeout "$(magicnet_xtables_timeout)" ip6tables -w 1 "$@"
     else
         ip6tables -w 1 "$@"
     fi
@@ -99,6 +99,33 @@ magicnet_xtables_available() {
     return "$_xtables_rc"
 }
 
+# Probe the table actually used by the caller. A working filter table says
+# nothing about nat support. Return 2 only for a missing binary/table/family;
+# permission errors and lock timeouts are failures, not proof of absence.
+magicnet_xtables_table_probe() (
+    _probe_family="$1"
+    _probe_table="$2"
+    magicnet_cmd_exists "$_probe_family" || return 2
+    _probe_rc=0
+    _probe_error="$(LC_ALL=C LANG=C "magicnet_${_probe_family}_cmd" -t "$_probe_table" -L -n 2>&1 >/dev/null)" || _probe_rc=$?
+    [ "$_probe_rc" -ne 0 ] || return 0
+    magicnet_warn "$_probe_family -t $_probe_table -L failed (exit=$_probe_rc): $_probe_error"
+    case "$_probe_rc" in 124 | 137 | 143) return 1 ;; esac
+    case "$_probe_error" in
+    *"Table does not exist"* | *"Address family not supported"* | *"Protocol not supported"*) return 2 ;;
+    esac
+    return 1
+)
+
+# Preserve actionable stderr without logging expected absent-rule checks.
+magicnet_xtables_require() (
+    _require_rc=0
+    _require_error="$("$@" 2>&1 >/dev/null)" || _require_rc=$?
+    [ "$_require_rc" -ne 0 ] || return 0
+    magicnet_warn "$* failed (exit=$_require_rc): $_require_error"
+    return "$_require_rc"
+)
+
 magicnet_xtables_ensure_rule() (
     _ensure_cmd="$1"
     _ensure_add="$2"
@@ -106,21 +133,24 @@ magicnet_xtables_ensure_rule() (
     shift 3
     _ensure_rc=0
     if [ -n "$_ensure_table" ]; then
-        "$_ensure_cmd" -t "$_ensure_table" -C "$@" >/dev/null 2>&1 || _ensure_rc=$?
+        _ensure_error="$("$_ensure_cmd" -t "$_ensure_table" -C "$@" 2>&1 >/dev/null)" || _ensure_rc=$?
     else
-        "$_ensure_cmd" -C "$@" >/dev/null 2>&1 || _ensure_rc=$?
+        _ensure_error="$("$_ensure_cmd" -C "$@" 2>&1 >/dev/null)" || _ensure_rc=$?
     fi
     case "$_ensure_rc" in
     0) return 0 ;;
     1)
         if [ -n "$_ensure_table" ]; then
-            "$_ensure_cmd" -t "$_ensure_table" "$_ensure_add" "$@" >/dev/null 2>&1
+            magicnet_xtables_require "$_ensure_cmd" -t "$_ensure_table" "$_ensure_add" "$@"
         else
-            "$_ensure_cmd" "$_ensure_add" "$@" >/dev/null 2>&1
+            magicnet_xtables_require "$_ensure_cmd" "$_ensure_add" "$@"
         fi
         ;;
-    124 | 137 | 143) return 124 ;;
-    *) return "$_ensure_rc" ;;
+    *)
+        magicnet_warn "$_ensure_cmd rule check failed (table=${_ensure_table:-filter}, exit=$_ensure_rc): $_ensure_error"
+        case "$_ensure_rc" in 124 | 137 | 143) return 124 ;; esac
+        return "$_ensure_rc"
+        ;;
     esac
 )
 
@@ -228,10 +258,17 @@ magicnet_enable_dns_capture() {
         return 1
     fi
 
-    if ! magicnet_xtables_available iptables; then
-        magicnet_warn "iptables is unavailable in the current Android root context; skipping kernel DNS capture and keeping sing-box TUN DNS"
+    _dns_capture_probe_rc=0
+    magicnet_xtables_table_probe iptables nat || _dns_capture_probe_rc=$?
+    case "$_dns_capture_probe_rc" in
+    0) ;;
+    2)
+        [ "$(magicnet_ipv6_mode)" != prefer_ipv6 ] || return 1
+        magicnet_warn "IPv4 nat unavailable; skipping kernel DNS capture and keeping sing-box TUN DNS only"
         return 0
-    fi
+        ;;
+    *) return 1 ;;
+    esac
 
     _dns_capture_port="$(magicnet_dns_capture_port)"
     _dns_capture_bypass_uids="$(magicnet_dns_capture_bypass_uids)"
@@ -241,16 +278,10 @@ magicnet_enable_dns_capture() {
     _dns_capture_rc=0
     _dns_capture_ipv6_unavailable=0
     if ! magicnet_iptables_cmd -t nat -N magicnet-dns-output >/dev/null 2>&1; then
-        magicnet_iptables_cmd -t nat -L magicnet-dns-output >/dev/null 2>&1 || _dns_capture_rc=1
+        magicnet_xtables_require magicnet_iptables_cmd -t nat -L magicnet-dns-output || _dns_capture_rc=1
     fi
-    magicnet_iptables_cmd -t nat -F magicnet-dns-output >/dev/null 2>&1 || _dns_capture_rc=1
-    _dns_capture_check_rc=0
-    magicnet_iptables_cmd -t nat -C OUTPUT -j magicnet-dns-output >/dev/null 2>&1 || _dns_capture_check_rc=$?
-    case "$_dns_capture_check_rc" in
-    0) ;;
-    1) magicnet_iptables_cmd -t nat -I OUTPUT 1 -j magicnet-dns-output >/dev/null 2>&1 || _dns_capture_rc=1 ;;
-    *) _dns_capture_rc=1 ;;
-    esac
+    magicnet_xtables_require magicnet_iptables_cmd -t nat -F magicnet-dns-output || _dns_capture_rc=1
+    magicnet_xtables_ensure_rule magicnet_iptables_cmd -I nat OUTPUT -j magicnet-dns-output || _dns_capture_rc=1
     # Direct UDP DNS servers are marked in the sing-box config. Keep those
     # resolver packets out of this chain without exempting all UID-0 traffic.
     if [ "$_dns_capture_singbox_marked" -eq 1 ]; then
@@ -264,8 +295,10 @@ magicnet_enable_dns_capture() {
 
     _dns_capture_ipv6_mode="$(magicnet_ipv6_mode 2>/dev/null || printf '%s\n' prefer_ipv4)"
     if [ "$_dns_capture_ipv6_mode" != ipv4_only ]; then
-        if ! magicnet_cmd_exists ip6tables || ! magicnet_ip6tables_cmd -t nat -L >/dev/null 2>&1; then
-            if [ "$_dns_capture_ipv6_mode" = prefer_ipv6 ]; then
+        _dns_capture_probe_rc=0
+        magicnet_xtables_table_probe ip6tables nat || _dns_capture_probe_rc=$?
+        if [ "$_dns_capture_probe_rc" -ne 0 ]; then
+            if [ "$_dns_capture_probe_rc" -ne 2 ] || [ "$_dns_capture_ipv6_mode" = prefer_ipv6 ]; then
                 _dns_capture_rc=1
             else
                 # Android kernels commonly expose ip6tables without an IPv6
@@ -277,16 +310,10 @@ magicnet_enable_dns_capture() {
             fi
         else
             if ! magicnet_ip6tables_cmd -t nat -N magicnet-dns-output >/dev/null 2>&1; then
-                magicnet_ip6tables_cmd -t nat -L magicnet-dns-output >/dev/null 2>&1 || _dns_capture_rc=1
+                magicnet_xtables_require magicnet_ip6tables_cmd -t nat -L magicnet-dns-output || _dns_capture_rc=1
             fi
-            magicnet_ip6tables_cmd -t nat -F magicnet-dns-output >/dev/null 2>&1 || _dns_capture_rc=1
-            _dns_capture_check_rc=0
-            magicnet_ip6tables_cmd -t nat -C OUTPUT -j magicnet-dns-output >/dev/null 2>&1 || _dns_capture_check_rc=$?
-            case "$_dns_capture_check_rc" in
-            0) ;;
-            1) magicnet_ip6tables_cmd -t nat -I OUTPUT 1 -j magicnet-dns-output >/dev/null 2>&1 || _dns_capture_rc=1 ;;
-            *) _dns_capture_rc=1 ;;
-            esac
+            magicnet_xtables_require magicnet_ip6tables_cmd -t nat -F magicnet-dns-output || _dns_capture_rc=1
+            magicnet_xtables_ensure_rule magicnet_ip6tables_cmd -I nat OUTPUT -j magicnet-dns-output || _dns_capture_rc=1
             if [ "$_dns_capture_singbox_marked" -eq 1 ]; then
                 magicnet_ip6tables_nat_ensure magicnet-dns-output -m mark --mark "$_dns_capture_singbox_mark/$_dns_capture_singbox_mark" -j RETURN || _dns_capture_rc=1
             fi
@@ -301,7 +328,7 @@ magicnet_enable_dns_capture() {
     if [ "$_dns_capture_rc" -ne 0 ]; then
         magicnet_disable_dns_capture >/dev/null 2>&1 || true
         unset _dns_capture_port _dns_capture_bypass_uids _dns_capture_bypass_uid _dns_capture_singbox_mark _dns_capture_singbox_marked
-        unset _dns_capture_rc _dns_capture_check_rc _dns_capture_ipv6_mode _dns_capture_ipv6_unavailable
+        unset _dns_capture_rc _dns_capture_probe_rc _dns_capture_ipv6_mode _dns_capture_ipv6_unavailable
         return 1
     fi
 
@@ -311,7 +338,7 @@ magicnet_enable_dns_capture() {
         magicnet_log "DNS capture redirected port 53 to 127.0.0.1:${_dns_capture_port}"
     fi
     unset _dns_capture_port _dns_capture_bypass_uids _dns_capture_bypass_uid _dns_capture_singbox_mark _dns_capture_singbox_marked
-    unset _dns_capture_rc _dns_capture_check_rc _dns_capture_ipv6_mode _dns_capture_ipv6_unavailable
+    unset _dns_capture_rc _dns_capture_probe_rc _dns_capture_ipv6_mode _dns_capture_ipv6_unavailable
 }
 
 magicnet_xtables_delete_rule() (
@@ -322,11 +349,12 @@ magicnet_xtables_delete_rule() (
     while [ "$_delete_attempt" -lt 64 ]; do
         _delete_rc=0
         if [ -n "$_delete_table" ]; then
-            "$_delete_cmd" -t "$_delete_table" -D "$@" >/dev/null 2>&1 || _delete_rc=$?
+            _delete_error="$("$_delete_cmd" -t "$_delete_table" -D "$@" 2>&1 >/dev/null)" || _delete_rc=$?
         else
-            "$_delete_cmd" -D "$@" >/dev/null 2>&1 || _delete_rc=$?
+            _delete_error="$("$_delete_cmd" -D "$@" 2>&1 >/dev/null)" || _delete_rc=$?
         fi
         case "$_delete_rc" in 124 | 137 | 143) return 124 ;; esac
+        _delete_write_rc=$_delete_rc
         _delete_rc=0
         if [ -n "$_delete_table" ]; then
             "$_delete_cmd" -t "$_delete_table" -C "$@" >/dev/null 2>&1 || _delete_rc=$?
@@ -335,6 +363,10 @@ magicnet_xtables_delete_rule() (
         fi
         case "$_delete_rc" in
         0)
+            if [ "$_delete_write_rc" -ne 0 ]; then
+                magicnet_warn "$_delete_cmd delete failed (exit=$_delete_write_rc): $_delete_error"
+                return 1
+            fi
             _delete_attempt=$((_delete_attempt + 1))
             continue
             ;;
@@ -353,46 +385,33 @@ magicnet_dns_capture_delete_jump() (
     magicnet_xtables_delete_rule "$_dns_capture_delete_cmd" "$_dns_capture_delete_table" "$@"
 )
 
-magicnet_disable_dns_capture() {
+magicnet_disable_dns_capture() (
     _dns_capture_cleanup_rc=0
-    if magicnet_xtables_available iptables; then
+    for _dns_capture_family in iptables ip6tables; do
+        _dns_capture_probe_rc=0
+        magicnet_xtables_table_probe "$_dns_capture_family" nat || _dns_capture_probe_rc=$?
+        case "$_dns_capture_probe_rc" in
+        0) ;;
+        2) continue ;;
+        *) _dns_capture_cleanup_rc=1; continue ;;
+        esac
+        _dns_capture_cmd="magicnet_${_dns_capture_family}_cmd"
         _dns_capture_chain_rc=0
-        magicnet_iptables_cmd -t nat -L magicnet-dns-output >/dev/null 2>&1 || _dns_capture_chain_rc=$?
+        "$_dns_capture_cmd" -t nat -L magicnet-dns-output >/dev/null 2>&1 || _dns_capture_chain_rc=$?
         case "$_dns_capture_chain_rc" in
         0)
-            # A failed/repeated enable can leave duplicate jumps in OUTPUT.  A
-            # single `-D` only removes the first one, so keep deleting until the
-            # chain is no longer referenced before flushing/removing it.
-            magicnet_dns_capture_delete_jump magicnet_iptables_cmd -t nat OUTPUT -j magicnet-dns-output || _dns_capture_cleanup_rc=1
-            magicnet_iptables_cmd -t nat -F magicnet-dns-output >/dev/null 2>&1 || _dns_capture_cleanup_rc=1
-            magicnet_iptables_cmd -t nat -X magicnet-dns-output >/dev/null 2>&1 || _dns_capture_cleanup_rc=1
+            # Remove every duplicate jump before flushing/deleting our chain.
+            magicnet_dns_capture_delete_jump "$_dns_capture_cmd" -t nat OUTPUT -j magicnet-dns-output || _dns_capture_cleanup_rc=1
+            magicnet_xtables_require "$_dns_capture_cmd" -t nat -F magicnet-dns-output || _dns_capture_cleanup_rc=1
+            magicnet_xtables_require "$_dns_capture_cmd" -t nat -X magicnet-dns-output || _dns_capture_cleanup_rc=1
             ;;
-        # Android iptables variants disagree on whether an absent custom chain
-        # is rc=1 or rc=2.  Both mean cleanup is already complete here.
+        # The table was readable; Android variants use 1 or 2 for no chain.
         1 | 2) ;;
         *) _dns_capture_cleanup_rc=1 ;;
         esac
-    fi
-    if magicnet_xtables_available ip6tables && magicnet_ip6tables_cmd -t nat -L >/dev/null 2>&1; then
-        _dns_capture_chain_rc=0
-        magicnet_ip6tables_cmd -t nat -L magicnet-dns-output >/dev/null 2>&1 || _dns_capture_chain_rc=$?
-        case "$_dns_capture_chain_rc" in
-        0)
-            magicnet_dns_capture_delete_jump magicnet_ip6tables_cmd -t nat OUTPUT -j magicnet-dns-output || _dns_capture_cleanup_rc=1
-            magicnet_ip6tables_cmd -t nat -F magicnet-dns-output >/dev/null 2>&1 || _dns_capture_cleanup_rc=1
-            magicnet_ip6tables_cmd -t nat -X magicnet-dns-output >/dev/null 2>&1 || _dns_capture_cleanup_rc=1
-            ;;
-        1 | 2) ;;
-        *) _dns_capture_cleanup_rc=1 ;;
-        esac
-    fi
-    if [ "$_dns_capture_cleanup_rc" -ne 0 ]; then
-        unset _dns_capture_cleanup_rc _dns_capture_chain_rc
-        return 1
-    fi
-    unset _dns_capture_cleanup_rc _dns_capture_chain_rc
-    return 0
-}
+    done
+    return "$_dns_capture_cleanup_rc"
+)
 
 magicnet_collect_physical_egress_ifaces() {
     if [ -n "${MAGIC_DNS_GUARD_IFACES:-}" ]; then
@@ -452,7 +471,7 @@ magicnet_dns_leak_guard_delete_family() (
 
 magicnet_dns_leak_guard_rule_ifaces() (
     _dns_guard_scan_cmd="$1"
-    _dns_guard_scan_rules="$("$_dns_guard_scan_cmd" -S OUTPUT 2>/dev/null)" || return $?
+    _dns_guard_scan_rules="$("$_dns_guard_scan_cmd" -S OUTPUT)" || return $?
     printf '%s\n' "$_dns_guard_scan_rules" | awk '
         $1 == "-A" && $2 == "OUTPUT" {
             iface = proto = port = target = ""
@@ -596,10 +615,9 @@ magicnet_disable_dns_leak_guard() (
     0) ;;
     *) _cleanup_ipv4_scan_failed=1 ;;
     esac
-    _cleanup_ipv4_ifaces=$(printf '%s\n%s\n' "$_cleanup_saved" "$_cleanup_ipv4_rules" |
-        awk 'NF && !seen[$0]++')
+    _cleanup_ipv4_ifaces="$_cleanup_ipv4_rules"
     if [ "$_cleanup_ipv4_scan_failed" -ne 0 ]; then
-        _cleanup_ipv4_ifaces=$(printf '%s\n%s\n' "$_cleanup_ipv4_ifaces" "$(magicnet_collect_physical_egress_ifaces)" |
+        _cleanup_ipv4_ifaces=$(printf '%s\n%s\n' "$_cleanup_saved" "$(magicnet_collect_physical_egress_ifaces)" |
             awk 'NF && !seen[$0]++')
     fi
 
@@ -623,10 +641,9 @@ magicnet_disable_dns_leak_guard() (
         0) ;;
         *) _cleanup_ipv6_scan_failed=1 ;;
         esac
-        _cleanup_ipv6_ifaces=$(printf '%s\n%s\n' "$_cleanup_saved" "$_cleanup_ipv6_rules" |
-            awk 'NF && !seen[$0]++')
+        _cleanup_ipv6_ifaces="$_cleanup_ipv6_rules"
         if [ "$_cleanup_ipv6_scan_failed" -ne 0 ]; then
-            _cleanup_ipv6_ifaces=$(printf '%s\n%s\n' "$_cleanup_ipv6_ifaces" "$(magicnet_collect_physical_egress_ifaces)" |
+            _cleanup_ipv6_ifaces=$(printf '%s\n%s\n' "$_cleanup_saved" "$(magicnet_collect_physical_egress_ifaces)" |
                 awk 'NF && !seen[$0]++')
         fi
         _cleanup_rc=0
@@ -652,7 +669,7 @@ magicnet_after_kernel_start_unlocked() {
     magicnet_after_kernel_start_deferred_unlocked
     _after_result=$?
     if [ "$_after_result" -ne 0 ]; then
-        magicnet_warn "Post-start network initialization failed; DNS interception remains disabled."
+        magicnet_warn "Post-start network initialization failed; DNS rule cleanup was attempted."
     fi
     set -- "$_after_result"
     unset _after_result

--- a/src/MagicNet/lib/magicnet/network.sh
+++ b/src/MagicNet/lib/magicnet/network.sh
@@ -346,6 +346,7 @@ magicnet_xtables_delete_rule() (
     _delete_table="$2"
     shift 2
     _delete_attempt=0
+    _delete_transient_retries=0
     while [ "$_delete_attempt" -lt 64 ]; do
         _delete_rc=0
         if [ -n "$_delete_table" ]; then
@@ -364,6 +365,12 @@ magicnet_xtables_delete_rule() (
         case "$_delete_rc" in
         0)
             if [ "$_delete_write_rc" -ne 0 ]; then
+                # Rule replacement can race a delete/check pair. Retry one
+                # generic rc=1 failure, but never spin on permission/lock errors.
+                if [ "$_delete_write_rc" -eq 1 ] && [ "$_delete_transient_retries" -eq 0 ]; then
+                    _delete_transient_retries=1
+                    continue
+                fi
                 magicnet_warn "$_delete_cmd delete failed (exit=$_delete_write_rc): $_delete_error"
                 return 1
             fi


### PR DESCRIPTION
## 问题与修复

针对 sing-box 已启动、随后 `dns-capture,dns-leak-guard` 初始化失败并回滚的日志，修复源码中可复现的兼容与清理问题，同时落实每次 CI 构建使用子模块最新远端提交的要求。

### 启动与 DNS 规则

- DNS 捕获按实际使用的 IPv4/IPv6 `nat` 表进行探测，避免用 `filter` 表可用性推断 `nat` 支持。只有明确缺失二进制、表或协议族时允许 IPv4 优先模式保留 TUN DNS 并记录降级警告；`prefer_ipv6` 不静默降级。
- 真实 xtables 调用增加 `-w 1`，保留外层超时；权限错误、锁等待超时及规则写入失败继续返回失败，不伪装成成功。
- 规则扫描成功时，仅清理实际发现的防 DNS 泄漏规则。旧接口状态仅在无法扫描时作为回退依据，避免关闭 guard 后对不存在的规则做推测性删除。
- 规则删除失败且规则仍存在时，保留重试状态并停止重复失败的删除尝试。新增表探测、规则写入及删除失败的底层错误日志。
- 保留真实后置初始化失败时停止核心的回滚逻辑；将误导性的“未找到支持的核心”改成缺少二进制、禁用启动、实际启动失败三种对应提示。

### 构建工作流

- 模块构建及 Rust/Shell 质量检查统一调用 `scripts/update-submodules.sh`，在工具链指纹与缓存键计算前更新依赖。
- 按 `.gitmodules` 指定分支获取最新远端提交；未指定分支时跟随远端默认分支。支持浅克隆、非默认分支（包括 sing-box/testing）、嵌套子模块，以及父仓库更新后的子模块配置。
- 任意拉取或分支解析失败均中止，不静默继续使用旧提交。
- 不改写主仓库已提交的 gitlink；在构建摘要与 `build-submodules.txt` 中记录实际 SHA。构建结束核对依赖提交未发生变化，构建产物及正式发布均携带清单。

## 验证

已在本地实际执行并通过：

- 新增启动回归：Bash、Dash、BusyBox ash 三种 shell。
- 现有 `scripts/test-dns-leak-guard-timeout.sh`。
- `python3 scripts/test-ci-submodules.py -v`：真实本地 Git 仓库的离线集成测试，覆盖浅克隆、嵌套分支更新、远端默认分支变更、重复刷新与缺失分支失败，以及工作流执行顺序。
- 修改脚本语法检查、`git diff --check`。
- 同一新增启动回归在原始源码上失败，在补丁源码上通过。

新增测试已接入 `scripts/test-host.sh`。

## 验证边界与风险

提供的设备日志没有底层 xtables stderr，无法据此断言设备的具体 errno 或 SELinux 原因。本 PR 修复已复现的源码路径并补齐诊断，尚未在用户 Android 真机验证。

本地仅运行上述定向测试，未运行完整 Android 模块构建、Rust/WebUI 全量测试及完整 host suite；这些检查由 PR CI 执行。采用最新远端依赖后，同一主仓库提交在不同时间构建可能得到不同依赖版本；实际 SHA 清单用于追溯，依赖更新引入的不兼容会暴露为构建/测试失败。

不包含发布或合并操作。

## Sourcery 总结

强化 sing-box DNS 启动与清理流程，同时在刷新递归子模块版本后，使 CI 构建具备可复现性和可追溯性。

Bug 修复：
- 强化 sing-box DNS 捕获和泄漏防护的启动与清理流程，确保能够检测实际的 NAT 支持情况，使 xtables 错误仍然可操作，并仅在安全时应用仅 IPv4 回退。
- 改进启动诊断，并在启动后的网络初始化失败时保留回滚行为。

增强功能：
- 将 DNS 规则清理限制为成功扫描期间发现的规则，同时在删除失败时保留重试状态。

构建：
- 在构建和质量检查前，从配置的远程分支或默认分支刷新递归子模块；更新失败时终止流程，并在构建产物和发布版本中记录和验证解析后的版本。

测试：
- 在 Bash、Dash 和 BusyBox ash 中新增基于 shell 的启动网络安全回归测试，并为递归 CI 子模块更新新增离线集成测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

强化 sing-box DNS 网络的启动与清理流程，同时刷新、验证并追踪 CI 子模块依赖。

错误修复：
- 通过探测实际的 NAT 表、保留 xtables 错误、应用安全的仅 IPv4 回退机制，并在启动后的网络故障中保留回滚逻辑，强化 sing-box DNS 捕获和防泄漏保护的启动与清理流程。
- 改进 sing-box 启动诊断，以区分二进制文件缺失、启动功能已禁用和实际启动失败。

增强功能：
- 将 DNS 防泄漏规则清理限制为成功扫描发现的规则，并在删除失败时保留重试状态。

构建：
- 在构建和质量检查输入之前，从已跟踪分支或远程默认分支刷新已配置的递归子模块；更新出错时使流程失败，保留主仓库的 gitlink，并在构建产物和发布内容中记录和验证解析后的修订版本。

测试：
- 添加 shell 启动网络安全回归测试，以及针对递归 CI 子模块更新的离线集成测试，覆盖分支变更、浅克隆、重复刷新和失败处理；并将两者集成到主机回归测试套件中。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

强化 sing-box DNS 网络功能，并确保 CI 子模块依赖得到刷新、验证和可追溯。

Bug 修复：
- 通过探测实际的 NAT 表、保留可操作的 xtables 错误、仅应用安全的 IPv4 回退机制，以及在启动后失败时保留回滚行为，强化 sing-box DNS 捕获和泄漏防护的启动与清理流程。
- 改进 sing-box 启动诊断，区分可执行文件缺失、启动功能已禁用，以及实际的启动或网络初始化失败。

增强功能：
- 将 DNS 泄漏防护清理限制为成功扫描发现的规则，并在规则删除失败时保留重试状态。

构建：
- 在对构建输入进行指纹计算前，从已跟踪分支或远程默认分支刷新已配置的递归子模块；更新失败时终止流程，保留主仓库的 gitlink，并在构建产物和发布版本中记录和验证解析后的修订版本。

CI：
- 在构建和质量检查工作流中，于计算依赖检查项和输入之前执行递归子模块刷新。

测试：
- 新增覆盖 Bash、Dash 和 BusyBox ash 的 Shell 启动网络安全回归测试，以及针对递归子模块更新和失败处理的离线集成测试；并将两者集成到主机回归测试套件中。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

强化 sing-box DNS 的启动和清理流程，同时刷新、验证并跟踪 CI 子模块依赖。

Bug 修复：
- 通过探测实际的 NAT 能力、保留 xtables 错误、仅应用安全的 IPv4 回退行为，并在启动后的网络失败时保留回滚机制，强化 sing-box DNS 捕获和防泄漏保护的启动流程。
- 改进 sing-box 启动诊断，以区分缺少二进制文件、启动已禁用，以及实际的启动或网络初始化失败。

增强功能：
- 将 DNS 防泄漏清理限制为成功扫描期间发现的规则，并在删除失败时保留重试状态。

构建：
- 在构建和质量检查之前，从已跟踪分支或远程默认分支刷新已配置的递归子模块；更新失败时终止流程，保留主仓库的 gitlink，并在构件和发布版本中记录和验证解析后的修订版本。

CI：
- 在计算构建输入之前，在构建和质量检查工作流中执行递归子模块刷新。

测试：
- 在 Bash、Dash 和 BusyBox ash 中新增 Shell 启动网络安全回归测试，并新增用于递归子模块更新及失败处理的离线集成测试；将两者集成到主机回归测试套件中。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

强化 sing-box DNS 网络功能，并确保 CI 子模块依赖得到刷新、验证和追踪。

错误修复：
- 通过探测实际的 NAT 能力、保留可操作的 xtables 失败信息、仅应用安全的 IPv4 回退机制，并在启动后的网络故障中保留回滚逻辑，强化 sing-box DNS 捕获和泄漏防护的启动与清理流程。
- 改进 sing-box 启动诊断，以区分可执行文件缺失、启动功能被禁用，以及实际的启动或网络初始化失败。

增强功能：
- 将 DNS 泄漏防护清理限制为成功扫描发现的规则，并在删除失败时保留重试状态。

构建：
- 在对构建输入进行指纹计算之前，从已跟踪分支或远程默认分支刷新已配置的递归子模块；更新失败时中止构建，并在构件和发布内容中记录和验证解析后的修订版本。

CI：
- 在构建和质量工作流中，于依赖检查之前执行递归子模块刷新。

测试：
- 在 Bash、Dash 和 BusyBox ash 中新增 shell 启动网络安全回归测试，并新增针对递归子模块更新及失败处理的离线集成测试；两者均纳入主机回归测试套件。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

强化 sing-box DNS 网络功能，并使 CI 子模块依赖得到刷新、验证和可追溯。

Bug 修复：
- 通过探测实际的 NAT 能力、保留 xtables 失败状态、仅应用安全的 IPv4 回退行为，并在启动后失败时保留回滚机制，强化 sing-box DNS 捕获和防泄漏保护的启动与清理流程。
- 改进 sing-box 启动诊断，以区分缺少二进制文件、启动已禁用，以及实际的启动或网络初始化失败。

增强功能：
- 将 DNS 防泄漏保护的清理范围限制为成功扫描发现的规则，并在规则删除失败时保留重试状态。

构建：
- 在计算构建输入之前，从已跟踪分支或远程默认分支刷新已配置的递归子模块；更新失败时终止构建，并在构建产物和发布内容中记录及验证解析后的版本。

CI：
- 在依赖或工具链输入生成指纹之前，在构建和质量工作流中执行递归子模块刷新。

测试：
- 添加覆盖 Bash、Dash 和 BusyBox ash 的 shell 启动网络安全回归测试，以及针对递归子模块更新和失败处理的离线集成测试；将两者集成到主机回归测试套件中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden sing-box DNS networking and make CI submodule dependencies refreshed, verified, and traceable.

Bug Fixes:
- Harden sing-box DNS capture and leak-guard startup and cleanup by probing the actual NAT capabilities, preserving xtables failures, applying only safe IPv4 fallback behavior, and retaining rollback after post-start failures.
- Improve sing-box startup diagnostics to distinguish missing binaries, disabled startup, and actual startup or network initialization failures.

Enhancements:
- Restrict DNS leak-guard cleanup to rules discovered by successful scans and preserve retry state when rule deletion fails.

Build:
- Refresh configured recursive submodules from their tracked or remote-default branches before build inputs are calculated, fail on update errors, and record and verify the resolved revisions in build artifacts and releases.

CI:
- Run recursive submodule refreshes in build and quality workflows before dependency or toolchain inputs are fingerprinted.

Tests:
- Add shell startup network-safety regressions covering Bash, Dash, and BusyBox ash, plus offline integration tests for recursive submodule updates and failure handling; integrate both into the host regression suite.

</details>

</details>

</details>

</details>

</details>

</details>