### PR TITLE
perf(network): 降低多连接场景的 DNS 捕获规则开销

### DIFF
--- a/scripts/test-dns-capture-fast-path.py
+++ b/scripts/test-dns-capture-fast-path.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Exercise the production DNS installer without touching the host firewall."""
+import itertools
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parent.parent
+SHELLS = [["sh"], ["bash"]]
+if shutil.which("busybox"):
+    SHELLS.append(["busybox", "ash"])
+FIXTURE = r'''
+set -eu
+. "$NETWORK_SOURCE"
+magicnet_cmd_exists() { return 0; }
+magicnet_transparent_mode() { printf '%s\n' "${MODE:-tun}"; }
+magicnet_ipv6_mode() { printf '%s\n' "${IPV6_MODE:-prefer_ipv4}"; }
+magicnet_dns_profile() { printf '%s\n' "${PROFILE:-default}"; }
+magicnet_dns_capture_singbox_mark() { printf '128\n'; }
+magicnet_dns_capture_singbox_udp_marked() { [ "${MARKED:-1}" = 1 ]; }
+magicnet_warn() { printf '%s\n' "$*" >&2; }
+magicnet_log() { :; }
+mock_xtables() (
+    family=$1; shift
+    printf '%s\n' "$family $*" >> "$CALLS"
+    case " $* " in
+    *' -C '* | *' -D '*) return 1 ;;
+    *' -N '*) [ "${EXISTING:-0}" = 0 ] || return 1 ;;
+    *' -L '*) case " $* " in *' -n '*) ;; *) return 3 ;; esac ;;
+    esac
+    [ "${FAIL:-}" != "$family $*" ]
+)
+magicnet_iptables_cmd() { mock_xtables iptables "$@"; }
+magicnet_ip6tables_cmd() { mock_xtables ip6tables "$@"; }
+magicnet_enable_dns_capture
+'''
+
+
+def evaluate(rules, proto, port, uid, mark):
+    """Small model of only the match/RETURN/REDIRECT subset emitted here."""
+    owners = 0
+    for visited, rule in enumerate(rules, 1):
+        if "-p" in rule and rule[rule.index("-p") + 1] != proto:
+            continue
+        if "--dport" in rule:
+            at = rule.index("--dport")
+            matches = port == int(rule[at + 1])
+            if rule[at - 1] == "!":
+                matches = not matches
+            if not matches:
+                continue
+        if "--mark" in rule:
+            value, mask = map(int, rule[rule.index("--mark") + 1].split("/"))
+            if mark & mask != value:
+                continue
+        if "--uid-owner" in rule:
+            owners += 1
+            if uid != int(rule[rule.index("--uid-owner") + 1]):
+                continue
+        target = rule[rule.index("-j") + 1]
+        if target == "REDIRECT":
+            target += ":" + rule[rule.index("--to-ports") + 1]
+        return target, visited, owners
+    return "RETURN", len(rules), owners
+
+
+class DNSCaptureFastPath(unittest.TestCase):
+    def run_installer(self, shell, count=32, **overrides):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            policy = directory / ".state/app-policy"
+            policy.mkdir(parents=True)
+            (policy / "exclude-uids.list").write_text(
+                "0\n" + "".join(f"{10001 + i}\n" for i in range(count)))
+            calls = directory / "calls"
+            calls.touch()
+            env = dict(os.environ, MODDIR=tmp, CALLS=str(calls),
+                       NETWORK_SOURCE=str(ROOT / "src/MagicNet/lib/magicnet/network.sh"),
+                       MAGIC_DNS_CAPTURE="1", MAGIC_DNS_CAPTURE_PORT="1053")
+            env.update(overrides)
+            result = subprocess.run(shell + ["-c", FIXTURE], env=env,
+                                    capture_output=True, text=True, timeout=30)
+            return result, [shlex.split(line) for line in calls.read_text().splitlines()]
+
+    def test_rules_preserve_dns_and_bound_non_dns_work(self):
+        for shell, count, marked in itertools.product(SHELLS, (0, 32, 256), ("0", "1")):
+            with self.subTest(shell=shell, uids=count, marked=marked):
+                result, calls = self.run_installer(shell, count, MARKED=marked)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                for family in ("iptables", "ip6tables"):
+                    rules = [c[5:] for c in calls if c[:5] ==
+                             [family, "-t", "nat", "-A", "magicnet-dns-output"]]
+                    expected = [["-p", p, "!", "--dport", "53", "-j", "RETURN"]
+                                for p in ("tcp", "udp")]
+                    self.assertEqual(rules[:2], expected)
+                    for proto, port, uid, mark in itertools.product(
+                            ("tcp", "udp", "icmp"), (53, 80, 443, 853),
+                            (0, 10001, 10032, 65534), (0, 128, 129)):
+                        verdict, visited, owners = evaluate(rules, proto, port, uid, mark)
+                        self.assertEqual(verdict, evaluate(rules[2:], proto, port, uid, mark)[0])
+                        if proto in ("tcp", "udp") and port != 53:
+                            self.assertLessEqual(visited, 2)
+                            self.assertEqual(owners, 0)
+                        if proto in ("tcp", "udp") and port == 53 and uid == 0 and mark == 0:
+                            self.assertEqual(verdict, "REDIRECT:1053")
+
+    def test_install_failure_attempts_cleanup_for_both_families(self):
+        for shell, family, proto in itertools.product(SHELLS, ("iptables", "ip6tables"), ("tcp", "udp")):
+            with self.subTest(shell=shell, family=family, proto=proto):
+                failed = f"{family} -t nat -A magicnet-dns-output -p {proto} ! --dport 53 -j RETURN"
+                result, calls = self.run_installer(shell, FAIL=failed)
+                self.assertNotEqual(result.returncode, 0)
+                for cleanup_family in ("iptables", "ip6tables"):
+                    self.assertIn([cleanup_family, "-t", "nat", "-X", "magicnet-dns-output"], calls)
+
+    def test_ebpf_disabled_and_udp_profile_do_not_install_capture(self):
+        for shell, options in itertools.product(SHELLS, (
+                {"MODE": "ebpf"}, {"MAGIC_DNS_CAPTURE": "0"}, {"PROFILE": "cloudflare-udp"})):
+            result, calls = self.run_installer(shell, **options)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(any("-A" in call or "-I" in call for call in calls))
+
+    def test_ipv4_only_does_not_install_ipv6_capture(self):
+        for shell in SHELLS:
+            result, calls = self.run_installer(shell, IPV6_MODE="ipv4_only")
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(any(call[0] == "ip6tables" for call in calls))
+
+    def test_existing_chains_are_inspected_numerically(self):
+        for shell in SHELLS:
+            result, calls = self.run_installer(shell, EXISTING="1")
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(any("-L" in call and "magicnet-dns-output" in call for call in calls))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-host.sh
+++ b/scripts/test-host.sh
@@ -83,6 +83,7 @@ if [ "$with_routing_assets" -eq 1 ]; then
     bash scripts/test-dns-profile-safety.sh
 fi
 bash scripts/test-dns-leak-guard-timeout.sh
+python3 scripts/test-dns-capture-fast-path.py
 sh scripts/test-startup-network-safety.sh
 bash scripts/test-submodule-updates.sh
 bash scripts/test-subscription-activation-order.sh

--- a/src/MagicNet/lib/magicnet/network.sh
+++ b/src/MagicNet/lib/magicnet/network.sh
@@ -91,8 +91,8 @@ magicnet_xtables_available() {
         return 0
     fi
     case "$_xtables_family" in
-    iptables) magicnet_iptables_cmd -L >/dev/null 2>&1 ;;
-    ip6tables) magicnet_ip6tables_cmd -L >/dev/null 2>&1 ;;
+    iptables) magicnet_iptables_cmd -L -n >/dev/null 2>&1 ;;
+    ip6tables) magicnet_ip6tables_cmd -L -n >/dev/null 2>&1 ;;
     esac
     _xtables_rc=$?
     unset _xtables_family
@@ -226,6 +226,14 @@ magicnet_dns_capture_singbox_udp_marked() {
     return "$_dns_marked_rc"
 }
 
+# Only new connections traverse nat. Keep ordinary TCP/UDP connections from
+# scanning every app-bypass UID; RETURN resumes the caller's remaining rules,
+# not ACCEPT. DNS still reaches the existing mark/owner checks and redirect.
+magicnet_dns_capture_fast_path() {
+    magicnet_xtables_ensure_rule "$1" -A nat magicnet-dns-output -p tcp ! --dport 53 -j RETURN &&
+        magicnet_xtables_ensure_rule "$1" -A nat magicnet-dns-output -p udp ! --dport 53 -j RETURN
+}
+
 magicnet_enable_dns_capture() {
     _dns_capture_mode="$(magicnet_transparent_mode)" || {
         magicnet_warn "transparent mode configuration is invalid; DNS capture rejected"
@@ -278,9 +286,10 @@ magicnet_enable_dns_capture() {
     _dns_capture_rc=0
     _dns_capture_ipv6_unavailable=0
     if ! magicnet_iptables_cmd -t nat -N magicnet-dns-output >/dev/null 2>&1; then
-        magicnet_xtables_require magicnet_iptables_cmd -t nat -L magicnet-dns-output || _dns_capture_rc=1
+        magicnet_xtables_require magicnet_iptables_cmd -t nat -L magicnet-dns-output -n || _dns_capture_rc=1
     fi
     magicnet_xtables_require magicnet_iptables_cmd -t nat -F magicnet-dns-output || _dns_capture_rc=1
+    magicnet_dns_capture_fast_path magicnet_iptables_cmd || _dns_capture_rc=1
     magicnet_xtables_ensure_rule magicnet_iptables_cmd -I nat OUTPUT -j magicnet-dns-output || _dns_capture_rc=1
     # Direct UDP DNS servers are marked in the sing-box config. Keep those
     # resolver packets out of this chain without exempting all UID-0 traffic.
@@ -310,9 +319,10 @@ magicnet_enable_dns_capture() {
             fi
         else
             if ! magicnet_ip6tables_cmd -t nat -N magicnet-dns-output >/dev/null 2>&1; then
-                magicnet_xtables_require magicnet_ip6tables_cmd -t nat -L magicnet-dns-output || _dns_capture_rc=1
+                magicnet_xtables_require magicnet_ip6tables_cmd -t nat -L magicnet-dns-output -n || _dns_capture_rc=1
             fi
             magicnet_xtables_require magicnet_ip6tables_cmd -t nat -F magicnet-dns-output || _dns_capture_rc=1
+            magicnet_dns_capture_fast_path magicnet_ip6tables_cmd || _dns_capture_rc=1
             magicnet_xtables_ensure_rule magicnet_ip6tables_cmd -I nat OUTPUT -j magicnet-dns-output || _dns_capture_rc=1
             if [ "$_dns_capture_singbox_marked" -eq 1 ]; then
                 magicnet_ip6tables_nat_ensure magicnet-dns-output -m mark --mark "$_dns_capture_singbox_mark/$_dns_capture_singbox_mark" -j RETURN || _dns_capture_rc=1
@@ -404,7 +414,7 @@ magicnet_disable_dns_capture() (
         esac
         _dns_capture_cmd="magicnet_${_dns_capture_family}_cmd"
         _dns_capture_chain_rc=0
-        "$_dns_capture_cmd" -t nat -L magicnet-dns-output >/dev/null 2>&1 || _dns_capture_chain_rc=$?
+        "$_dns_capture_cmd" -t nat -L magicnet-dns-output -n >/dev/null 2>&1 || _dns_capture_chain_rc=$?
         case "$_dns_capture_chain_rc" in
         0)
             # Remove every duplicate jump before flushing/deleting our chain.
@@ -536,7 +546,7 @@ magicnet_enable_dns_leak_guard() {
         # devices commonly expose filter support while omitting an IPv6 nat
         # table; probing nat here would silently disable IPv6 leak protection
         # on exactly those devices.
-        if magicnet_cmd_exists ip6tables && magicnet_ip6tables_cmd -L >/dev/null 2>&1; then
+        if magicnet_cmd_exists ip6tables && magicnet_ip6tables_cmd -L -n >/dev/null 2>&1; then
             _dns_guard_ipv6_available=1
         elif [ "$_dns_guard_ipv6_mode" = prefer_ipv6 ]; then
             _dns_guard_rc=1
@@ -564,7 +574,7 @@ magicnet_enable_dns_leak_guard() {
 
     # Keep the interface set that actually received rules.  Android can
     # switch from Wi-Fi to cellular between enable and cleanup; discovering
-    # only the current interface would otherwise leave the old REJECT rules
+    # only the current interface would otherwise leave the REJECT rules
     # behind and make later DNS behavior depend on the previous network.
     _dns_guard_state_file="$(magicnet_dns_leak_guard_state_file)"
     _dns_guard_state_tmp="${_dns_guard_state_file}.new.$$"


### PR DESCRIPTION
## 问题与改动

TUN 的 NAT OUTPUT 无条件跳转到 `magicnet-dns-output`。原链先检查 sing-box mark 和每一个 app-bypass UID，再匹配 TCP/UDP 53，因此普通 HTTPS/QUIC 新连接也会线性扫描绕过名单。

- 在 IPv4/IPv6 DNS 捕获链最前面添加 TCP/UDP 非 53 端口的 `RETURN`，跳过不相关的 owner 匹配。
- 保留原有 mark 豁免、非 root app-bypass UID、netd/UID-0 DNS 捕获和 REDIRECT。
- `RETURN` 仅返回上层链，不是 `ACCEPT`，不会跳过上层后续防火墙规则。
- 探测/清理中的 `iptables -L` 和 `ip6tables -L` 使用 `-n`，避免控制流程执行地址/服务名解析。
- 新增 `scripts/test-dns-capture-fast-path.py`，接入 `scripts/test-host.sh`。

## 验证

本地从 GitHub 读取生产文件并核对 Git blob SHA 后执行：

- `python3 scripts/test-dns-capture-fast-path.py -v`：5 组测试通过，45 次实际 Shell 安装流程调用；Shell 为 sh/dash、Bash、BusyBox ash。防火墙命令被 mock，不修改宿主防火墙。
- 覆盖 IPv4/IPv6、0/32/256 个绕过 UID、mark 开关、DNS/非 DNS、root DNS、快速返回规则安装失败后的错误传播和清理调用、eBPF/关闭捕获/cloudflare-udp、IPv4-only，以及既有链的 numeric listing。
- 由实际生成规则建立的有限匹配模型完成 5,184 组前后判定比较；DNS 和非 DNS 处理结果一致。
- `bash scripts/test-dns-leak-guard-timeout.sh`：通过。
- `bash -n src/MagicNet/lib/magicnet/network.sh scripts/test-host.sh`：通过。
- `dash -n src/MagicNet/lib/magicnet/network.sh`：通过。
- `busybox ash -n src/MagicNet/lib/magicnet/network.sh`：通过。
- `python3 -m py_compile scripts/test-dns-capture-fast-path.py`、`git diff --check`：通过。

## 性能边界与取舍

规则模型中，32 个绕过 UID、启用 mark 规则、未命中豁免的普通 TCP/UDP 443 新连接，DNS 子链内访问规则数由 35 分别降到 1/2，owner 检查由 32 降到 0。这是生成规则的遍历计数，不是内核耗时或带宽基准，也不是整个防火墙的规则总数。

NAT 主要处理连接首包；本改动针对频繁新建连接，不宣称提高单条长连接下载带宽。DNS 本身会多经过两条简单条件规则。原本立即命中 mark/早期 UID 的部分非 DNS 流量不保证更少的规则访问。

未运行 Android 真机测速、实际内核 netfilter 验证、完整 host/fake-Magisk/pre-commit 套件。当前本地环境只有按需读取的源码和相关测试，没有完整子模块/构建产物；完整集成状态以本 PR 的 CI 结果为准。

未改 sing-box 配置/MTU/嗅探/TCP 拥塞控制/默认 tun|ebpf 选择，未合并或发布。

## Sourcery 摘要

降低非 DNS 连接的 DNS 捕获规则遍历开销，同时保留 DNS 拦截、豁免、清理和错误处理功能。

增强功能：
- 在 IPv4/IPv6 DNS 捕获链中添加 TCP/UDP 非 DNS 连接的提前返回，避免为普通连接扫描标记和应用绕过 UID 规则。
- 在 DNS 捕获以及泄漏防护探测和清理过程中使用防火墙规则的数字列表，避免名称/服务解析开销。

CI：
- 在主机测试套件中添加跨 Shell 的 DNS 捕获快速路径测试。

测试：
- 为 DNS 捕获添加模拟安装器、规则行为、失败清理、配置模式、仅 IPv4 和数字列表覆盖测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reduce DNS capture rule traversal overhead for non-DNS connections while preserving DNS interception, exemptions, cleanup, and error handling.

Enhancements:
- Add early TCP/UDP non-DNS returns to IPv4/IPv6 DNS capture chains to avoid scanning mark and app-bypass UID rules for ordinary connections.
- Use numeric firewall rule listings during DNS capture and leak-guard probing and cleanup to avoid name/service resolution overhead.

CI:
- Add cross-shell DNS capture fast-path tests to the host test suite.

Tests:
- Add mocked installer, rule-behavior, failure-cleanup, configuration-mode, IPv4-only, and numeric-listing coverage for DNS capture.

</details>