### PR TITLE
fix(install): 升级保留订阅并自动刷新完整配置模板

### DIFF
--- a/scripts/package-install-smoke.sh
+++ b/scripts/package-install-smoke.sh
@@ -46,11 +46,12 @@ fail() {
     exit 1
 }
 
-for tool in bash cargo chmod cp env find grep ln mkdir python3 readlink rm sed sh timeout unzip; do
+for tool in bash cargo chmod cp env find grep ln mkdir mv python3 readlink rm sed sh timeout unzip; do
     command -v "$tool" >/dev/null 2>&1 || fail "missing required command: $tool"
 done
 HOST_ENV="$(command -v env)"
 
+bash "$ROOT/scripts/test-install-config-template.sh"
 "$ROOT/scripts/package-smoke.sh" "$ZIP_PATH"
 
 mkdir -p "$MODPATH" "$MANAGER_MODPATH" "$MOCK_BIN"
@@ -90,7 +91,7 @@ done
 
 install_host_tool_fixtures() {
     fixture_module="$1"
-    for tool in bash chown chmod cp cut date find grep ln mkdir rm sed sh timeout tr unzip; do
+    for tool in bash chown chmod cp cut date find grep ln mkdir mv rm sed sh timeout tr unzip; do
         host_tool="$(command -v "$tool")" || fail "missing host tool fixture: $tool"
         [[ -x "$host_tool" ]] || fail "host tool fixture is not executable: $tool"
         [[ ! -e "$fixture_module/bin/$tool" ]] || fail "host tool fixture collides with package binary: $tool"
@@ -104,7 +105,7 @@ install_host_tool_fixtures() {
 
 remove_host_tool_fixtures() {
     fixture_module="$1"
-    rm -f "$fixture_module/bin"/{bash,chcon,chmod,chown,cmd,cp,cut,date,find,getevent,grep,ln,mkdir,restorecon,rm,sed,settings,sh,timeout,tr,unzip}
+    rm -f "$fixture_module/bin"/{bash,chcon,chmod,chown,cmd,cp,cut,date,find,getevent,grep,ln,mkdir,mv,restorecon,rm,sed,settings,sh,timeout,tr,unzip}
 }
 
 assert_fixture_path() {

--- a/scripts/test-install-config-template.sh
+++ b/scripts/test-install-config-template.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+python3 - "$ROOT" <<'PY'
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import zipfile
+
+source = (Path(sys.argv[1]) / 'src/MagicNet/customize.sh').read_text()
+start = source.index('magicnet_install_config_template() (\n')
+end = source.index('\n)\n', start) + 3
+helper = source[start:end]
+template = b'{"dns":{"servers":[]},"route":{"rules":[]},"outbounds":[],"new_template":true}\n'
+shells = [['sh'], ['bash']]
+if shutil.which('busybox'):
+    shells.append(['busybox', 'ash'])
+
+class InstallTemplate(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.mod = self.root / 'module with spaces'
+        self.config = self.mod / '.config/sing-box'
+        self.config.mkdir(parents=True)
+        self.active = self.config / 'config.json'
+        self.active.write_bytes(b'{"old_template":true}\n')
+        self.archive = self.root / 'release.zip'
+        self.write_zip(template)
+
+    def write_zip(self, content):
+        with zipfile.ZipFile(self.archive, 'w') as archive:
+            if content is not None:
+                archive.writestr('.config/sing-box/config.json', content)
+
+    def run_helper(self, shell, success=True, prefix=''):
+        result = subprocess.run(
+            shell + ['-c', helper + '\n' + prefix + '\nmagicnet_install_config_template'],
+            env={**os.environ, 'MODPATH': str(self.mod), 'ZIPFILE': str(self.archive)},
+            capture_output=True, timeout=10,
+        )
+        self.assertEqual(result.returncode == 0, success, result.stderr.decode())
+        self.assertEqual(list(self.config.glob('.install-template.*')), [])
+
+    def test_upgrade_preserves_subscription_inputs_and_cache(self):
+        work = self.mod / '.state/sing-box/subscription-work'
+        work.mkdir(parents=True)
+        preserved = {
+            self.config / 'subscription.url': b'https://example.invalid/a\nhttps://example.invalid/b\n',
+            self.config / 'subscription.local': b'local subscription fixture\n',
+            self.config / 'subscription.user-agent': b'custom-agent\n',
+            self.config / 'subscription-filter.list': b'',
+            work / 'outbounds.json': b'[]\n',
+        }
+        for path, content in preserved.items():
+            path.write_bytes(content)
+        for shell in shells:
+            with self.subTest(shell=shell):
+                self.active.write_bytes(b'{"old_template":true}\n')
+                (self.config / 'standalone-config').touch()
+                (self.config / 'config.json.update').write_bytes(b'old update\n')
+                self.run_helper(shell)
+                self.assertEqual(self.active.read_bytes(), template)
+                self.assertEqual(self.active.stat().st_mode & 0o777, 0o600)
+                self.assertFalse((self.config / 'standalone-config').exists())
+                self.assertFalse((self.config / 'config.json.update').exists())
+                for path, content in preserved.items():
+                    self.assertEqual(path.read_bytes(), content)
+
+    def test_fresh_install(self):
+        for shell in shells:
+            with self.subTest(shell=shell):
+                shutil.rmtree(self.mod)
+                self.run_helper(shell)
+                self.assertEqual(self.active.read_bytes(), template)
+
+    def test_missing_or_empty_template_keeps_previous_config(self):
+        for content in (None, b''):
+            self.write_zip(content)
+            for shell in shells:
+                with self.subTest(shell=shell, content=content):
+                    self.run_helper(shell, success=False)
+                    self.assertEqual(self.active.read_bytes(), b'{"old_template":true}\n')
+
+    def test_corrupt_archive_keeps_previous_config(self):
+        self.archive.write_bytes(b'not a zip')
+        for shell in shells:
+            with self.subTest(shell=shell):
+                self.run_helper(shell, success=False)
+                self.assertEqual(self.active.read_bytes(), b'{"old_template":true}\n')
+
+    def test_config_symlink_is_rejected(self):
+        outside = self.root / 'outside.json'
+        outside.write_bytes(b'must survive')
+        self.active.unlink()
+        self.active.symlink_to(outside)
+        for shell in shells:
+            with self.subTest(shell=shell):
+                self.run_helper(shell, success=False)
+                self.assertEqual(outside.read_bytes(), b'must survive')
+
+    def test_config_directory_is_rejected(self):
+        self.active.unlink()
+        self.active.mkdir()
+        for shell in shells:
+            with self.subTest(shell=shell):
+                self.run_helper(shell, success=False)
+                self.assertTrue(self.active.is_dir())
+
+    def test_no_interactive_old_config_restore(self):
+        self.assertNotIn('confirm_update_file ', source)
+        self.assertGreater(source.index('magicnet_install_config_template || abort'),
+                           source.index('! failed to restore MagicNet migration data:'))
+
+unittest.main(argv=[sys.argv[0]], verbosity=2)
+PY

--- a/src/MagicNet/customize.sh
+++ b/src/MagicNet/customize.sh
@@ -179,13 +179,13 @@ sing-box: /data/adb/modules/MagicNet/.config/sing-box/config.json"
 
 set_i18n "INSTALL_NEXT_STEPS" \
   "zh" "安装后操作：
-1. 执行 cli setup <合法订阅链接> 初始化 sing-box 订阅。
+1. 首次安装执行 cli setup <合法订阅链接>；升级自动保留订阅并更新完整配置模板。
 2. 重启设备，或在模块操作页启动内核。
 3. 打开模块 WebUI 的内核面板，或在终端执行 cli api ui 查看当前核心入口。
 4. 把想戒掉的网站、规则组或域名指向 REJECT / block。
 sing-box 默认: http://127.0.0.1:9090/ui/#/setup?hostname=127.0.0.1&port=9090" \
   "en" "After installation:
-1. Run cli setup <legal-subscription-url> to initialize the sing-box subscription.
+1. First install: run cli setup <legal-subscription-url>. Upgrades preserve subscriptions and replace the full config template.
 2. Reboot, or start the core from the module action page.
 3. Open Kernel Panel in the module WebUI, or run cli api ui to print the current core entry.
 4. Point distracting sites, groups, or domains to REJECT / block.
@@ -445,12 +445,33 @@ rm -f "${MODPATH}/kam.log" "${MODPATH}/cli.legacy.sh" "${MODPATH}/mcp-server.sh"
 [ -d "${MODPATH}/bin" ] && set_perm_recursive "${MODPATH}/bin" 0 0 0755 0755 u:object_r:system_file:s0
 [ -d "${MODPATH}/webroot" ] && set_perm_recursive "${MODPATH}/webroot" 0 0 0755 0644 u:object_r:system_file:s0
 
-# sing-box configs contain subscription credentials and node secrets.  Atomic
-# runtime writers enforce this too, but set the permission before the first
-# boot so a packaged or restored config never starts world-readable.
-if [ -f "${MODPATH}/.config/sing-box/config.json" ]; then
-  chmod 600 "${MODPATH}/.config/sing-box/config.json" || abort "! failed to protect sing-box config"
-fi
+# Subscription inputs/cache were restored above; the generated config is not
+# user state. Always take the whole template from this release, even when the
+# manager pre-extracted the ZIP over an existing directory. Startup replays the
+# cached nodes (or fetches the saved subscription) using the normal validator.
+# Do not run the core or require a network connection inside the installer.
+magicnet_install_config_template() (
+  _config_dir="${MODPATH}/.config/sing-box"
+  for _path in "${MODPATH}/.config" "$_config_dir" "$_config_dir/config.json"; do
+    [ ! -L "$_path" ] || return 1
+  done
+  mkdir -p "$_config_dir" || return 1
+  _stage="$_config_dir/.install-template.$$"
+  (umask 077; mkdir "$_stage") || return 1
+  trap 'rm -rf "$_stage"' 0
+  trap 'exit 1' 1 2 3 15
+  unzip -p "$ZIPFILE" '.config/sing-box/config.json' >"$_stage/config.json" || return 1
+  [ -s "$_stage/config.json" ] && chmod 600 "$_stage/config.json" || return 1
+  [ ! -e "$_config_dir/config.json" ] || [ -f "$_config_dir/config.json" ] || return 1
+  mv -f "$_stage/config.json" "$_config_dir/config.json" || return 1
+  # A stale standalone marker would bypass subscription/cache replay entirely.
+  if [ -s "$_config_dir/subscription.url" ] || [ -s "$_config_dir/subscription.local" ]; then
+    rm -f "$_config_dir/standalone-config" || return 1
+  fi
+  rm -f "$_config_dir/config.json.update"
+)
+
+magicnet_install_config_template || abort "! failed to install the new sing-box config template"
 
 rm -f "${MODPATH}/cli" 2>/dev/null || true
 ln -s "bin/magicnet-cli" "${MODPATH}/cli" 2>/dev/null || true
@@ -461,10 +482,6 @@ for _magicnet_entry in action.sh service.sh boot-completed.sh; do
   set_perm "${MODPATH}/${_magicnet_entry}" 0 0 0755 u:object_r:system_file:s0
 done
 unset _magicnet_entry
-
-if magicnet_install_is_interactive; then
-  [ -f "${MODPATH}/.config/sing-box/config.json" ] && confirm_update_file ".config/sing-box/config.json"
-fi
 
 import launcher
 launch url "https://github.com/LIghtJUNction/MagicNet/blob/main/src/MagicNet/README.md"


### PR DESCRIPTION
## 需求
每次刷入 MagicNet 新版本，自动保留订阅资料，并使用本次发布包的完整配置模板；不再要求用户确认是否沿用旧 config.json，也不要求重新输入订阅。

## 修改
- 保留原有订阅 URL、本地订阅、User-Agent、过滤规则、订阅工作缓存和选择状态的迁移流程。
- 在迁移完成后，从当前 ZIP 显式提取 `.config/sing-box/config.json`，通过私有临时目录及同文件系统 rename 替换整份配置模板，写入前设置 0600 权限。
- 删除终端安装中的 `confirm_update_file` 旧配置保留询问，避免旧配置重新覆盖新模板。
- 对存在订阅来源的安装清除过时的 `standalone-config` 标记，避免启动时跳过订阅/缓存恢复；清理旧 `config.json.update`。
- 更新中英文安装提示，区分首次配置和自动升级。
- 不在安装器内启动 sing-box，不要求联网。重启后的现有启动流程负责把缓存节点写入新模板；无可用节点缓存时再尝试拉取已保存的订阅。

## 防护与回归
新增 `scripts/test-install-config-template.sh`，直接提取并执行实际安装器中的函数，而不是复制实现。覆盖首次安装、完整模板替换、多订阅及本地订阅/UA/空过滤列表/缓存保留、0600 权限、旧标记清理、缺失或空模板、损坏 ZIP、符号链接及目录目标拒绝，以及不再调用交互保留旧配置的检查。

模板提取失败时，不覆盖目标已有配置；临时目录只在本次成功创建后清理。安装阶段只检查 ZIP 提取与非空文件，配置语义校验继续交给现有发布包检查和启动/订阅验证流程。

## 验证结果
- [x] `bash scripts/test-install-config-template.sh`：7 个测试方法通过，运行类场景分别使用 `sh`、`bash`、`busybox ash`。
- [x] `sh -n src/MagicNet/customize.sh`
- [x] `bash -n src/MagicNet/customize.sh`
- [x] `busybox ash -n src/MagicNet/customize.sh`
- [x] `git diff --check`
- [ ] 完整发布包 `scripts/package-install-smoke.sh`：本环境未运行。
- [ ] Android 真机刷入和重启：未验证。

范围仅为安装阶段的模板更新和对应回归测试，不改变运行期订阅下载、透明代理模式或节点选择算法。未合并、未发布新版本。

## Sourcery 摘要

在升级过程中自动保留订阅状态，同时使用完整的 sing-box 发布模板替换现有配置，并安全地验证安装过程。

错误修复：
- 确保升级时安装发布版本的完整 sing-box 配置模板，同时保留现有的订阅输入和缓存节点数据。
- 防止过时的独立配置标记和更新文件绕过订阅恢复流程，或覆盖新模板。
- 拒绝不安全或无效的模板提取场景，避免替换现有配置。

增强功能：
- 移除保留之前 config.json 的交互式提示，并将订阅/缓存恢复延后至正常的安装后启动流程。
- 将已安装的配置模板权限设置为限制性的 0600，并更新首次设置与升级场景下的安装指导。

测试：
- 增加跨 Shell 的回归测试，覆盖全新安装、升级、订阅状态保留、模板替换、权限、清理、无效归档、不安全的文件系统目标以及非交互式安装。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在升级过程中自动保留订阅状态，并使用完整的发布版本模板替换 sing-box 配置。

错误修复：
- 确保升级时安装发布版本的完整 sing-box 配置模板，同时保留现有的订阅输入和缓存节点数据。
- 防止过期的独立标记和更新文件绕过订阅恢复流程，或干扰新模板。
- 拒绝无效或不安全的模板归档文件和文件系统目标，避免覆盖现有配置。

增强功能：
- 移除保留先前配置的交互式提示，并将订阅或缓存恢复操作推迟到正常的安装后启动流程。
- 将已安装的 sing-box 配置权限设置为 0600，并更新首次设置和升级时的安装指南。

CI：
- 添加跨 Shell 的回归测试，覆盖全新安装、升级、模板替换、状态保留、权限、清理、无效归档文件、不安全目标以及非交互式安装；并从软件包安装冒烟测试中运行这些测试。

测试：
- 添加安装模板回归测试，覆盖受支持 Shell 中的成功和失败场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automatically preserve subscription state during upgrades and replace the sing-box configuration with the complete release template.

Bug Fixes:
- Ensure upgrades install the release’s complete sing-box configuration template while preserving existing subscription inputs and cached node data.
- Prevent stale standalone markers and update files from bypassing subscription recovery or interfering with the new template.
- Reject invalid or unsafe template archives and filesystem targets without overwriting the existing configuration.

Enhancements:
- Remove the interactive prompt to retain the previous config and defer subscription or cache restoration to the normal post-install startup flow.
- Set the installed sing-box configuration permissions to 0600 and update installation guidance for first-time setup versus upgrades.

CI:
- Add cross-shell regression coverage for fresh installs, upgrades, template replacement, state preservation, permissions, cleanup, invalid archives, unsafe targets, and non-interactive installation; run it from the package installation smoke test.

Tests:
- Add install-template regression tests covering successful and failure scenarios across supported shells.

</details>

</details>