### PR TITLE
style(webui): 打磨纸感界面与稳定的加载反馈

### DIFF
--- a/webui/e2e/interaction-finish.spec.mjs
+++ b/webui/e2e/interaction-finish.spec.mjs
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem("magicnet.webui.onboarding.v1", "dismissed");
+    localStorage.setItem("magicnet.webui.theme", "light");
+  });
+  await page.goto("/", { waitUntil: "networkidle" });
+  await expect(page.locator(".mn-control")).toBeVisible();
+});
+
+async function setTask(page, task) {
+  // Display-only fixture: never install a bridge or execute root commands.
+  await page.evaluate(async (task) => {
+    const { useMagicNet } = await import("/src/composables/useMagicNet.ts");
+    useMagicNet().state.task = task;
+  }, task);
+}
+
+test("busy buttons keep their geometry, labels and disabled state", async ({ page }) => {
+  const buttons = [
+    ["刷新面板", "刷新面板", true],
+    ["创建 GitHub Issue", "创建 GitHub issue", false],
+  ];
+  for (const [label, task, iconOnly] of buttons) {
+    const button = page.getByRole("button", { name: label, exact: true });
+    if (!(await button.isVisible())) continue; // Feedback lives in the desktop toolbar.
+    const before = await button.boundingBox();
+    const text = await button.innerText();
+    await setTask(page, task);
+    await expect(button).toHaveAttribute("aria-busy", "true");
+    await expect(button).toBeDisabled();
+    const during = await button.boundingBox();
+    for (const key of ["x", "y", "width", "height"])
+      expect(Math.abs(during[key] - before[key])).toBeLessThan(1);
+    expect(await button.innerText()).toBe(text);
+    await expect(button.locator(".mn-button__content")).toHaveCSS("opacity", iconOnly ? "0" : "1");
+    if (!iconOnly) {
+      expect(await button.evaluate((el) => getComputedStyle(el, "::after").animationName)).toBe("none");
+    }
+    await setTask(page, "");
+    await expect(button).toBeEnabled();
+    await expect(button.locator(".mn-button__content")).toHaveCSS("opacity", "1");
+  }
+});
+
+test("navigation and disclosure focus remain distinct in both themes", async ({ page }, testInfo) => {
+  for (const theme of ["light", "dark"]) {
+    if (theme === "dark") await page.getByRole("button", { name: /外观主题/ }).click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", theme);
+    const mobile = await page.locator(".mobile-nav").isVisible();
+    const active = page.locator(mobile ? ".mobile-nav .mn-nav-active" : ".desktop-rail .mn-nav-active");
+    await expect(active).toHaveCount(1);
+    const colors = await active.evaluate((el) => [getComputedStyle(el).backgroundColor, getComputedStyle(document.body).backgroundColor]);
+    expect(colors[0]).not.toBe(colors[1]);
+    const summary = page.locator(".mn-disclosure > summary").first();
+    await page.keyboard.press("Tab");
+    await summary.focus();
+    await expect(summary).toBeFocused();
+    await expect(summary).toHaveCSS("outline-style", "solid");
+    await expect(summary).toHaveCSS("outline-width", "2px");
+    await page.screenshot({ path: testInfo.outputPath(`paper-${theme}.png`), fullPage: false });
+  }
+});

--- a/webui/src/components/ui/Button.vue
+++ b/webui/src/components/ui/Button.vue
@@ -95,9 +95,9 @@ const classes = computed(() =>
   to { opacity: 1; }
 }
 @media (prefers-reduced-motion: reduce) {
-  .mn-button[aria-busy="true"]::after { animation: none; }
+  .mn-button[aria-busy="true"]:not([data-size="icon"])::after { animation: none; }
 }
 @media (forced-colors: active) {
-  .mn-button[aria-busy="true"]::after { background: ButtonText; }
+  .mn-button[aria-busy="true"]:not([data-size="icon"])::after { background: ButtonText; }
 }
 </style>

--- a/webui/src/components/ui/Button.vue
+++ b/webui/src/components/ui/Button.vue
@@ -63,12 +63,41 @@ const classes = computed(() =>
     v-bind="$attrs"
     :type="type"
     :class="classes"
+    :data-size="size"
     :disabled="loading || disabled"
     :aria-busy="loading ? 'true' : undefined"
   >
-    <span class="inline-flex min-w-0 items-center justify-center gap-2">
-      <Loader2 v-if="loading" class="shrink-0 motion-safe:animate-spin" :size="size === 'sm' ? 14 : 16" aria-hidden="true" />
+    <Loader2 v-if="loading" v-show="size === 'icon'" class="mn-button__spinner motion-safe:animate-spin" :size="18" aria-hidden="true" />
+    <span class="mn-button__content inline-flex min-w-0 items-center justify-center gap-2">
       <slot />
     </span>
   </button>
 </template>
+
+<style scoped>
+/* Loading never adds intrinsic width or replaces a text button's label. */
+.mn-button[aria-busy="true"] { opacity: 1; }
+.mn-button__spinner { position: absolute; inset: 0; margin: auto; }
+.mn-button[aria-busy="true"][data-size="icon"] .mn-button__content { opacity: 0; }
+.mn-button[aria-busy="true"]:not([data-size="icon"])::after {
+  content: "";
+  position: absolute;
+  inset-inline: calc(50% - 12px);
+  bottom: 5px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+  pointer-events: none;
+  animation: mn-button-working 900ms ease-in-out infinite alternate;
+}
+@keyframes mn-button-working {
+  from { opacity: 0.35; }
+  to { opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .mn-button[aria-busy="true"]::after { animation: none; }
+}
+@media (forced-colors: active) {
+  .mn-button[aria-busy="true"]::after { background: ButtonText; }
+}
+</style>

--- a/webui/src/interaction.css
+++ b/webui/src/interaction.css
@@ -1,0 +1,65 @@
+/* Shared interaction details; keep the Paper palette and open page sections. */
+.mn-section-tabs button,
+.mobile-nav button,
+.desktop-rail nav button {
+  transition: color 160ms ease-out, background-color 160ms ease-out,
+    border-color 160ms ease-out, transform var(--mn-motion-press) ease-out;
+}
+
+.mn-page-title {
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  text-wrap: balance;
+}
+
+/* Keep the focus ring inside the horizontally clipped tab strip. */
+.mn-section-tabs button:focus-visible {
+  outline-offset: -4px;
+  border-radius: var(--mn-radius-sm);
+}
+
+.mobile-nav button.mn-nav-active {
+  border-color: var(--mn-border);
+  background: var(--mn-surface-raised);
+}
+.mobile-nav button.mn-nav-active svg { stroke-width: 2; }
+.desktop-rail nav button.mn-nav-active {
+  background: var(--mn-surface-sunken);
+  color: var(--mn-primary-strong);
+}
+
+.mn-field {
+  transition: border-color 160ms ease-out, box-shadow 160ms ease-out;
+}
+.mn-field[aria-invalid="true"] { border-color: var(--mn-danger); }
+.mn-field[aria-invalid="true"]:focus {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--mn-danger) 16%, transparent);
+}
+
+.mn-disclosure > summary { border-radius: var(--mn-radius-sm); }
+.mn-disclosure > summary:focus-visible,
+.config-action-menu > summary:focus-visible {
+  outline: 2px solid var(--mn-focus);
+  outline-offset: 4px;
+}
+.mn-disclosure > summary::after,
+.mn-disclosure[open] > summary::after {
+  margin: 0 4px 0 auto;
+  transition: transform 160ms var(--mn-motion-spring);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .mn-disclosure > summary:hover { color: var(--mn-primary-strong); }
+  .mn-brand-mark:hover { background: var(--mn-surface-sunken); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mn-disclosure > summary::after { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .mobile-nav button.mn-nav-active { border-color: Highlight; }
+  .mn-field[aria-invalid="true"] { border-style: dashed; }
+  .mn-disclosure > summary:focus-visible,
+  .config-action-menu > summary:focus-visible { outline-color: Highlight; }
+}

--- a/webui/src/main.ts
+++ b/webui/src/main.ts
@@ -4,6 +4,7 @@ import { installMagicNetFavicon } from "@/branding";
 import { bootstrapTheme } from "@/composables/useTheme";
 import { bootstrapLocale } from "@/i18n";
 import "./styles.css";
+import "./interaction.css";
 
 installMagicNetFavicon();
 bootstrapTheme();


### PR DESCRIPTION
## 改动
- 沿用 Paper 配色与开放式分区，优化标题字重、字距及手机/桌面导航选中状态。
- 输入框增加平滑焦点和错误反馈；展开项补齐键盘焦点，箭头开合不再改变边距。
- 文字按钮加载时保留图标、文字和尺寸，以底部细线提示；图标按钮在原位显示加载图标，保留 disabled 与 aria-busy。
- 补齐减少动效、强制颜色适配，不增加外部字体或依赖。

## 最后失败项修复
提交 a7e6449 修正 Button.vue 两处媒体查询的选择器优先级，使其与原始加载指示器规则一致。没有删除或放宽浏览器测试断言。

## 已验证（提交 a7e6449）
- WebUI：通过（run 34632686147），包括单元测试、Vue 类型检查和生产构建。
- Code Quality：通过（run 34632686202），包括 Shell、Rust 和完整浏览器回归；此前失败的减少动效用例已通过。
- Validate Kam Module：通过（run 34632686061）。
- 已下载同一提交的 WebUI 生产产物并核对编译后的 CSS，两处修正均已包含。
- 本地额外生产页面浏览器检查被运行环境策略拦截，未完成；交互验证依据以上 GitHub CI，不宣称真机网络验证。

完整安装包构建（run 34632686064）在执行合并时仍在运行，未将其记为通过，也未确认新版本发布。

## 合并
已按用户要求 squash 合并到 main，提交 232e06fd4fc2f81d827d047ef9695e11507969f6。

仅涉及前端样式、基础按钮和测试；不修改订阅保存、代理模式或 sing-box 运行逻辑。