### PR TITLE
feat(install): 升级时保留订阅并自动重建完整配置

### DIFF
--- a/scripts/test-host.sh
+++ b/scripts/test-host.sh
@@ -42,6 +42,7 @@ done
 jq empty src/MagicNet/.config/sing-box/config.json
 bash scripts/test-repository-hygiene.sh
 bash scripts/test-config-template-pin.sh
+bash scripts/test-install-config-refresh.sh
 sh scripts/test-kamfw-i18n.sh
 sh scripts/test-magicnet-i18n.sh
 if [ "$with_routing_assets" -eq 1 ]; then

--- a/scripts/test-install-config-refresh.sh
+++ b/scripts/test-install-config-refresh.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Migration contract tests. The subscription generator/core are controlled
+# fixtures here; their protocol and policy behavior have separate runtime tests.
+set -Eeuo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export MODPATH="$TMP/module" MAGICNET_BACKUP_DIR="$TMP/previous" ZIPFILE="$TMP/module.zip"
+mkdir -p "$MODPATH"/{bin,lib,.config/sing-box,.state/sing-box/subscription-work} \
+    "$MAGICNET_BACKUP_DIR/.config/sing-box"
+CONFIG="$MODPATH/.config/sing-box/config.json"
+PREVIOUS="$MAGICNET_BACKUP_DIR/.config/sing-box/config.json"
+CACHE="$MODPATH/.state/sing-box/subscription-work/outbounds.json"
+MARKER="$MODPATH/.config/sing-box/standalone-config"
+export CONFIG
+python3 - "$ZIPFILE" <<'PY'
+import sys, zipfile
+with zipfile.ZipFile(sys.argv[1], 'w') as z:
+    z.writestr('.config/sing-box/config.json', '{"dns":{"tag":"new"},"route":{"final":"proxy"},"inbounds":[{"type":"tun"}],"outbounds":[]}')
+PY
+cat >"$MODPATH/lib/magicnet_singbox_subscribe.sh" <<'FIXTURE'
+magicnet_singbox_build_outbounds_file_with_jq() {
+    [ -f "$2" ] || return 1
+    jq '[.[] | select(.type == "trojan" and .tag != "HK filtered")] + [{"type":"selector","tag":"proxy","default":"new-policy"}]' "$1" >"$3"
+}
+magicnet_singbox_update_config_with_nodes() (
+    trap 'rm -f "${MAGICNET_SUB_CONFIG_FILE}.new"' 0
+    jq --slurpfile nodes "$1" '.outbounds = $nodes[0]' \
+        "$MAGICNET_SUB_CONFIG_FILE" >"${MAGICNET_SUB_CONFIG_FILE}.new" || return 1
+    sing-box check -c "${MAGICNET_SUB_CONFIG_FILE}.new" -D "${MAGICNET_SUB_CONFIG_FILE%/*}" || return 1
+    mv "${MAGICNET_SUB_CONFIG_FILE}.new" "$MAGICNET_SUB_CONFIG_FILE"
+)
+FIXTURE
+cat >"$MODPATH/bin/sing-box" <<'FIXTURE'
+#!/bin/sh
+[ "${REJECT_CONFIG:-0}" != 1 ] || exit 1
+[ "$1" = check ] && [ "$2" = -c ] && [ "$4" = -D ] && [ "$5" = "${CONFIG%/*}" ] || exit 1
+jq -e 'type == "object"' "$3" >/dev/null
+FIXTURE
+chmod +x "$MODPATH/bin/sing-box"
+cat >"$TMP/runner.sh" <<'SHRUN'
+set -eu
+info() { printf '%s\n' "$*"; }
+error() { printf '%s\n' "$*" >&2; }
+. "$1"
+magicnet_refresh_install_config
+SHRUN
+run_refresh() { "${TEST_SHELL:-sh}" "$TMP/runner.sh" "$ROOT/src/MagicNet/lib/magicnet/install_config.sh" >"$TMP/log" 2>&1; }
+expect_failure() { if run_refresh; then echo 'expected migration failure' >&2; exit 1; fi; }
+no_temporary_files() {
+    [[ -z "$(find "$MODPATH" -name 'install-config.*' -o -name '*.install-new.*')" ]]
+}
+# Fresh install: use the ZIP even if an unrelated config already exists.
+printf '%s\n' '{"old":true}' >"$CONFIG"
+run_refresh
+jq -e '.dns.tag == "new" and (has("old") | not)' "$CONFIG" >/dev/null
+[[ "$(stat -c %a "$CONFIG")" == 600 ]]
+# Preserve source files byte-for-byte; no network access is needed.
+for item in subscription.url subscription.local subscription.user-agent subscription-filter.list; do
+    printf 'saved-%s\n' "$item" >"$MODPATH/.config/sing-box/$item"
+done
+printf '%s\n' '{"old":true,"dns":{"tag":"old"},"outbounds":[{"type":"trojan","tag":"US saved","server":"node.example","server_port":443,"password":"fixture-secret"}]}' >"$PREVIOUS"
+printf '%s\n' '[{"type":"trojan","tag":"US cached","server":"node.example","server_port":443,"password":"fixture-secret"},{"type":"trojan","tag":"HK filtered","server":"hk.example","server_port":443,"password":"fixture-secret"},{"type":"selector","tag":"proxy","default":"old-policy"}]' >"$CACHE"
+run_refresh
+jq -e '.dns.tag == "new" and .inbounds[0].type == "tun" and .route.final == "proxy" and (has("old") | not) and any(.outbounds[]; .tag == "US cached" and .password == "fixture-secret") and any(.outbounds[]; .tag == "proxy" and .default == "new-policy") and all(.outbounds[]; .tag != "HK filtered")' "$CONFIG" >/dev/null
+cmp "$PREVIOUS" "$CONFIG.pre-upgrade"
+[[ "$(stat -c %a "$CONFIG.pre-upgrade")" == 600 ]]
+for item in subscription.url subscription.local subscription.user-agent subscription-filter.list; do
+    [[ "$(cat "$MODPATH/.config/sing-box/$item")" == "saved-$item" ]]
+done
+! grep -q 'fixture-secret' "$TMP/log"
+no_temporary_files
+# Corrupt/missing caches fall back to nodes from the previous full config.
+printf 'broken cache\n' >"$CACHE"
+: >"$MARKER"
+run_refresh
+jq -e 'any(.outbounds[]; .tag == "US saved")' "$CONFIG" >/dev/null
+[[ ! -e "$MARKER" ]]
+rm "$CACHE"
+run_refresh
+# Legacy cached fragments are still usable.
+printf '"outbounds": [{"type":"trojan","tag":"US legacy","server":"node.example","server_port":443,"password":"fixture-secret"}],\n' >"$CACHE"
+run_refresh
+jq -e 'any(.outbounds[]; .tag == "US legacy")' "$CONFIG" >/dev/null
+# Failed validation leaves both the existing file and standalone marker intact.
+cp "$CONFIG" "$TMP/before"
+: >"$MARKER"
+export REJECT_CONFIG=1
+expect_failure
+unset REJECT_CONFIG
+cmp "$CONFIG" "$TMP/before"
+[[ -f "$MARKER" ]]
+no_temporary_files
+# A broken ZIP or unsafe backup path must never overwrite the active config.
+SAVED_ZIP="$ZIPFILE"; export ZIPFILE="$TMP/missing.zip"
+expect_failure
+cmp "$CONFIG" "$TMP/before"
+export ZIPFILE="$SAVED_ZIP"
+rm "$CONFIG.pre-upgrade"
+ln -s "$TMP/before" "$CONFIG.pre-upgrade"
+expect_failure
+cmp "$CONFIG" "$TMP/before"
+rm "$CONFIG.pre-upgrade"
+# Unsupported standalone configurations fail instead of silently losing access.
+printf '{"outbounds":[]}\n' >"$PREVIOUS"
+rm "$CACHE"
+expect_failure
+cmp "$CONFIG" "$TMP/before"
+no_temporary_files
+# The installer snapshots the old file, restores subscriptions, then rebuilds.
+python3 - "$ROOT/src/MagicNet/customize.sh" <<'PY'
+import sys
+s = open(sys.argv[1]).read()
+a, b = s.split('if [ "$MAGICNET_BACKUP_READY" = 1 ]; then', 1)
+assert '".config/sing-box/config.json"' in a
+assert '".config/sing-box/config.json"' not in b.split('# The repository selector', 1)[0]
+assert 'confirm_update_file' not in s
+assert b.index('magicnet_refresh_install_config ||') < b.index('magicnet_cleanup_install_backup ||')
+PY
+printf '%s\n' 'install config refresh: all migration contract checks passed'

--- a/src/MagicNet/customize.sh
+++ b/src/MagicNet/customize.sh
@@ -99,7 +99,9 @@ if [ -d "$MAGICNET_PREV_DIR" ]; then
       printf '%s\n' "$MAGICNET_BACKUP_MARKER_VALUE" >"$MAGICNET_BACKUP_DIR/$MAGICNET_BACKUP_MARKER"
   ) || abort "! failed to create the MagicNet migration backup"
   MAGICNET_BACKUP_ACTIVE=1
+  # Snapshot the old full file for node recovery and a private rollback copy.
   for _item in \
+    ".config/sing-box/config.json" \
     ".config/sing-box/subscription.url" \
     ".config/sing-box/subscription.local" \
     ".config/sing-box/subscription.user-agent" \
@@ -316,7 +318,6 @@ if [ "$MAGICNET_BACKUP_READY" = 1 ]; then
       cp -a "${MAGICNET_BACKUP_DIR}/${_item}" "${MODPATH}/${_item}" || abort "! failed to restore MagicNet migration data: $_item"
     fi
   done
-  magicnet_cleanup_install_backup || abort "! failed to remove the MagicNet migration backup"
   unset _item
 fi
 
@@ -462,9 +463,11 @@ for _magicnet_entry in action.sh service.sh boot-completed.sh; do
 done
 unset _magicnet_entry
 
-if magicnet_install_is_interactive; then
-  [ -f "${MODPATH}/.config/sing-box/config.json" ] && confirm_update_file ".config/sing-box/config.json"
-fi
+# Upgrade automatically in both manager and terminal installs. Never let the
+# old full config override the new package template.
+. "${MODPATH}/lib/magicnet/install_config.sh"
+magicnet_refresh_install_config || abort "! failed to rebuild the sing-box config; upgrade aborted"
+magicnet_cleanup_install_backup || abort "! failed to remove the MagicNet migration backup"
 
 import launcher
 launch url "https://github.com/LIghtJUNction/MagicNet/blob/main/src/MagicNet/README.md"

--- a/src/MagicNet/lib/magicnet/install_config.sh
+++ b/src/MagicNet/lib/magicnet/install_config.sh
@@ -1,0 +1,82 @@
+# shellcheck shell=ash
+# Rebuild from this ZIP, importing subscription nodes rather than old policy.
+# Runs in a subshell so installer paths, traps and runtime helpers stay isolated.
+magicnet_refresh_install_config() (
+    umask 077
+    MODDIR="$MODPATH"
+    PATH="${MODDIR}/bin:${MODDIR}/system/bin:${PATH:-}"
+    export MODDIR PATH
+    _refresh_config="${MODDIR}/.config/sing-box/config.json"
+    _refresh_previous="${MAGICNET_BACKUP_DIR}/.config/sing-box/config.json"
+    _refresh_backup="${_refresh_config}.pre-upgrade"
+    _refresh_candidate="${_refresh_config}.install-new.$$"
+    _refresh_work="${MODDIR}/.state/install-config.$$"
+    for _refresh_path in "${MODDIR}/.config" "${MODDIR}/.config/sing-box" \
+        "${MODDIR}/.state" "$_refresh_config" "$_refresh_backup"; do
+        [ ! -L "$_refresh_path" ] || return 1
+    done
+    for _refresh_path in "$_refresh_config" "$_refresh_backup"; do
+        [ ! -e "$_refresh_path" ] || [ -f "$_refresh_path" ] || return 1
+    done
+    mkdir -p "${MODDIR}/.state" || return 1
+    mkdir "$_refresh_work" || return 1
+    trap 'rm -rf "$_refresh_work"' 0
+    (set -C; : >"$_refresh_candidate") || return 1
+    trap 'rm -rf "$_refresh_work"; rm -f "$_refresh_candidate"' 0
+    trap 'exit 1' 1 2 3 15
+
+    # Never use the installed config as the template, including in-place flashes.
+    unzip -p "$ZIPFILE" '.config/sing-box/config.json' >"$_refresh_candidate" || return 1
+    [ -s "$_refresh_candidate" ] || return 1
+    _refresh_cached="${MODDIR}/.state/sing-box/subscription-work/outbounds.json"
+    _refresh_restored=0
+    if [ -s "$_refresh_cached" ] || [ -s "$_refresh_previous" ]; then
+        . "${MODDIR}/lib/magicnet_singbox_subscribe.sh" || return 1
+        for _refresh_source in "$_refresh_cached" "$_refresh_previous"; do
+            [ -f "$_refresh_source" ] && [ ! -L "$_refresh_source" ] || continue
+            # Accept array/object caches and the legacy '"outbounds": [...],'
+            # fragment. Never import DNS, routes, inbounds or old selectors.
+            jq -R -s -e '
+                (. as $raw | try fromjson catch ($raw | sub(",[[:space:]]*$"; "") | ("{" + . + "}") | fromjson))
+                | if type == "array" then . else .outbounds end
+                | select(type == "array")
+                | map(select(type == "object" and (.server | type) == "string"))
+                | select(length > 0)
+            ' "$_refresh_source" >"$_refresh_work/nodes.json" 2>/dev/null || continue
+            : >"$_refresh_work/tags.txt" || return 1
+            magicnet_singbox_build_outbounds_file_with_jq \
+                "$_refresh_work/nodes.json" "$_refresh_work/tags.txt" \
+                "$_refresh_work/outbounds.json" || return 1
+            jq -e 'any(.[]; (.server | type) == "string")' \
+                "$_refresh_work/outbounds.json" >/dev/null || continue
+            MAGICNET_SUB_CONFIG_FILE="$_refresh_candidate"
+            export MAGICNET_SUB_CONFIG_FILE
+            if ! magicnet_singbox_update_config_with_nodes "$_refresh_work/outbounds.json" >/dev/null 2>&1; then
+                error "The regenerated sing-box config failed validation; the previous config was not replaced."
+                return 1
+            fi
+            _refresh_restored=1
+            break
+        done
+    fi
+    if [ "$_refresh_restored" = 0 ] && [ -f "${MODDIR}/.config/sing-box/standalone-config" ]; then
+        error "Cannot migrate standalone nodes to the new template; the previous config was not replaced."
+        return 1
+    fi
+
+    # Keep one private, recoverable copy, not an ever-growing credential history.
+    if [ -f "$_refresh_previous" ]; then
+        cp "$_refresh_previous" "$_refresh_work/previous.json" &&
+            chmod 600 "$_refresh_work/previous.json" &&
+            mv -f "$_refresh_work/previous.json" "$_refresh_backup" || return 1
+    fi
+    chmod 600 "$_refresh_candidate" &&
+        mv -f "$_refresh_candidate" "$_refresh_config" || return 1
+    # The full file now belongs to the new managed template, not a stale import.
+    rm -f "${MODDIR}/.config/sing-box/standalone-config" || return 1
+    if [ "$_refresh_restored" = 1 ]; then
+        info "Rebuilt the complete sing-box config from the new template with saved subscription nodes."
+    else
+        info "Installed the new sing-box template; saved subscriptions will be prepared at startup."
+    fi
+)


### PR DESCRIPTION
## 目标
每次刷入新版时自动保留订阅，用本次 ZIP 的模板重建整个 sing-box `config.json`，不再要求手动确认，也不把旧完整配置覆盖回来。

## 变更
- 升级前额外快照旧 `config.json`，仅用于节点恢复与私有备份，不加入整文件恢复清单。
- 优先从订阅缓存提取节点，缓存不可用时从旧配置恢复；调用新版生成器重建出站分组，保留新版模板的 DNS、路由与入站配置。
- 刷入过程不拉取远程订阅；无可复用节点时保留订阅来源，启动阶段使用现有初始化流程。
- 在配置目录下生成临时文件，沿用现有节点更新函数的校验、代理链物化及原子替换机制。
- 旧配置保留为一份 `config.json.pre-upgrade`，权限为 0600；拒绝不安全目标路径；无法恢复节点的独立配置中止升级，而不是静默丢失。
- 新增迁移契约测试，并接入 `scripts/test-host.sh`。

## 验证
已完成以下本地检查：
- `bash scripts/test-install-config-refresh.sh`
- `TEST_SHELL=bash bash scripts/test-install-config-refresh.sh`
- `bash -n scripts/test-host.sh scripts/test-install-config-refresh.sh`
- `sh -n src/MagicNet/customize.sh src/MagicNet/lib/magicnet/install_config.sh`

覆盖：新版模板替换、订阅来源原样保留、缓存/旧配置节点恢复、旧格式缓存、校验失败不替换、备份权限、临时文件清理、缺失 ZIP、符号链接拒绝和独立配置失败保护。

验证范围：迁移测试使用受控的生成器与 sing-box 校验夹具，测试了真实 ZIP/JSON/文件操作及 shell 控制流；未完成 Android 真机刷入、生产内核集成验证或本地完整 host suite。GitHub CI 状态需单独确认。

## 行为说明
直接编辑旧 `config.json` 的 DNS/路由/分组等内容不会继续覆盖新版模板；需要查阅旧内容时可使用 `config.json.pre-upgrade`。单独保存的订阅来源、过滤设置和模块偏好仍沿用现有迁移清单。

## Sourcery 总结

自动将 sing-box 安装迁移到新的配置模板，同时保留可复用的订阅数据，并安全防止升级失败。

新功能：
- 根据新安装的软件包模板自动重新构建 sing-box 配置，同时保留订阅节点和订阅源。

错误修复：
- 防止过时的完整配置覆盖升级后的模板；当节点无法迁移或验证失败时安全中止。
- 保护升级备份并拒绝不安全的路径，同时确保迁移失败时活动配置保持不变。

增强功能：
- 支持从当前订阅缓存、先前的配置和旧版缓存格式中恢复节点，但不会导入旧的 DNS、路由、入站或策略设置。
- 保留私有的升级前配置备份，并在迁移成功后移除独立配置标记。

CI：
- 为主机测试套件添加安装配置迁移契约测试。

测试：
- 覆盖模板替换、节点恢复、订阅保留、验证失败、备份权限、临时文件清理、软件包缺失、符号链接拒绝以及独立配置保护措施。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

自动将 sing-box 安装迁移到新的配置模板，同时安全地保留可复用的订阅数据。

新功能：
- 根据新的安装模板重新构建完整的 sing-box 配置，同时保留可复用的订阅节点和订阅源。

错误修复：
- 防止过时的完整配置覆盖升级后的模板，并在迁移或验证失败时保留当前正在使用的配置。
- 拒绝不安全的备份路径，并保留受保护的升级前配置备份。

改进：
- 从当前订阅缓存、之前的配置或旧版缓存格式中恢复节点，同时不导入已过时的策略、DNS、路由或入站设置。

CI：
- 将安装配置迁移契约测试添加到主机测试套件中。

测试：
- 覆盖模板替换、订阅和节点恢复、验证失败、备份权限、临时文件清理、缺少软件包、拒绝符号链接，以及独立配置保护。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automatically migrate sing-box installations to the new configuration template while safely preserving reusable subscription data.

New Features:
- Rebuild the complete sing-box configuration from the new installation template while preserving reusable subscription nodes and subscription sources.

Bug Fixes:
- Prevent stale full configurations from overwriting upgraded templates and preserve the active configuration when migration or validation fails.
- Reject unsafe backup paths and retain a protected pre-upgrade configuration backup.

Enhancements:
- Restore nodes from current subscription caches, previous configurations, or legacy cache formats without importing obsolete policy, DNS, routing, or inbound settings.

CI:
- Add installation configuration migration contract tests to the host test suite.

Tests:
- Cover template replacement, subscription and node recovery, validation failures, backup permissions, temporary-file cleanup, missing packages, symlink rejection, and standalone-configuration protection.

</details>

</details>