### PR TITLE
feat(install): 使用 kamfw 自动打开首次订阅配置页

### DIFF
--- a/.github/workflows/install-onboarding.yml
+++ b/.github/workflows/install-onboarding.yml
@@ -1,0 +1,48 @@
+name: Install Onboarding
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'src/MagicNet/customize.sh'
+      - 'src/MagicNet/lib/magicnet/install_onboarding.sh'
+      - 'src/MagicNet/lib/magicnet/onboarding/**'
+      - 'src/MagicNet/lib/kamfw'
+      - 'scripts/install-onboarding-test.py'
+      - '.github/workflows/install-onboarding.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'src/MagicNet/customize.sh'
+      - 'src/MagicNet/lib/magicnet/install_onboarding.sh'
+      - 'src/MagicNet/lib/magicnet/onboarding/**'
+      - 'src/MagicNet/lib/kamfw'
+      - 'scripts/install-onboarding-test.py'
+      - '.github/workflows/install-onboarding.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: install-onboarding-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - name: Initialize pinned kamfw only
+        run: git submodule update --init --depth 1 src/MagicNet/lib/kamfw
+      - name: Install host dependencies
+        run: sudo apt-get update && sudo apt-get install -y busybox-static shellcheck
+      - name: Lint install-only shell
+        run: >-
+          shellcheck -s sh -e SC1090,SC1091,SC2015,SC2016,SC2034,SC2059,SC2218,SC2329
+          src/MagicNet/lib/magicnet/install_onboarding.sh
+          src/MagicNet/lib/magicnet/onboarding/*.sh
+      - name: Test real BusyBox HTTP, CGI and kamfw launcher contracts
+        timeout-minutes: 3
+        run: python3 scripts/install-onboarding-test.py

--- a/docs/install-onboarding.md
+++ b/docs/install-onboarding.md
@@ -1,0 +1,72 @@
+# Install-time subscription setup
+
+The installer sources `lib/magicnet/install_onboarding.sh` **after** restoring
+old configuration, installing the new template and applying permissions. It no
+longer opens the README on every install.
+
+On a booted Android device without a saved subscription, a temporary loopback
+page opens through kamfw's `import launcher` / `launch url` dispatcher. The
+Android call uses `ACTION_VIEW`, `CATEGORY_BROWSABLE` and `--user current`, not a
+browser package. Android chooses the configured browser; without a default it
+may show its chooser. A blocked launch leaves the complete local URL in the
+installer output. A clickable notification is best-effort, not required.
+
+The page has Chinese, English, Russian, Japanese and Korean strings, a language
+selector, automatic light/dark themes and reduced-motion support. It uses only
+bundled HTML/CSS/JavaScript. GitHub Star, the guide, Discord and the author's LMM
+API links are optional navigation; no login, tracking or automatic starring.
+
+## Configuration and fallback
+
+- Existing URL, local-subscription or standalone configuration is retained and
+  does not reopen setup. Even malformed non-comment user data is not replaced.
+- Saving stages one HTTPS URL in `.config/sing-box/subscription.url` with mode
+  `0600` and an atomic rename. It does not download a subscription, start a core,
+  modify the generated config, change SELinux or touch firewall rules.
+- The normal startup pipeline validates the destination and loads the saved
+  source. The installer checks URL syntax only, not whether a remote service is
+  reachable or returns a valid subscription.
+- Skipping or waiting 180 seconds continues installation. The module WebUI can
+  configure the source later; the existing no-subscription startup guard stays
+  unchanged.
+- Recovery, an unbooted Android system, disabled sing-box, noninteractive mode,
+  missing BusyBox applets or failed HTTP/CGI self-checks skip this optional step.
+
+`MAGICNET_INSTALL_ONBOARDING=0` disables the prompt.
+`MAGICNET_NONINTERACTIVE=1` also disables it, without relying on a TTY test.
+`MAGICNET_SETUP_TIMEOUT` accepts 5–1800 seconds, default 180.
+`MAGICNET_SETUP_BUSYBOX` optionally selects an existing compatible BusyBox.
+No dependency is downloaded during installation.
+
+## Local interface security
+
+The server binds only to `127.0.0.1` on a randomized port. A 192-bit random
+capability is delivered in the URL fragment and sent in a request header.
+Requests enforce Host, Origin (when present), Fetch Metadata (when present),
+method, content type and an 8192-byte limit. Subscription text stays out of the
+URL and responses. Never share the temporary setup URL or installer screenshots
+containing its fragment.
+
+The CGI and state are outside the static document root. Input is treated as
+literal data, not shell code. Private temporary directories, a submission lock,
+symlink checks and a last-moment existing-data check protect publication.
+Normal completion, timeout and catchable signals close the HTTP process group
+and remove temporary state. A hard server deadline limits exposure after an
+uncatchable kill; like any shell trap, cleanup cannot run after SIGKILL or power
+loss. A stale install lock fails closed rather than deleting unverified data.
+
+## Verification
+
+Initialize the pinned kamfw submodule and install BusyBox with `httpd`, CGI,
+`setsid`, `timeout` and `wget` support (Debian/Ubuntu: `busybox-static`):
+
+```sh
+git submodule update --init --depth 1 src/MagicNet/lib/kamfw
+python3 scripts/install-onboarding-test.py
+```
+
+The dedicated Install Onboarding workflow runs real BusyBox HTTP/CGI tests and
+ShellCheck. Android Binder calls are mocked; host success is **not** Android
+SELinux, notification permission or OEM browser verification. Before release,
+try first install, upgrade with existing data, skip, timeout, disabled automatic
+activity launches, and install cancellation on Magisk, KernelSU and APatch.

--- a/scripts/fake-magisk-smoke.sh
+++ b/scripts/fake-magisk-smoke.sh
@@ -131,7 +131,8 @@ SH
 
     install_customize_fixtures() {
         local tool host_tool
-        for tool in bash chmod cp cut date find grep ln mkdir rm sed sh tr unzip; do
+        # Atomic template publication needs mv even with a module-only PATH.
+        for tool in bash chmod cp cut date find grep ln mkdir mv rm sed sh tr unzip; do
             host_tool="$(command -v "$tool")" || {
                 echo "missing host tool fixture: $tool" >&2
                 exit 127
@@ -156,7 +157,7 @@ SH
     }
 
     remove_customize_fixtures() {
-        rm -f "$MODDIR/bin"/{am,bash,chcon,chmod,chown,cmd,cp,cut,date,find,getevent,grep,ln,mkdir,restorecon,rm,sed,settings,sh,tr,unzip}
+        rm -f "$MODDIR/bin"/{am,bash,chcon,chmod,chown,cmd,cp,cut,date,find,getevent,grep,ln,mkdir,mv,restorecon,rm,sed,settings,sh,tr,unzip}
     }
 
     install_customize_fixtures
@@ -177,6 +178,7 @@ SH
         PATH="$MODDIR/bin:$POISONED_CALLER_PATH" \
         "$MODDIR/bin/sh" "$MODDIR/customize.sh" >"$TMP/customize.log" 2>&1; then
         echo "customize.sh failed during fake Magisk zip smoke" >&2
+        tail -n 120 "$TMP/customize.log" >&2 || true
         exit 1
     fi
     remove_customize_fixtures
@@ -257,7 +259,7 @@ setup_toybox_layer() {
     done
 
     if [[ "$installed" -eq 0 ]]; then
-        echo "toybox layer disabled: no matching applets from $toybox_bin"
+        echo "toybox layer disabled: no matching applets from $toybox_bin" >&2
         return 0
     fi
 

--- a/scripts/install-onboarding-test.py
+++ b/scripts/install-onboarding-test.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Host contracts for install-only onboarding; uses real BusyBox HTTP/CGI.
+
+No device, root privileges, Internet, actual subscription or third-party Python
+packages are needed. Android Binder/UI is mocked, not claimed as device-tested.
+"""
+from __future__ import annotations
+
+import http.client
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import signal
+import socket
+import stat
+import subprocess
+import tempfile
+import time
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE = ROOT / "src/MagicNet"
+HELPER = MODULE / "lib/magicnet/install_onboarding.sh"
+BUSYBOX = shutil.which("busybox")
+KAMFW = Path(os.environ.get("KAMFW_TEST_DIR", str(MODULE / "lib/kamfw")))
+URL = "https://feed.example.test/subscribe?token=a+b%2F%26&x=$(id)&quote='&semi=;&pct=%25"
+
+
+class Session:
+    def __init__(self, timeout: int = 30, am_status: int = 0):
+        self.temp = tempfile.TemporaryDirectory(prefix="magicnet-onboarding-")
+        self.root = Path(self.temp.name)
+        (self.root / "lib/magicnet").mkdir(parents=True)
+        shutil.copytree(MODULE / "lib/magicnet/onboarding", self.root / "lib/magicnet/onboarding")
+        self.log_path = self.root / "installer-output"
+        self.log = self.log_path.open("w")
+        env = dict(os.environ, MODPATH=str(self.root), MAGICNET_SETUP_BUSYBOX=str(BUSYBOX),
+                   MAGICNET_SETUP_TIMEOUT=str(timeout), KAMFW_TEST_DIR=str(KAMFW),
+                   KAM_UI_LANGUAGE="zh", TEST_AM_RC=str(am_status))
+        script = r'''
+. "$1"
+print() { printf '%s\n' "$*"; }
+i18n() { printf '%s' "$1"; }
+import() { . "$KAMFW_TEST_DIR/$1.sh"; }
+magicnet_onboarding_android_am() {
+    printf '%s\n' "$@" >"$MODPATH/am-arguments"
+    return "$TEST_AM_RC"
+}
+magicnet_onboarding_collect
+'''
+        self.proc = subprocess.Popen([str(BUSYBOX), "ash", "-c", script, "test", str(HELPER)],
+                                     env=env, stdout=self.log, stderr=subprocess.STDOUT,
+                                     start_new_session=True)
+        self.port = 0
+        self.token = ""
+        for _ in range(350):
+            text = self.log_path.read_text()
+            match = re.search(r"http://127\.0\.0\.1:(\d+)/\?lang=zh#([a-f0-9]{48})", text)
+            if match:
+                self.port, self.token = int(match[1]), match[2]
+                self.url = match[0]
+                break
+            if self.proc.poll() is not None:
+                self.close()
+                raise RuntimeError("collector failed before readiness: " + text)
+            time.sleep(0.02)
+        if not self.port:
+            self.close()
+            raise RuntimeError("collector did not become ready")
+
+    def request(self, action: str, body: str | bytes | None = None,
+                method: str = "POST", headers: dict | None = None):
+        connection = http.client.HTTPConnection("127.0.0.1", self.port, timeout=12)
+        defaults = {"X-Setup-Token": self.token, "Content-Type": "text/plain;charset=UTF-8"}
+        defaults.update(headers or {})
+        try:
+            connection.request(method, "/cgi-bin/setup/" + action, body=body, headers=defaults)
+            response = connection.getresponse()
+            return response.status, json.loads(response.read()), dict(response.getheaders())
+        finally:
+            connection.close()
+
+    def wait(self, timeout: int = 10):
+        result = self.proc.wait(timeout=timeout)
+        # A signal can reap the outer installer before its isolated collector
+        # finishes EXIT cleanup. Bound that drain instead of racing the trap.
+        for _ in range(100):
+            if not list((self.root / ".state").glob("install-onboarding*")):
+                break
+            time.sleep(0.02)
+        assert not list((self.root / ".state").glob("install-onboarding*")), "temporary files leaked"
+        with socket.socket() as client:
+            client.settimeout(1)
+            assert client.connect_ex(("127.0.0.1", self.port)) != 0, "HTTP port leaked"
+        return result
+
+    def close(self):
+        if self.proc.poll() is None:
+            os.killpg(self.proc.pid, signal.SIGTERM)
+            try:
+                self.proc.wait(timeout=4)
+            except subprocess.TimeoutExpired:
+                os.killpg(self.proc.pid, signal.SIGKILL)
+                self.proc.wait(timeout=2)
+        self.log.close()
+        self.temp.cleanup()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+
+
+@unittest.skipUnless(BUSYBOX, "BusyBox is required")
+class OnboardingTests(unittest.TestCase):
+    def test_pinned_framework_is_available(self):
+        self.assertTrue((KAMFW / "launcher.sh").is_file(), "initialize the kamfw submodule")
+
+    def test_shell_and_javascript_syntax(self):
+        for path in [HELPER, MODULE / "customize.sh", *(MODULE / "lib/magicnet/onboarding").glob("*.sh")]:
+            subprocess.run([BUSYBOX, "ash", "-n", str(path)], check=True)
+        if shutil.which("node"):
+            subprocess.run(["node", "--check", str(MODULE / "lib/magicnet/onboarding/app.js")], check=True)
+
+    def test_save_preserves_literal_bytes_permissions_and_config(self):
+        with Session() as session:
+            config = session.root / ".config/sing-box/config.json"
+            config.write_text('{"sentinel":true}\n')
+            status, payload, headers = session.request("save", URL)
+            self.assertEqual((status, payload), (200, {"code": "saved"}))
+            self.assertEqual(headers["Cache-Control"], "no-store")
+            out = session.root / ".config/sing-box/subscription.url"
+            self.assertEqual(out.read_bytes(), (URL + "\n").encode())
+            self.assertEqual(stat.S_IMODE(out.stat().st_mode), 0o600)
+            self.assertEqual(config.read_text(), '{"sentinel":true}\n')
+            self.assertNotIn(URL, session.log_path.read_text())
+            self.assertEqual(session.wait(), 0)
+
+    def test_skip_does_not_create_subscription(self):
+        with Session() as session:
+            self.assertEqual(session.request("skip", "")[:2], (200, {"code": "skipped"}))
+            self.assertEqual(session.wait(), 2)
+            self.assertFalse((session.root / ".config/sing-box/subscription.url").exists())
+
+    def test_timeout_closes_server_and_cleans_private_state(self):
+        with Session(timeout=5) as session:
+            self.assertEqual(session.wait(), 3)
+            self.assertFalse((session.root / ".config/sing-box/subscription.url").exists())
+
+    def test_signal_closes_server_and_cleans_private_state(self):
+        with Session() as session:
+            os.killpg(session.proc.pid, signal.SIGTERM)
+            self.assertNotEqual(session.wait(), 0)
+
+    def test_browser_failure_keeps_manual_page_usable(self):
+        with Session(am_status=7) as session:
+            time.sleep(0.1)
+            self.assertIn("MN_SETUP_MANUAL", session.log_path.read_text())
+            self.assertEqual(session.request("save", "https://feed.example.test/list")[0], 200)
+            self.assertEqual(session.wait(), 0)
+
+    def test_kamfw_launcher_keeps_default_browser_current_user_and_exit_status(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            recorder = Path(tmp) / "busybox-recorder"
+            recorder.write_text('#!/bin/sh\nprintf "%s\\n" "$@" >"$TEST_ARGS"\nexit 7\n')
+            recorder.chmod(0o700)
+            env = dict(os.environ, KAMFW_TEST_DIR=str(KAMFW), MN_SETUP_BB=str(recorder),
+                       MN_SETUP_RUN=tmp, TEST_ARGS=str(Path(tmp) / "arguments"))
+            script = '. "$1"; import() { . "$KAMFW_TEST_DIR/$1.sh"; }; magicnet_onboarding_open "$2"'
+            result = subprocess.run([BUSYBOX, "ash", "-c", script, "test", str(HELPER), "http://127.0.0.1:33333/#test"], env=env)
+            self.assertEqual(result.returncode, 7)
+            args = (Path(tmp) / "arguments").read_text().splitlines()
+            self.assertEqual(args, ["timeout", "5", "/system/bin/am", "start", "-a", "android.intent.action.VIEW", "-d",
+                                    "http://127.0.0.1:33333/#test", "--user", "current", "-c", "android.intent.category.BROWSABLE"])
+            self.assertNotIn("-n", args)  # No hard-coded browser package/component.
+
+    def test_http_security_boundaries(self):
+        with Session() as session:
+            for headers in [{"X-Setup-Token": ""}, {"X-Setup-Token": "wrong"},
+                            {"Origin": "https://outside.example.test"}, {"Host": "outside.example.test"},
+                            {"Sec-Fetch-Site": "cross-site"}, {"Sec-Fetch-Site": "same-site"}]:
+                with self.subTest(headers=headers):
+                    self.assertEqual(session.request("save", URL, headers=headers)[0], 403)
+            self.assertEqual(session.request("save", None, "GET")[0], 405)
+            self.assertEqual(session.request("anything", "")[0], 404)
+            self.assertEqual(session.request("save", URL, headers={"Content-Type": "application/json"})[0], 415)
+            self.assertEqual(session.request("health", None, "GET")[0], 200)
+            self.assertFalse((session.root / ".config/sing-box/subscription.url").exists())
+
+    def test_invalid_input_cannot_publish_state(self):
+        invalid = ["", "http://feed.example.test/list", "file:///etc/passwd", "javascript:alert(1)",
+                   "https:///no-host", "https://user:pass@feed.example.test/x", "https://feed.example.test/x#secret",
+                   "https://feed.example.test/with space", "https://feed.example.test/\n", "https://feed.example.test/\x00",
+                   "https://feed.example.test/\x7f", "https://feed.example.test\\other/x", "https://feed.example.test:0/x",
+                   "https://feed.example.test:65536/x", "https://feed.example.test:00000/x", "https://:443/x", "https://[::1]:99999/x"]
+        with Session() as session:
+            for value in invalid:
+                with self.subTest(value=repr(value)):
+                    self.assertEqual(session.request("save", value.encode())[0], 400)
+            self.assertEqual(session.request("save", "https://feed.example.test/" + "a" * 8192)[0], 413)
+            self.assertFalse((session.root / ".config/sing-box/subscription.url").exists())
+
+    def test_ipv6_literal_is_staged_without_fetching(self):
+        # Runtime download validation still enforces public destination checks;
+        # this install-only collector performs no network resolution or fetch.
+        with Session() as session:
+            value = "https://[2001:db8::1]:00443/sub"
+            self.assertEqual(session.request("save", value)[0], 200)
+            self.assertEqual(session.wait(), 0)
+
+    def test_existing_user_input_is_never_overwritten(self):
+        with Session() as session:
+            out = session.root / ".config/sing-box/subscription.url"
+            out.write_text("https://existing.example.test/sub\n")
+            self.assertEqual(session.request("save", URL)[:2], (409, {"code": "existing"}))
+            self.assertEqual(out.read_text(), "https://existing.example.test/sub\n")
+
+    def test_symlink_target_is_refused(self):
+        with Session() as session:
+            victim = session.root / "victim"
+            victim.write_text("do not touch")
+            (session.root / ".config/sing-box/subscription.url").symlink_to(victim)
+            self.assertEqual(session.request("save", URL)[:2], (409, {"code": "unsafe_path"}))
+            self.assertEqual(victim.read_text(), "do not touch")
+
+    def test_symlink_configuration_directory_is_refused(self):
+        with Session() as session:
+            config = session.root / ".config/sing-box"
+            config.rmdir()
+            outside = session.root / "outside"
+            outside.mkdir()
+            config.symlink_to(outside)
+            self.assertEqual(session.request("save", URL)[:2], (409, {"code": "unsafe_path"}))
+            self.assertFalse(list(outside.iterdir()))
+
+    def test_repeated_and_concurrent_submissions_are_locked(self):
+        with Session() as session:
+            run = next(p for p in (session.root / ".state").glob("install-onboarding.*") if p.name != "install-onboarding.lock")
+            (run / "submit.lock").mkdir()
+            self.assertEqual(session.request("save", URL)[:2], (409, {"code": "busy"}))
+            (run / "submit.lock").rmdir()
+            self.assertEqual(session.request("save", URL)[0], 200)
+            self.assertEqual(session.request("skip", "")[:2], (409, {"code": "finished"}))
+            self.assertEqual(session.wait(), 0)
+
+    def test_incomplete_http_body_is_rejected(self):
+        with Session() as session:
+            with socket.create_connection(("127.0.0.1", session.port), timeout=12) as client:
+                request = (f"POST /cgi-bin/setup/save HTTP/1.0\r\nHost: 127.0.0.1:{session.port}\r\n"
+                           f"X-Setup-Token: {session.token}\r\nContent-Type: text/plain\r\nContent-Length: 30\r\n\r\nx")
+                client.sendall(request.encode())
+                client.shutdown(socket.SHUT_WR)
+                response = b""
+                while data := client.recv(4096):
+                    response += data
+                self.assertIn(b"400 Bad Request", response)
+            self.assertFalse((session.root / ".config/sing-box/subscription.url").exists())
+
+    def test_document_root_does_not_expose_secrets_or_handlers(self):
+        with Session() as session:
+            for path in ["/", "/app.js", "/style.css", "/handler.sh", "/result"]:
+                with self.subTest(path=path):
+                    conn = http.client.HTTPConnection("127.0.0.1", session.port, timeout=3)
+                    conn.request("GET", path)
+                    response = conn.getresponse()
+                    body = response.read()
+                    self.assertNotIn(session.token.encode(), body)
+                    self.assertEqual(response.status, 200 if path in ["/", "/app.js", "/style.css"] else 404)
+                    conn.close()
+
+    def test_install_gates_and_no_tty_requirement(self):
+        cases = [("fresh", {}, {}, True), ("gui", {"IS_TTY": "false"}, {}, True),
+                 ("noninteractive", {"MAGICNET_NONINTERACTIVE": "1"}, {}, False),
+                 ("optout", {"MAGICNET_INSTALL_ONBOARDING": "0"}, {}, False),
+                 ("core-disabled", {"MAGIC_SINGBOX": "0"}, {}, False),
+                 ("recovery", {"BOOTMODE": "false"}, {}, False),
+                 ("url", {}, {"subscription.url": "https://old.example.test/sub\n"}, False),
+                 ("local", {}, {"subscription.local": "/local/subscription.yaml\n"}, False),
+                 ("standalone", {}, {"standalone-config": "", "config.json": "{}"}, False),
+                 ("comments", {}, {"subscription.url": " # configure later\n\n"}, True)]
+        for name, variables, files, expected in cases:
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                config = root / ".config/sing-box"
+                config.mkdir(parents=True)
+                for name, content in files.items():
+                    (config / name).write_text(content)
+                env = dict(os.environ, MODPATH=tmp, BOOTMODE="true")
+                env.update(variables)
+                script = '. "$1"; magicnet_onboarding_android_ready() { return 0; }; magicnet_onboarding_allowed'
+                result = subprocess.run([BUSYBOX, "ash", "-c", script, "test", str(HELPER)], env=env)
+                self.assertEqual(result.returncode == 0, expected)
+
+    def test_installer_hook_order_and_no_unconditional_promotion(self):
+        source = (MODULE / "customize.sh").read_text()
+        self.assertGreater(source.index('magicnet_install_onboarding ||'), source.index('magicnet_install_config_template ||'))
+        self.assertGreater(source.index('magicnet_install_onboarding ||'), source.index('set_perm "${MODPATH}/${_magicnet_entry}"'))
+        self.assertNotIn('launch url "https://github.com', source)
+        helper = HELPER.read_text()
+        self.assertIn('import launcher', helper)
+        self.assertIn('launch url "$1"', helper)
+        self.assertNotIn('cli setup', helper)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test-magicnet-i18n.sh
+++ b/scripts/test-magicnet-i18n.sh
@@ -95,6 +95,18 @@ for key in INSTALL_TITLE INSTALL_PROFILE INSTALL_ROW_PROFILE INSTALL_DEFAULTS IN
     [ -n "$russian" ] && [ -n "$english" ] || fail "English or Russian translation missing: $key"
     [ "$(KAM_UI_LANGUAGE=ru i18n "$key")" = "$russian" ] || fail "Russian lookup failed: $key"
 done
+# First install now uses the browser, with WebUI as the fallback. The remaining
+# CLI command, routing action and panel URL are still unlocalized protocol data.
 next_steps=$(KAM_UI_LANGUAGE=ru i18n INSTALL_NEXT_STEPS)
-case "$next_steps" in *'cli setup '*'cli api ui'*'REJECT / block'*'hostname=127.0.0.1&port=9090') ;; *) fail 'installer translated command or URL values' ;; esac
-printf 'ok - MagicNet English/Russian locales, picker, fallback, installer and protocol safety\n'
+case "$next_steps" in *'WebUI'*'cli api ui'*'REJECT / block'*'hostname=127.0.0.1&port=9090') ;; *) fail 'installer translated command or URL values' ;; esac
+
+. "$ROOT/src/MagicNet/lib/magicnet/onboarding/messages.sh"
+for key in MN_SETUP_WAIT MN_SETUP_OPEN MN_SETUP_MANUAL MN_SETUP_SAVED MN_SETUP_CLOSED MN_SETUP_UNAVAILABLE; do
+    for locale in zh en ru ja ko; do
+        # Both names come from the fixed lists above, never from user input.
+        eval "translated=\${_I18N_${key}_${locale}:-}"
+        [ -n "$translated" ] || fail "onboarding translation missing: $key/$locale"
+        [ "$(KAM_UI_LANGUAGE="$locale" i18n "$key")" = "$translated" ] || fail "onboarding lookup failed: $key/$locale"
+    done
+done
+printf 'ok - MagicNet locales, picker, fallback, installer, onboarding and protocol safety\n'

--- a/src/MagicNet/customize.sh
+++ b/src/MagicNet/customize.sh
@@ -181,31 +181,31 @@ sing-box: /data/adb/modules/MagicNet/.config/sing-box/config.json"
 
 set_i18n "INSTALL_NEXT_STEPS" \
   "zh" "安装后操作：
-1. 首次安装执行 cli setup <合法订阅链接>；升级自动保留订阅并更新完整配置模板。
+1. 首次安装在自动打开的网页填写订阅，也可稍后通过 WebUI 配置；升级自动保留订阅并更新完整配置模板。
 2. 重启设备，或在模块操作页启动内核。
 3. 打开模块 WebUI 的内核面板，或在终端执行 cli api ui 查看当前核心入口。
 4. 把想戒掉的网站、规则组或域名指向 REJECT / block。
 sing-box 默认: http://127.0.0.1:9090/ui/#/setup?hostname=127.0.0.1&port=9090" \
   "en" "After installation:
-1. First install: run cli setup <legal-subscription-url>. Upgrades preserve subscriptions and replace the full config template.
+1. First install: add a subscription in the browser, or use WebUI later. Upgrades preserve subscriptions and replace the full config template.
 2. Reboot, or start the core from the module action page.
 3. Open Kernel Panel in the module WebUI, or run cli api ui to print the current core entry.
 4. Point distracting sites, groups, or domains to REJECT / block.
 sing-box default: http://127.0.0.1:9090/ui/#/setup?hostname=127.0.0.1&port=9090" \
   "ru" "После установки:
-1. Выполните cli setup <URL-подписки> для настройки подписки sing-box.
+1. Добавьте подписку на открывшейся странице или позже в WebUI. При обновлении подписка сохраняется.
 2. Перезагрузите устройство или запустите ядро из меню действий модуля.
 3. Откройте панель ядра в WebUI модуля или выполните cli api ui, чтобы узнать адрес панели.
 4. Назначьте отвлекающим сайтам, группам правил или доменам REJECT / block.
 Адрес sing-box по умолчанию: http://127.0.0.1:9090/ui/#/setup?hostname=127.0.0.1&port=9090" \
   "ja" "インストール後:
-1. cli setup <合法な購読 URL> を実行して sing-box 購読を初期化します。
+1. 開いたページで購読を追加するか、後で WebUI から設定します。更新時は既存の購読を保持します。
 2. 再起動するか、モジュール操作画面からコアを起動します。
 3. モジュール WebUI の Kernel Panel を開くか、cli api ui で現在のコア入口を確認します。
 4. 見たくないサイト、グループ、ドメインを REJECT / block に向けます。
 sing-box 既定: http://127.0.0.1:9090/ui/#/setup?hostname=127.0.0.1&port=9090" \
   "ko" "설치 후:
-1. cli setup <합법 구독 URL>로 sing-box 구독을 초기화하세요.
+1. 열린 페이지에서 구독을 추가하거나 나중에 WebUI에서 설정하세요. 업데이트 시 기존 구독은 유지됩니다.
 2. 재부팅하거나 모듈 작업 화면에서 코어를 시작하세요.
 3. 모듈 WebUI의 Kernel Panel을 열거나 cli api ui로 현재 코어 진입점을 확인하세요.
 4. 끊고 싶은 사이트, 그룹, 도메인을 REJECT / block으로 지정하세요.
@@ -491,5 +491,8 @@ unset _magicnet_entry
 
 magicnet_cleanup_install_backup || abort "! failed to remove the MagicNet migration backup"
 
-import launcher
-launch url "https://github.com/LIghtJUNction/MagicNet/blob/main/src/MagicNet/README.md"
+# Offer browser input only after migration and all permission/template writes.
+# Otherwise upgrades would prompt again, or chmod/template installation could
+# overwrite the just-collected private state. This does not require a TTY.
+. "$MODPATH/lib/magicnet/install_onboarding.sh" || abort "! subscription setup helper missing"
+magicnet_install_onboarding || warn "! subscription setup interrupted; configure it later in WebUI"

--- a/src/MagicNet/lib/magicnet/install_onboarding.sh
+++ b/src/MagicNet/lib/magicnet/install_onboarding.sh
@@ -61,6 +61,8 @@ magicnet_onboarding_open() (
     # launcher does not forward --user or the am exit status, so adapt only this
     # subshell; do not change am or the dispatcher's behavior elsewhere.
     import launcher || exit 1
+    # Called indirectly by the imported kamfw launcher; covered by host tests.
+    # shellcheck disable=SC2317
     am() {
         unset LD_LIBRARY_PATH LD_PRELOAD
         magicnet_onboarding_android_am "$@" >"$MN_SETUP_RUN/browser.log" 2>&1
@@ -92,6 +94,8 @@ magicnet_onboarding_collect() (
     _pid=''
     _notice=0
     _tag="MagicNet_setup_$$"
+    # EXIT/signal callback, not a direct call in this subshell.
+    # shellcheck disable=SC2317
     cleanup() {
         trap - 0 1 2 3 15
         if [ -n "$_pid" ]; then

--- a/src/MagicNet/lib/magicnet/install_onboarding.sh
+++ b/src/MagicNet/lib/magicnet/install_onboarding.sh
@@ -1,0 +1,198 @@
+# shellcheck shell=ash
+# Install-only UI. Sourced after kamfw initialization and configuration migration.
+# No core startup, subscription download, APK, external assets or firewall changes.
+
+magicnet_install_has_subscription() (
+    _root=$1
+    for _file in subscription.url subscription.local; do
+        _path="$_root/.config/sing-box/$_file"
+        # Treat any non-comment data as user state, even if it needs later repair.
+        [ ! -L "$_path" ] || exit 0
+        if [ -f "$_path" ] && LC_ALL=C grep -qEv '^[[:space:]]*(#.*)?$' "$_path"; then
+            exit 0
+        fi
+    done
+    [ -f "$_root/.config/sing-box/standalone-config" ] &&
+        [ -s "$_root/.config/sing-box/config.json" ]
+)
+
+magicnet_onboarding_android_ready() {
+    [ -x /system/bin/am ] && [ "$(getprop sys.boot_completed 2>/dev/null)" = 1 ]
+}
+
+magicnet_onboarding_allowed() {
+    [ "${MAGICNET_NONINTERACTIVE:-0}" != 1 ] &&
+        [ "${MAGICNET_INSTALL_ONBOARDING:-1}" != 0 ] &&
+        [ "${MAGIC_SINGBOX:-1}" != 0 ] || return 1
+    case "${BOOTMODE:-}" in false | 0) return 1 ;; esac
+    magicnet_install_has_subscription "$MODPATH" && return 1
+    magicnet_onboarding_android_ready
+}
+
+magicnet_onboarding_find_busybox() (
+    for _bb in "${MAGICNET_SETUP_BUSYBOX:-}" "${BUSYBOX:-}" \
+        "$MODPATH/bin/busybox" /data/adb/magisk/busybox /data/adb/ksu/bin/busybox \
+        /data/adb/ap/bin/busybox /data/adb/apatch/bin/busybox \
+        /debug_ramdisk/.magisk/busybox/busybox /sbin/.magisk/busybox/busybox \
+        /system/xbin/busybox /system/bin/busybox "$(command -v busybox 2>/dev/null)"; do
+        case "$_bb" in /*) ;; *) continue ;; esac
+        case "$_bb" in *[[:space:]]*) continue ;; esac
+        [ -x "$_bb" ] || continue
+        _applets=$("$_bb" --list 2>/dev/null) || continue
+        _ok=1
+        for _applet in ash httpd wget timeout setsid od tr dd cat mkdir mktemp chmod cp \
+            mv rm rmdir wc grep sleep kill; do
+            printf '%s\n' "$_applets" | "$_bb" grep -qx "$_applet" || { _ok=0; break; }
+        done
+        [ "$_ok" = 1 ] || continue
+        printf '%s\n' "$_bb"
+        exit 0
+    done
+    exit 1
+)
+
+magicnet_onboarding_android_am() {
+    "$MN_SETUP_BB" timeout 5 /system/bin/am "$@" --user current \
+        -c android.intent.category.BROWSABLE
+}
+
+magicnet_onboarding_open() (
+    # Use kamfw's URL dispatcher, not a hard-coded browser package. Its pinned
+    # launcher does not forward --user or the am exit status, so adapt only this
+    # subshell; do not change am or the dispatcher's behavior elsewhere.
+    import launcher || exit 1
+    am() {
+        unset LD_LIBRARY_PATH LD_PRELOAD
+        magicnet_onboarding_android_am "$@" >"$MN_SETUP_RUN/browser.log" 2>&1
+        exit "$?"
+    }
+    launch url "$1"
+)
+
+magicnet_onboarding_collect() (
+    # Isolation preserves the installer's kamfw at_exit migration cleanup.
+    set -eu
+    umask 077
+    export LC_ALL=C
+    _wait=${MAGICNET_SETUP_TIMEOUT:-180}
+    case "$_wait" in '' | *[!0-9]* | 0*) exit 1 ;; esac
+    [ "${#_wait}" -le 4 ] && [ "$_wait" -ge 5 ] && [ "$_wait" -le 1800 ] || exit 1
+    MN_SETUP_BB=$(magicnet_onboarding_find_busybox) || exit 1
+    _bb=$MN_SETUP_BB
+    case "$MODPATH" in /*) ;; *) exit 1 ;; esac
+    [ "$MODPATH" != / ] || exit 1
+    for _path in "$MODPATH" "$MODPATH/.state" "$MODPATH/.config" "$MODPATH/.config/sing-box"; do
+        [ ! -L "$_path" ] || exit 1
+        [ ! -e "$_path" ] || [ -d "$_path" ] || exit 1
+    done
+    "$_bb" mkdir -p "$MODPATH/.state" "$MODPATH/.config/sing-box" || exit 1
+    _lock="$MODPATH/.state/install-onboarding.lock"
+    "$_bb" mkdir "$_lock" 2>/dev/null || exit 1
+    MN_SETUP_RUN=''
+    _pid=''
+    _notice=0
+    _tag="MagicNet_setup_$$"
+    cleanup() {
+        trap - 0 1 2 3 15
+        if [ -n "$_pid" ]; then
+            "$_bb" kill -TERM -- "-$_pid" 2>/dev/null || kill "$_pid" 2>/dev/null || :
+            wait "$_pid" 2>/dev/null || :
+        fi
+        if [ "$_notice" = 1 ]; then
+            "$_bb" timeout 3 /system/bin/cmd notification post -t MagicNet \
+                "$_tag" "$(i18n MN_SETUP_CLOSED)" >/dev/null 2>&1 || :
+        fi
+        [ -z "$MN_SETUP_RUN" ] || "$_bb" rm -rf "$MN_SETUP_RUN"
+        "$_bb" rmdir "$_lock" 2>/dev/null || :
+    }
+    trap cleanup 0
+    trap 'exit 130' 2
+    trap 'exit 143' 1 3 15
+    MN_SETUP_RUN=$("$_bb" mktemp -d "$MODPATH/.state/install-onboarding.XXXXXX") || exit 1
+    MN_SETUP_ROOT=$MODPATH
+    MN_SETUP_TOKEN=$("$_bb" od -An -N24 -tx1 /dev/urandom | "$_bb" tr -d ' \n')
+    [ "${#MN_SETUP_TOKEN}" = 48 ] || exit 1
+    export MN_SETUP_BB MN_SETUP_RUN MN_SETUP_ROOT MN_SETUP_TOKEN
+    "$_bb" mkdir -p "$MN_SETUP_RUN/www/cgi-bin" || exit 1
+    for _asset in index.html style.css app.js; do
+        "$_bb" cp "$MODPATH/lib/magicnet/onboarding/$_asset" "$MN_SETUP_RUN/www/$_asset" || exit 1
+    done
+    "$_bb" cp "$MODPATH/lib/magicnet/onboarding/handler.sh" "$MN_SETUP_RUN/handler.sh" || exit 1
+    printf 'A:127.0.0.1\nD:*\n' >"$MN_SETUP_RUN/httpd.conf" || exit 1
+    {
+        printf '#!%s ash\n' "$_bb"
+        printf '%s\n' 'exec "$MN_SETUP_BB" timeout 8 "$MN_SETUP_BB" ash "$MN_SETUP_RUN/handler.sh"'
+    } >"$MN_SETUP_RUN/www/cgi-bin/setup" || exit 1
+    "$_bb" chmod 700 "$MN_SETUP_RUN/www/cgi-bin/setup" || exit 1
+    _attempt=0
+    _started=0
+    while [ "$_attempt" -lt 12 ]; do
+        _attempt=$((_attempt + 1))
+        _random=$("$_bb" od -An -N2 -tu2 /dev/urandom | "$_bb" tr -d ' \n')
+        _port=$((20000 + _random % 30000))
+        MN_SETUP_ORIGIN="http://127.0.0.1:$_port"
+        export MN_SETUP_ORIGIN
+        # A hard lifetime also bounds HTTP children if the installer is killed.
+        "$_bb" setsid "$_bb" timeout "$((_wait + 30))" "$_bb" httpd -f \
+            -p "127.0.0.1:$_port" -h "$MN_SETUP_RUN/www" -c "$MN_SETUP_RUN/httpd.conf" \
+            >"$MN_SETUP_RUN/server.log" 2>&1 &
+        _pid=$!
+        "$_bb" sleep 1
+        if kill -0 "$_pid" 2>/dev/null; then _started=1; break; fi
+        wait "$_pid" 2>/dev/null || :
+        _pid=''
+        "$_bb" grep -qi 'address already in use' "$MN_SETUP_RUN/server.log" || break
+    done
+    [ "$_started" = 1 ] || exit 1
+    _health=$("$_bb" timeout 6 "$_bb" wget -Y off -q -O - \
+        --header "X-Setup-Token: $MN_SETUP_TOKEN" "$MN_SETUP_ORIGIN/cgi-bin/setup/health" \
+        2>/dev/null) || exit 1
+    [ "$_health" = '{"code":"ready"}' ] || exit 1
+    _page=$("$_bb" timeout 6 "$_bb" wget -Y off -q -O - "$MN_SETUP_ORIGIN/" 2>/dev/null) || exit 1
+    case "$_page" in *'id="setup-form"'*) ;; *) exit 1 ;; esac
+    _lang=${KAM_UI_LANGUAGE:-${KAM_LANG:-$(getprop persist.sys.locale 2>/dev/null || :)}}
+    case "$_lang" in zh*) _lang=zh ;; ru*) _lang=ru ;; ja*) _lang=ja ;; ko*) _lang=ko ;; *) _lang=en ;; esac
+    _url="$MN_SETUP_ORIGIN/?lang=$_lang#$MN_SETUP_TOKEN"
+    print "$(i18n MN_SETUP_WAIT)"
+    # A short-lived local capability, never the subscription itself. Do not
+    # include this link in diagnostics, support bundles or permanent logs.
+    print "$_url"
+    if [ -x /system/bin/cmd ]; then
+        "$_bb" timeout 4 /system/bin/cmd notification post -t MagicNet \
+            -c activity "$_url" "$_tag" "$(i18n MN_SETUP_OPEN)" \
+            >/dev/null 2>&1 && _notice=1
+    fi
+    magicnet_onboarding_open "$_url" || print "$(i18n MN_SETUP_MANUAL)"
+    _elapsed=0
+    while [ "$_elapsed" -lt "$_wait" ]; do
+        if [ -f "$MN_SETUP_RUN/result" ]; then
+            _result=$("$_bb" cat "$MN_SETUP_RUN/result")
+            "$_bb" sleep 1 # Let the final HTTP response reach the browser.
+            case "$_result" in
+                saved) print "$(i18n MN_SETUP_SAVED)"; exit 0 ;;
+                skipped) print "$(i18n MN_SETUP_CLOSED)"; exit 2 ;;
+                *) exit 1 ;;
+            esac
+        fi
+        kill -0 "$_pid" 2>/dev/null || exit 1
+        "$_bb" sleep 1
+        _elapsed=$((_elapsed + 1))
+    done
+    print "$(i18n MN_SETUP_CLOSED)"
+    exit 3
+)
+
+magicnet_install_onboarding() {
+    magicnet_onboarding_allowed || return 0
+    . "$MODPATH/lib/magicnet/onboarding/messages.sh" || return 1
+    # Declining or timing out must not break module installation.
+    if magicnet_onboarding_collect; then
+        return 0
+    else
+        case "$?" in
+            2 | 3) return 0 ;;
+            130 | 143) return 1 ;;
+            *) print "$(i18n MN_SETUP_UNAVAILABLE)"; return 0 ;;
+        esac
+    fi
+}

--- a/src/MagicNet/lib/magicnet/onboarding/app.js
+++ b/src/MagicNet/lib/magicnet/onboarding/app.js
@@ -1,0 +1,145 @@
+(function () {
+  'use strict';
+  const translations = {
+    en: {
+      language: 'Language', eyebrow: 'A NEW CONNECTION', title: 'Your network.', accent: 'Your rules.',
+      subtitle: 'Add a subscription. Make yourself at home.', label: 'Subscription URL', save: 'Save & continue', skip: 'Set up later',
+      privacy: 'Stored on your device. Loaded on the next start.', explore: 'Keep exploring', star: 'Star on GitHub', docs: 'Guide', community: 'Community', local: 'PRIVATE, BY DESIGN',
+      submitting: 'Saving…', checking: 'Connecting to the installer…', invalid: 'Use a complete HTTPS URL without spaces, a fragment or credentials.',
+      too_long: 'The URL must be no longer than 8192 bytes.', forbidden: 'This setup link is invalid. Open the complete link from the installer.',
+      missing_token: 'Open the complete setup link from the installer, including the part after #.',
+      network: 'Could not confirm the result. Return to the installer to check; this temporary page may have closed.',
+      busy: 'Another request is being processed. Please try again.', existing: 'A subscription is already configured. It has not been overwritten.',
+      finished: 'This setup session has ended. Return to the installer.', unsafe_path: 'The configuration path is unsafe. Use the module WebUI after installation.',
+      save_failed: 'Could not save. Return to the installer; no success has been confirmed.', format: 'Unsupported request format.', method: 'Unsupported request method.', missing: 'Setup endpoint not found.',
+      saved_title: 'You’re all set.', saved_note: 'The link is saved. Return to the installer and finish installing. MagicNet will load the subscription on its next start.',
+      skipped_title: 'At your own pace.', skipped_note: 'Return to the installer. You can add a subscription in the module WebUI later.'
+    },
+    zh: {
+      language: '语言', eyebrow: '新的连接，从这里开始', title: '你的网络。', accent: '由你定义。',
+      subtitle: '添加订阅，开始使用 MagicNet。', label: '订阅链接', save: '保存并继续', skip: '稍后设置',
+      privacy: '保存在本机，下次启动时加载。', explore: '不止于此', star: '在 GitHub 点亮 Star', docs: '使用指南', community: '加入社区', local: '留在本机，保持私密',
+      submitting: '正在保存…', checking: '正在连接安装器…', invalid: '请填写完整的 HTTPS 链接，不含空格、# 片段或账号密码。',
+      too_long: '链接不能超过 8192 字节。', forbidden: '本次入口无效，请打开安装器显示的完整地址。',
+      missing_token: '请打开安装器显示的完整地址，包括 # 后面的部分。',
+      network: '无法确认结果，请返回安装器查看；临时页面可能已关闭。',
+      busy: '另一个请求正在处理，请重试。', existing: '已有订阅配置，没有覆盖。', finished: '本次配置已经结束，请返回安装器。',
+      unsafe_path: '配置路径不安全，请安装后通过模块 WebUI 设置。', save_failed: '未能确认保存成功，请返回安装器查看。', format: '请求格式不支持。', method: '请求方式不支持。', missing: '配置接口不存在。',
+      saved_title: '链接已收好。', saved_note: '返回安装器完成安装。MagicNet 下次启动时会加载订阅。',
+      skipped_title: '稍后再出发。', skipped_note: '返回安装器继续安装，之后可在模块 WebUI 添加订阅。'
+    },
+    ru: {
+      language: 'Язык', eyebrow: 'НОВОЕ ПОДКЛЮЧЕНИЕ', title: 'Ваша сеть.', accent: 'Ваши правила.',
+      subtitle: 'Добавьте подписку и начните пользоваться MagicNet.', label: 'Ссылка на подписку', save: 'Сохранить', skip: 'Настроить позже',
+      privacy: 'Хранится на устройстве. Загрузится при следующем запуске.', explore: 'Узнать больше', star: 'Звезда на GitHub', docs: 'Руководство', community: 'Сообщество', local: 'ПРИВАТНО ПО УМОЛЧАНИЮ',
+      submitting: 'Сохранение…', checking: 'Подключение к установщику…', invalid: 'Введите полный HTTPS URL без пробелов, фрагмента # и учётных данных.',
+      too_long: 'Ссылка не должна превышать 8192 байта.', forbidden: 'Ссылка настройки недействительна. Откройте полную ссылку из установщика.',
+      missing_token: 'Откройте полную ссылку из установщика, включая часть после #.',
+      network: 'Результат не подтверждён. Проверьте установщик; временная страница могла закрыться.',
+      busy: 'Другой запрос обрабатывается. Повторите попытку.', existing: 'Подписка уже настроена и не была перезаписана.', finished: 'Сеанс завершён. Вернитесь в установщик.',
+      unsafe_path: 'Небезопасный путь конфигурации. Используйте WebUI после установки.', save_failed: 'Сохранение не подтверждено. Проверьте установщик.', format: 'Неподдерживаемый формат.', method: 'Неподдерживаемый метод.', missing: 'Интерфейс настройки не найден.',
+      saved_title: 'Ссылка сохранена.', saved_note: 'Вернитесь в установщик и завершите установку. MagicNet загрузит подписку при следующем запуске.',
+      skipped_title: 'Можно и позже.', skipped_note: 'Вернитесь в установщик. Подписку можно добавить в WebUI модуля позже.'
+    },
+    ja: {
+      language: '言語', eyebrow: '新しいつながり', title: 'あなたのネット。', accent: 'あなたのルール。',
+      subtitle: '購読を追加して、MagicNet を始めましょう。', label: '購読 URL', save: '保存して続ける', skip: '後で設定',
+      privacy: '端末内に保存し、次回起動時に読み込みます。', explore: 'さらに詳しく', star: 'GitHub で Star', docs: 'ガイド', community: 'コミュニティ', local: 'プライバシーを大切に',
+      submitting: '保存しています…', checking: 'インストーラーに接続しています…', invalid: '空白、# フラグメント、認証情報を含まない完全な HTTPS URL を入力してください。',
+      too_long: 'URL は8192バイト以内にしてください。', forbidden: '無効な設定リンクです。インストーラーのリンク全体を開いてください。',
+      missing_token: 'インストーラーのリンクを、# 以降も含めて開いてください。',
+      network: '結果を確認できません。インストーラーに戻って確認してください。一時ページが閉じた可能性があります。',
+      busy: '別のリクエストを処理中です。再試行してください。', existing: '購読は既に設定されています。上書きしていません。', finished: '設定を終了しました。インストーラーに戻ってください。',
+      unsafe_path: '安全でない設定パスです。インストール後に WebUI を使用してください。', save_failed: '保存を確認できません。インストーラーを確認してください。', format: '未対応の形式です。', method: '未対応のメソッドです。', missing: '設定インターフェースが見つかりません。',
+      saved_title: 'リンクを保存しました。', saved_note: 'インストーラーに戻ってインストールを完了してください。次回起動時に購読を読み込みます。',
+      skipped_title: 'また後で。', skipped_note: 'インストーラーに戻ってください。購読は後から WebUI で追加できます。'
+    },
+    ko: {
+      language: '언어', eyebrow: '새로운 연결', title: '당신의 네트워크.', accent: '당신의 규칙.',
+      subtitle: '구독을 추가하고 MagicNet을 시작하세요.', label: '구독 링크', save: '저장하고 계속', skip: '나중에 설정',
+      privacy: '기기에 저장하고 다음 시작 때 불러옵니다.', explore: '더 알아보기', star: 'GitHub에 Star', docs: '사용 안내', community: '커뮤니티', local: '개인정보를 소중하게',
+      submitting: '저장 중…', checking: '설치 프로그램에 연결 중…', invalid: '공백, # 조각, 인증 정보가 없는 완전한 HTTPS 링크를 입력하세요.',
+      too_long: '링크는 8192바이트 이하여야 합니다.', forbidden: '유효하지 않은 설정 링크입니다. 설치 프로그램의 전체 링크를 여세요.',
+      missing_token: '설치 프로그램의 링크를 # 뒤의 부분까지 모두 여세요.',
+      network: '결과를 확인하지 못했습니다. 설치 프로그램으로 돌아가 확인하세요. 임시 페이지가 닫혔을 수 있습니다.',
+      busy: '다른 요청을 처리 중입니다. 다시 시도하세요.', existing: '이미 구독이 설정되어 있습니다. 덮어쓰지 않았습니다.', finished: '설정이 종료되었습니다. 설치 프로그램으로 돌아가세요.',
+      unsafe_path: '설정 경로가 안전하지 않습니다. 설치 후 WebUI를 사용하세요.', save_failed: '저장을 확인하지 못했습니다. 설치 프로그램을 확인하세요.', format: '지원하지 않는 형식입니다.', method: '지원하지 않는 방식입니다.', missing: '설정 인터페이스를 찾을 수 없습니다.',
+      saved_title: '링크를 저장했어요.', saved_note: '설치 프로그램으로 돌아가 설치를 완료하세요. 다음 시작 때 구독을 불러옵니다.',
+      skipped_title: '나중에 해도 돼요.', skipped_note: '설치 프로그램으로 돌아가세요. 나중에 모듈 WebUI에서 구독을 추가할 수 있습니다.'
+    }
+  };
+  const byId = (id) => document.getElementById(id);
+  const input = byId('subscription');
+  const status = byId('status');
+  const select = byId('language');
+  const supported = (value) => Object.prototype.hasOwnProperty.call(translations, value);
+  const normalize = (value) => String(value || '').toLowerCase().split(/[-_]/)[0];
+  const requested = normalize(new URLSearchParams(location.search).get('lang'));
+  const candidates = (navigator.languages || [navigator.language]).map(normalize);
+  let language = supported(requested) ? requested : candidates.find(supported) || 'en';
+  let token = location.hash.slice(1);
+  let message = '';
+  let error = false;
+  let result = '';
+  function render() {
+    const t = translations[language];
+    document.documentElement.lang = language;
+    document.title = 'MagicNet · ' + t.label;
+    select.value = language;
+    document.querySelectorAll('[data-i18n]').forEach((element) => {
+      element.textContent = t[element.dataset.i18n];
+    });
+    status.textContent = message ? t[message] || t.network : '';
+    status.dataset.error = String(error);
+    if (result) {
+      byId('completion-title').textContent = t[result + '_title'];
+      byId('completion-note').textContent = t[result + '_note'];
+    }
+  }
+  function show(key, isError) { message = key; error = Boolean(isError); render(); }
+  function lock(value) { input.disabled = value; byId('save').disabled = value; byId('skip').disabled = value; }
+  function done(action) {
+    result = action;
+    input.value = '';
+    token = '';
+    history.replaceState(null, '', location.pathname + location.search);
+    byId('setup-form').hidden = true;
+    byId('completion').hidden = false;
+    lock(true);
+    show('', false);
+  }
+  function request(action, value) {
+    lock(true);
+    show(action === 'health' ? 'checking' : 'submitting', false);
+    const xhr = new XMLHttpRequest();
+    xhr.open(action === 'health' ? 'GET' : 'POST', '/cgi-bin/setup/' + action, true);
+    xhr.timeout = 10000;
+    xhr.setRequestHeader('X-Setup-Token', token);
+    if (action !== 'health') xhr.setRequestHeader('Content-Type', 'text/plain;charset=UTF-8');
+    xhr.onload = function () {
+      let code = 'network';
+      try { code = JSON.parse(xhr.responseText).code; } catch (_) { /* Report an unconfirmed result, not a false success. */ }
+      if (xhr.status === 200 && action === 'health' && code === 'ready') { lock(false); show('', false); return; }
+      if (xhr.status === 200 && ((action === 'save' && code === 'saved') || (action === 'skip' && code === 'skipped'))) { done(code); return; }
+      lock(['forbidden', 'finished', 'existing', 'unsafe_path'].includes(code));
+      show(supported(language) && Object.prototype.hasOwnProperty.call(translations[language], code) ? code : 'network', true);
+    };
+    xhr.onerror = xhr.ontimeout = function () { lock(false); show('network', true); };
+    xhr.send(action === 'health' ? null : value);
+  }
+  select.addEventListener('change', function () { language = supported(select.value) ? select.value : 'en'; render(); });
+  byId('setup-form').addEventListener('submit', function (event) {
+    event.preventDefault();
+    const value = input.value.trim();
+    try {
+      const parsed = new URL(value);
+      if (!value.startsWith('https://') || parsed.protocol !== 'https:' || !parsed.hostname || /[\x00-\x20\x7f@#\\]/.test(value)) throw new Error('invalid');
+      if (new TextEncoder().encode(value).length > 8192) { show('too_long', true); return; }
+    } catch (_) { show('invalid', true); return; }
+    request('save', value);
+  });
+  byId('skip').addEventListener('click', function () { request('skip', ''); });
+  render();
+  if (!/^[0-9a-f]{48}$/.test(token)) { lock(true); show('missing_token', true); return; }
+  request('health', '');
+})();

--- a/src/MagicNet/lib/magicnet/onboarding/handler.sh
+++ b/src/MagicNet/lib/magicnet/onboarding/handler.sh
@@ -9,6 +9,8 @@ root=$MN_SETUP_ROOT
 body=''
 stage=''
 locked=0
+# EXIT/signal callback is exercised by request and interruption tests.
+# shellcheck disable=SC2317
 cleanup() {
     [ -z "$body" ] || "$bb" rm -f "$body"
     [ -z "$stage" ] || "$bb" rm -f "$stage"
@@ -49,7 +51,7 @@ bad=$("$bb" tr -cd '\000-\040\177' <"$body" | "$bb" wc -c | "$bb" tr -d ' ')
 value=$("$bb" cat "$body")
 # Match the runtime's HTTPS-only policy; never eval/source the received value.
 case "$value" in https://?*) ;; *) reply '400 Bad Request' invalid ;; esac
-case "$value" in *'@'* | *'#'* | *'\'*) reply '400 Bad Request' invalid ;; esac
+case "$value" in *'@'* | *'#'* | *\\*) reply '400 Bad Request' invalid ;; esac
 authority=${value#https://}
 authority=${authority%%[/?]*}
 printf '%s\n' "$authority" | "$bb" grep -Eq '^([A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?|\[[0-9A-Fa-f:]+\])(:[0-9]{1,5})?$' || reply '400 Bad Request' invalid

--- a/src/MagicNet/lib/magicnet/onboarding/handler.sh
+++ b/src/MagicNet/lib/magicnet/onboarding/handler.sh
@@ -1,0 +1,91 @@
+# shellcheck shell=ash
+# CGI entry invoked only by the private, bounded BusyBox wrapper.
+set -eu
+umask 077
+export LC_ALL=C
+bb=$MN_SETUP_BB
+run=$MN_SETUP_RUN
+root=$MN_SETUP_ROOT
+body=''
+stage=''
+locked=0
+cleanup() {
+    [ -z "$body" ] || "$bb" rm -f "$body"
+    [ -z "$stage" ] || "$bb" rm -f "$stage"
+    [ "$locked" != 1 ] || "$bb" rmdir "$run/submit.lock" 2>/dev/null || :
+}
+trap cleanup 0
+trap 'exit 1' 1 2 3 15
+reply() {
+    printf 'Status: %s\r\nContent-Type: application/json; charset=utf-8\r\nCache-Control: no-store\r\nX-Content-Type-Options: nosniff\r\nReferrer-Policy: no-referrer\r\n\r\n{"code":"%s"}\n' "$1" "$2"
+    exit 0
+}
+[ "${HTTP_HOST:-}" = "${MN_SETUP_ORIGIN#http://}" ] || reply '403 Forbidden' forbidden
+[ "${HTTP_X_SETUP_TOKEN:-}" = "$MN_SETUP_TOKEN" ] || reply '403 Forbidden' forbidden
+[ -z "${HTTP_ORIGIN:-}" ] || [ "$HTTP_ORIGIN" = "$MN_SETUP_ORIGIN" ] || reply '403 Forbidden' forbidden
+case "${HTTP_SEC_FETCH_SITE:-}" in '' | same-origin | none) ;; *) reply '403 Forbidden' forbidden ;; esac
+if [ "${REQUEST_METHOD:-}" = GET ] && [ "${PATH_INFO:-}" = /health ]; then
+    reply '200 OK' ready
+fi
+[ "${REQUEST_METHOD:-}" = POST ] || reply '405 Method Not Allowed' method
+case "${PATH_INFO:-}" in /save | /skip) ;; *) reply '404 Not Found' missing ;; esac
+"$bb" mkdir "$run/submit.lock" 2>/dev/null || reply '409 Conflict' busy
+locked=1
+[ ! -e "$run/result" ] || reply '409 Conflict' finished
+if [ "$PATH_INFO" = /skip ]; then
+    printf '%s\n' skipped >"$run/result.new"
+    "$bb" mv "$run/result.new" "$run/result"
+    reply '200 OK' skipped
+fi
+case "${CONTENT_TYPE:-}" in text/plain | text/plain\;*) ;; *) reply '415 Unsupported Media Type' format ;; esac
+length=${CONTENT_LENGTH:-}
+case "$length" in '' | *[!0-9]* | 0*) reply '400 Bad Request' invalid ;; esac
+[ "${#length}" -le 4 ] && [ "$length" -le 8192 ] || reply '413 Content Too Large' too_long
+body=$("$bb" mktemp "$run/request.XXXXXX")
+"$bb" dd bs=1 count="$length" of="$body" 2>/dev/null || reply '400 Bad Request' invalid
+[ "$("$bb" wc -c <"$body" | "$bb" tr -d ' ')" = "$length" ] || reply '400 Bad Request' invalid
+bad=$("$bb" tr -cd '\000-\040\177' <"$body" | "$bb" wc -c | "$bb" tr -d ' ')
+[ "$bad" = 0 ] || reply '400 Bad Request' invalid
+value=$("$bb" cat "$body")
+# Match the runtime's HTTPS-only policy; never eval/source the received value.
+case "$value" in https://?*) ;; *) reply '400 Bad Request' invalid ;; esac
+case "$value" in *'@'* | *'#'* | *'\'*) reply '400 Bad Request' invalid ;; esac
+authority=${value#https://}
+authority=${authority%%[/?]*}
+printf '%s\n' "$authority" | "$bb" grep -Eq '^([A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?|\[[0-9A-Fa-f:]+\])(:[0-9]{1,5})?$' || reply '400 Bad Request' invalid
+case "$authority" in
+    \[*\]) ;;
+    *:*)
+        port=${authority##*:}
+        # Strip leading zeroes before arithmetic to avoid ash's octal rules.
+        while [ "${port#0}" != "$port" ]; do port=${port#0}; done
+        [ -n "$port" ] && [ "$port" -le 65535 ] || reply '400 Bad Request' invalid
+        ;;
+esac
+for path in "$root" "$root/.config" "$root/.config/sing-box"; do
+    [ -d "$path" ] && [ ! -L "$path" ] || reply '409 Conflict' unsafe_path
+done
+out="$root/.config/sing-box/subscription.url"
+for path in "$out" "$root/.config/sing-box/subscription.local" "$root/.config/sing-box/standalone-config"; do
+    [ ! -L "$path" ] || reply '409 Conflict' unsafe_path
+    [ ! -e "$path" ] || [ -f "$path" ] || reply '409 Conflict' unsafe_path
+done
+# Recheck immediately before publication: opening a form never authorizes
+# overwriting a subscription imported by another path while the form was open.
+for path in "$out" "$root/.config/sing-box/subscription.local"; do
+    if [ -f "$path" ] && "$bb" grep -qEv '^[[:space:]]*(#.*)?$' "$path"; then
+        reply '409 Conflict' existing
+    fi
+done
+if [ -f "$root/.config/sing-box/standalone-config" ] && [ -s "$root/.config/sing-box/config.json" ]; then
+    reply '409 Conflict' existing
+fi
+stage=$("$bb" mktemp "$root/.config/sing-box/.install-subscription.XXXXXX")
+printf '%s\n' "$value" >"$stage" || reply '500 Internal Server Error' save_failed
+"$bb" chmod 600 "$stage" || reply '500 Internal Server Error' save_failed
+"$bb" rm -f "$root/.config/sing-box/standalone-config" || reply '500 Internal Server Error' save_failed
+"$bb" mv -f "$stage" "$out" || reply '500 Internal Server Error' save_failed
+stage=''
+printf '%s\n' saved >"$run/result.new"
+"$bb" mv "$run/result.new" "$run/result"
+reply '200 OK' saved

--- a/src/MagicNet/lib/magicnet/onboarding/index.html
+++ b/src/MagicNet/lib/magicnet/onboarding/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="referrer" content="no-referrer">
+  <meta name="color-scheme" content="light dark">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; connect-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
+  <title>MagicNet · Setup</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="app.js" defer></script>
+</head>
+<body>
+  <div class="shell">
+    <header>
+      <a class="brand" href="https://github.com/LIghtJUNction/MagicNet" target="_blank" rel="noopener noreferrer" aria-label="MagicNet on GitHub">
+        <span class="brand-mark" aria-hidden="true"><i></i><i></i><i></i></span><span>MagicNet</span>
+      </a>
+      <label class="language"><span aria-hidden="true">文 / A</span><span class="sr-only" data-i18n="language">Language</span>
+        <select id="language"><option value="zh">简体中文</option><option value="en">English</option><option value="ru">Русский</option><option value="ja">日本語</option><option value="ko">한국어</option></select>
+      </label>
+    </header>
+    <main>
+      <section class="intro" aria-labelledby="title">
+        <p class="eyebrow"><span class="live-dot" aria-hidden="true"></span><span data-i18n="eyebrow">A NEW CONNECTION</span><span class="edition">01 / SETUP</span></p>
+        <h1 id="title"><span data-i18n="title">Your network.</span><em data-i18n="accent">Your rules.</em></h1>
+        <p class="subtitle" data-i18n="subtitle">Add a subscription. Make yourself at home.</p>
+        <form id="setup-form" novalidate>
+          <label for="subscription" data-i18n="label">Subscription URL</label>
+          <div class="input-wrap"><input id="subscription" name="subscription" type="url" inputmode="url" autocomplete="off" autocapitalize="none" spellcheck="false" placeholder="https://…" maxlength="8192" required aria-describedby="status"><span class="input-badge" aria-hidden="true">HTTPS</span></div>
+          <div class="actions"><button id="save" class="primary" type="submit"><span data-i18n="save">Save & continue</span><span aria-hidden="true">↗</span></button><button id="skip" type="button" class="quiet" data-i18n="skip">Set up later</button></div>
+        </form>
+        <div id="status" role="status" aria-live="polite"></div>
+        <section id="completion" hidden aria-label="Setup result"><div class="complete-mark" aria-hidden="true">✓</div><h2 id="completion-title"></h2><p id="completion-note"></p><a class="primary star-success" href="https://github.com/LIghtJUNction/MagicNet" target="_blank" rel="noopener noreferrer"><span aria-hidden="true">☆</span><span data-i18n="star">Star on GitHub</span><span aria-hidden="true">↗</span></a></section>
+        <p class="privacy"><span aria-hidden="true">◈</span><span data-i18n="privacy">Stored on your device. Loaded on the next start.</span></p>
+      </section>
+      <div class="visual" aria-hidden="true"><div class="orbital"><div class="disc"></div><div class="orbit orbit-a"></div><div class="orbit orbit-b"></div><div class="orbit orbit-c"></div><div class="orbit orbit-d"></div><span class="satellite satellite-a"></span><span class="satellite satellite-b"></span><div class="monogram"><i></i><i></i><i></i></div><span class="orbit-caption">LESS NOISE.<br>MORE POSSIBILITY.</span><span class="coordinate">M / N — 01</span></div></div>
+    </main>
+    <footer>
+      <div class="footer-label"><span class="footer-line" aria-hidden="true"></span><span data-i18n="explore">Keep exploring</span></div>
+      <nav aria-label="MagicNet links"><a class="star-link" href="https://github.com/LIghtJUNction/MagicNet" target="_blank" rel="noopener noreferrer"><span aria-hidden="true">☆</span><span data-i18n="star">Star on GitHub</span><span aria-hidden="true">↗</span></a><a href="https://github.com/LIghtJUNction/MagicNet/blob/main/src/MagicNet/README.md" target="_blank" rel="noopener noreferrer"><span data-i18n="docs">Guide</span><span aria-hidden="true">↗</span></a><a href="https://discord.gg/asRwgK9FpA" target="_blank" rel="noopener noreferrer"><span data-i18n="community">Community</span><span aria-hidden="true">↗</span></a><a href="https://api.lmm.best" target="_blank" rel="noopener noreferrer"><span>LMM API</span><span aria-hidden="true">↗</span></a></nav>
+      <p class="signature"><span>MAGICNET — OPEN SOURCE</span><span data-i18n="local">PRIVATE, BY DESIGN</span></p>
+    </footer>
+    <noscript>Enable JavaScript to use this local setup page. / 请启用 JavaScript，或安装后通过模块 WebUI 配置。</noscript>
+  </div>
+</body>
+</html>

--- a/src/MagicNet/lib/magicnet/onboarding/messages.sh
+++ b/src/MagicNet/lib/magicnet/onboarding/messages.sh
@@ -1,0 +1,35 @@
+# shellcheck shell=ash
+# Registered through kamfw, using the installer's already selected language.
+set_i18n MN_SETUP_WAIT \
+    zh '请在浏览器填写订阅；默认等待 180 秒，也可稍后配置。临时地址请勿分享：' \
+    en 'Add a subscription in your browser, or skip. Default timeout: 180 seconds. Do not share this temporary link:' \
+    ru 'Добавьте подписку в браузере или пропустите. Ожидание по умолчанию: 180 секунд. Не передавайте эту временную ссылку:' \
+    ja 'ブラウザーで購読を入力するか、スキップしてください。既定の待機時間は180秒です。この一時リンクを共有しないでください:' \
+    ko '브라우저에서 구독을 입력하거나 건너뛰세요. 기본 대기 시간은 180초입니다. 임시 링크를 공유하지 마세요:'
+set_i18n MN_SETUP_OPEN \
+    zh '点击填写订阅链接' en 'Tap to add your subscription' ru 'Нажмите, чтобы добавить подписку' \
+    ja 'タップして購読を追加' ko '눌러서 구독 추가'
+set_i18n MN_SETUP_MANUAL \
+    zh '未能自动打开浏览器，请手动打开上面的完整地址。' \
+    en 'Could not open your browser. Open the complete link above manually.' \
+    ru 'Не удалось открыть браузер. Откройте полную ссылку выше вручную.' \
+    ja 'ブラウザーを開けませんでした。上のリンク全体を手動で開いてください。' \
+    ko '브라우저를 열지 못했습니다. 위의 전체 링크를 직접 열어 주세요.'
+set_i18n MN_SETUP_SAVED \
+    zh '订阅链接已保存。完成安装并重启后，MagicNet 会按正常启动流程加载订阅。' \
+    en 'Subscription saved. Finish installing and reboot; MagicNet will load it during normal startup.' \
+    ru 'Подписка сохранена. Завершите установку и перезагрузите устройство; MagicNet загрузит её при запуске.' \
+    ja '購読を保存しました。インストールを完了して再起動すると、通常の起動処理で読み込みます。' \
+    ko '구독을 저장했습니다. 설치를 완료하고 재부팅하면 정상 시작 과정에서 불러옵니다.'
+set_i18n MN_SETUP_CLOSED \
+    zh '配置入口已关闭，可在安装后通过 WebUI 配置订阅。' \
+    en 'Setup link closed. You can configure the subscription in the module WebUI after installation.' \
+    ru 'Временная страница закрыта. Подписку можно настроить в WebUI после установки.' \
+    ja '設定リンクを閉じました。インストール後に WebUI から購読を設定できます。' \
+    ko '설정 링크가 닫혔습니다. 설치 후 WebUI에서 구독을 설정할 수 있습니다.'
+set_i18n MN_SETUP_UNAVAILABLE \
+    zh '本地配置页不可用，安装继续；请在安装后通过 WebUI 配置订阅。未更改 SELinux 或防火墙。' \
+    en 'Local setup is unavailable. Installation continues; configure the subscription in WebUI afterwards. SELinux and firewall settings are unchanged.' \
+    ru 'Локальная страница недоступна. Установка продолжится; настройте подписку в WebUI. SELinux и брандмауэр не изменены.' \
+    ja 'ローカル設定ページを利用できません。インストール後に WebUI で設定してください。SELinux やファイアウォールは変更していません。' \
+    ko '로컬 설정 페이지를 사용할 수 없습니다. 설치 후 WebUI에서 설정하세요. SELinux와 방화벽은 변경하지 않았습니다.'

--- a/src/MagicNet/lib/magicnet/onboarding/style.css
+++ b/src/MagicNet/lib/magicnet/onboarding/style.css
@@ -1,0 +1,126 @@
+:root {
+  color-scheme: light dark;
+  --paper: #f7f6f2; --ink: #202722; --muted: #677068; --line: #d8ddd4;
+  --field: #fffefa; --accent: #276447; --accent-text: #f4f8ef; --soft: #dce8c9;
+  --orbit: #96aa87; --focus: #326cbd;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", sans-serif;
+  color: var(--ink); background: var(--paper); font-synthesis: none;
+}
+* { box-sizing: border-box; }
+body { margin: 0; min-width: 280px; }
+button, input, select { font: inherit; }
+a { color: inherit; text-decoration: none; }
+button, a, select { -webkit-tap-highlight-color: transparent; }
+button { cursor: pointer; }
+a:focus-visible, button:focus-visible, select:focus-visible, input:focus-visible { outline: 3px solid var(--focus); outline-offset: 5px; }
+[hidden] { display: none !important; }
+.shell { max-width: 1240px; margin: auto; padding: max(30px, env(safe-area-inset-top)) 52px max(22px, env(safe-area-inset-bottom)); }
+header { display: flex; align-items: center; justify-content: space-between; gap: 22px; }
+.brand { display: inline-flex; align-items: center; gap: 13px; font-size: 21px; font-weight: 650; letter-spacing: -.8px; }
+.brand-mark { display: flex; gap: 3px; align-items: center; height: 27px; transform: skew(-19deg); }
+.brand-mark i { width: 5px; height: 23px; background: var(--accent); border-radius: 3px; }
+.brand-mark i:nth-child(2) { height: 14px; }
+.language { display: flex; gap: 10px; align-items: center; font-size: 12px; color: var(--muted); }
+.language select { max-width: 135px; border: 0; border-bottom: 1px solid var(--line); background: transparent; color: var(--ink); padding: 9px 3px; font-size: 13px; cursor: pointer; }
+.language option { color: var(--ink); background: var(--paper); }
+main { display: grid; grid-template-columns: 1.12fr 1fr; gap: 36px; align-items: center; padding: 94px 0 64px; min-height: 650px; }
+.intro { position: relative; z-index: 1; max-width: 570px; }
+.eyebrow { display: flex; align-items: center; gap: 8px; margin: 0 0 29px; color: var(--accent); font-size: 10px; letter-spacing: 1.6px; font-weight: 600; }
+.live-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+.edition { color: var(--muted); margin-left: 20px; letter-spacing: 1px; font-size: 9px; white-space: nowrap; }
+h1 { font-size: clamp(44px, 5.1vw, 68px); font-weight: 550; line-height: 1.09; letter-spacing: -3px; margin: 0; }
+h1 span, h1 em { display: block; }
+h1 em { color: var(--accent); font-weight: 450; font-family: Georgia, "Noto Serif", serif; font-style: italic; }
+:lang(zh) h1, :lang(ja) h1, :lang(ko) h1 { letter-spacing: -2px; line-height: 1.26; }
+:lang(zh) h1 em, :lang(ja) h1 em, :lang(ko) h1 em { font-style: normal; }
+:lang(ru) h1 { font-size: clamp(40px, 4.6vw, 61px); }
+.subtitle { margin: 22px 0 37px; font-size: 14px; line-height: 1.65; color: var(--muted); }
+form { max-width: 470px; }
+form label { display: block; font-size: 12px; margin-bottom: 10px; color: var(--muted); }
+.input-wrap { display: flex; align-items: center; border: 1px solid var(--line); background: var(--field); border-radius: 12px; transition: border-color .2s, box-shadow .2s; }
+.input-wrap:focus-within { border-color: var(--accent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 10%, transparent); }
+input { min-width: 0; width: 100%; padding: 18px 16px; font-size: 16px; color: var(--ink); background: transparent; border: 0; border-radius: 12px; }
+input:focus-visible { outline: 0; }
+input::placeholder { color: var(--muted); opacity: .72; }
+.input-badge { margin-right: 15px; font-size: 9px; color: var(--muted); letter-spacing: .8px; }
+.actions { display: flex; gap: 19px; align-items: center; margin-top: 15px; }
+.primary { display: inline-flex; align-items: center; justify-content: space-between; gap: 25px; color: var(--accent-text); background: var(--accent); border: 1px solid var(--accent); border-radius: 12px; min-height: 53px; padding: 14px 19px; font-size: 14px; font-weight: 550; transition: transform .2s, filter .2s; }
+.primary:hover { filter: brightness(1.1); transform: translateY(-2px); }
+.primary:active { transform: translateY(0); }
+.quiet { border: 0; background: transparent; color: var(--muted); padding: 14px 0; font-size: 13px; text-align: left; }
+.quiet:hover { color: var(--ink); }
+button:disabled, input:disabled { opacity: .55; cursor: default; }
+button:disabled { transform: none; }
+#status { margin-top: 13px; min-height: 20px; max-width: 470px; font-size: 12px; line-height: 1.6; color: var(--muted); overflow-wrap: anywhere; }
+#status[data-error="true"] { color: #b64233; }
+.privacy { display: flex; gap: 7px; align-items: flex-start; margin: 14px 0 0; color: var(--muted); font-size: 10px; line-height: 1.7; }
+.visual { width: 100%; aspect-ratio: 1; display: grid; place-items: center; }
+.orbital { width: 100%; aspect-ratio: 1; position: relative; perspective: 700px; }
+.disc { position: absolute; inset: 13%; border-radius: 50%; background: radial-gradient(circle at 37% 32%, var(--soft), transparent 70%); opacity: .85; }
+.orbit { position: absolute; border: 1px solid var(--orbit); border-radius: 50%; inset: 11%; opacity: .7; }
+.orbit-a { transform: rotate(-29deg) scaleY(.42); }
+.orbit-b { transform: rotate(31deg) scaleY(.58); }
+.orbit-c { transform: rotate(86deg) scaleY(.72); opacity: .35; }
+.orbit-d { inset: 19%; border-style: dashed; border-width: 1px; opacity: .3; animation: revolve 90s linear infinite; }
+.monogram { position: absolute; inset: 36%; display: flex; align-items: center; justify-content: center; gap: 9%; transform: rotate(-16deg) skew(-11deg); }
+.monogram i { display: block; width: 17%; height: 69%; border-radius: 30px; background: var(--accent); box-shadow: 5px 9px 0 color-mix(in srgb, var(--accent) 9%, transparent); }
+.monogram i:nth-child(2) { height: 42%; }
+.satellite { position: absolute; width: 10px; height: 10px; border: 2px solid var(--paper); background: var(--accent); border-radius: 50%; box-shadow: 0 0 0 1px var(--orbit); }
+.satellite-a { left: 18%; top: 56%; }
+.satellite-b { right: 19%; top: 24%; width: 6px; height: 6px; border-width: 0; opacity: .7; }
+.orbit-caption { position: absolute; bottom: 5%; left: 26%; font-size: 9px; letter-spacing: 2px; line-height: 1.7; color: var(--muted); }
+.coordinate { position: absolute; top: 5%; right: 11%; writing-mode: vertical-rl; font-size: 8px; letter-spacing: 1.5px; color: var(--muted); }
+.footer-label { display: flex; align-items: center; gap: 12px; color: var(--muted); font-size: 10px; }
+.footer-line { width: 21px; height: 1px; background: var(--muted); }
+nav { display: flex; flex-wrap: wrap; gap: 12px 34px; align-items: center; padding: 19px 0 30px; border-bottom: 1px solid var(--line); }
+nav a { display: inline-flex; align-items: center; gap: 9px; min-height: 34px; font-size: 12px; color: var(--muted); }
+nav a:hover { color: var(--accent); }
+nav a > span:last-child { font-size: 12px; opacity: .55; }
+nav .star-link { color: var(--ink); }
+.star-link > span:first-child { font-size: 21px; }
+.signature { display: flex; justify-content: space-between; gap: 20px; margin: 19px 0 0; color: var(--muted); font-size: 8px; letter-spacing: 1.2px; }
+#completion { margin-top: 25px; }
+.complete-mark { color: var(--accent); border: 1px solid var(--line); border-radius: 50%; display: grid; place-items: center; width: 36px; height: 36px; }
+#completion h2 { margin: 16px 0 7px; font-size: 22px; font-weight: 500; }
+#completion p { font-size: 13px; color: var(--muted); line-height: 1.7; max-width: 390px; margin: 0 0 20px; }
+.star-success { min-height: 48px; font-size: 13px; }
+.sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; }
+@keyframes revolve { to { transform: rotate(360deg); } }
+@media (prefers-color-scheme: dark) {
+  :root { --paper: #131a16; --ink: #e7ebe1; --muted: #a0aa9e; --line: #344237; --field: #1a231d; --accent: #b8d798; --accent-text: #182618; --soft: #334936; --orbit: #778e68; --focus: #95bdf0; }
+  .disc { opacity: .72; }
+  .monogram i { box-shadow: 5px 9px 0 #b8d7980b; }
+  #status[data-error="true"] { color: #f5a395; }
+}
+@media (max-width: 760px) {
+  .shell { padding: max(24px, env(safe-area-inset-top)) 26px max(22px, env(safe-area-inset-bottom)); }
+  .brand { font-size: 19px; }
+  .language { gap: 6px; }
+  .language > span[aria-hidden] { display: none; }
+  main { display: block; min-height: 0; padding: 53px 0 39px; position: relative; }
+  .intro { max-width: none; }
+  .eyebrow { font-size: 9px; margin-bottom: 24px; letter-spacing: 1px; }
+  .edition { margin-left: auto; font-size: 8px; }
+  h1 { font-size: clamp(39px, 10.5vw, 58px); letter-spacing: -2px; max-width: 85%; }
+  :lang(ru) h1 { font-size: clamp(32px, 8.5vw, 52px); }
+  .subtitle { font-size: 12px; margin: 20px 0 32px; max-width: 86%; }
+  form, #status { max-width: none; }
+  .visual { position: absolute; right: -15px; top: 51px; width: 114px; z-index: 0; opacity: .25; pointer-events: none; }
+  .orbit-caption, .coordinate { display: none; }
+  .actions { gap: 22px; }
+  .primary { font-size: 13px; gap: 30px; }
+  .quiet { font-size: 12px; }
+  .privacy { font-size: 10px; }
+  nav { column-gap: 26px; row-gap: 5px; padding: 17px 0 22px; }
+  nav a { font-size: 11px; min-height: 40px; }
+  .signature { font-size: 7px; letter-spacing: .8px; }
+}
+@media (max-width: 350px) {
+  .shell { padding-left: 20px; padding-right: 20px; }
+  .actions { gap: 15px; }
+  .primary { padding: 13px; gap: 16px; }
+  nav { column-gap: 20px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation: none !important; transition: none !important; }
+}


### PR DESCRIPTION
## 实现

安装器恢复旧配置、更新模板并设置权限后，才判断是否需要收集订阅。已有 URL、本地订阅或独立配置时不打扰升级用户；移除每次安装无条件打开 README 的行为。

首次配置通过 kamfw `import launcher` / `launch url` 自动打开本机临时网页。作用域内补齐 Android 当前用户与 BROWSABLE 参数，并保留实际启动失败状态；不绑定浏览器包名。没有默认浏览器时由系统选择，被系统阻止时提供完整临时地址手动打开。通知仅为可选入口。

页面支持中文、英文、俄文、日文和韩文，自动跟随系统亮暗主题，包含留白布局、轨道动效、移动端适配和减少动态效果偏好。GitHub Star、使用指南、Discord 与作者的 LMM API 链接均已加入，不自动点赞，也不强制跳转。

仅保存 HTTPS 订阅文本，不在安装阶段下载订阅或启动内核。只监听 127.0.0.1，随机端口与一次性令牌，校验 Host/Origin、请求方法、大小和输入；原子写入且权限 0600。跳过、超时、缺少依赖及非交互/Recovery 场景继续安装，不修改 SELinux 或防火墙。

## 验证

- Linux 上 19 项真实 BusyBox HTTP/CGI 与 kamfw launcher 契约测试通过：保存、特殊字符原样保留、升级跳过、默认浏览器参数、失败回退、非法请求、符号链接拒绝、重复提交、超时和中断清理。
- Chromium 离线界面检查通过：5 种语言 × 3 种宽度（320/390/1440）× 2 种主题，共 30 种组合；加上交互共 38 项检查。界面测试的传输层为 mock；真实 HTTP/CGI 由上面的后端测试单独覆盖。
- 新增 Install Onboarding CI 工作流，运行 ShellCheck 与后端回归测试。
- 未做 Android 真机验证，也未把宿主机测试等同于 Magisk/KernelSU/APatch 的 SELinux、通知权限或 OEM 浏览器行为验证。

实现与兼容性边界见 `docs/install-onboarding.md`。

## Sourcery 摘要

引入可选且安全的首次安装订阅引导流程：打开本地多语言配置页面，同时保持升级兼容性和安装回退行为。

新功能：
- 在首次设置期间添加安装时引导页面，用于输入 HTTPS 订阅地址，并支持多语言、响应式布局、主题适配和减少动态效果。
- 通过系统浏览器使用 kamfw 打开临时引导页面，同时提供通知和手动 URL 回退方式。

Bug 修复：
- 防止升级和现有订阅配置被中断或覆盖，并移除安装后无条件启动 README 的行为。
- 当用户跳过引导、引导超时、不可用或启动失败时，仍可正常继续安装。

增强功能：
- 通过仅允许回环访问、使用能力令牌、验证请求、安全地原子发布内容、设置私有权限以及处理清理操作，强化本地引导界面的安全性。
- 通过仅暂存 HTTPS URL 而不下载订阅或启动 sing-box 核心，确保订阅数据保留在本地。

CI：
- 添加 Install Onboarding 工作流，运行 ShellCheck 以及 BusyBox HTTP/CGI/kamfw 契约测试。

文档：
- 记录引导行为、兼容性边界、配置控制项、本地界面安全性和验证要求。

测试：
- 添加全面的回归测试，覆盖引导流程、浏览器启动契约、安全边界、输入验证、现有数据保护、清理操作和安装程序门控。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

引入安全、可选的基于浏览器的订阅设置流程，用于首次安装，同时保留升级行为和安装回退机制。

新功能：
- 添加可选的首次安装订阅引导页面，该页面通过 kamfw 打开，并提供多语言、响应式、支持主题的浏览器界面以及手动回退处理。

错误修复：
- 在升级过程中保留现有的订阅和独立配置，并允许在跳过引导、引导不可用、超时或失败时继续安装。

增强功能：
- 通过仅允许回环访问、功能令牌、请求验证、原子化私有存储、清理机制，以及在安装期间不下载订阅或启动核心服务，来保护临时本地设置流程的安全。

CI：
- 添加 Install Onboarding 工作流，用于运行 ShellCheck 以及 BusyBox HTTP/CGI/kamfw 契约测试。

文档：
- 记录引导行为、配置控制项、安全边界、兼容性限制和验证要求。

测试：
- 添加针对引导门控、浏览器启动契约、输入验证、安全边界、现有数据保护和清理机制的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为首次安装引入安全、可选的基于浏览器的订阅设置流程，同时保持升级兼容性和安装回退行为。

新功能：
- 添加可选的首次安装浏览器引导页面，通过 kamfw 收集 HTTPS 订阅 URL，并支持多语言、响应式布局、主题适配和减少动态效果。

错误修复：
- 在升级过程中保留现有的订阅配置和独立配置，并允许在跳过引导、引导不可用、超时或失败时继续安装。
- 移除无条件启动安装后 README 的行为。

增强功能：
- 通过仅允许回环访问、能力令牌、请求验证、原子化私有存储、清理机制，以及安装期间不下载订阅或启动核心服务，来保护临时本地设置流程。

CI：
- 添加 Install Onboarding 工作流，运行 ShellCheck 和 BusyBox HTTP/CGI/kamfw 契约测试。

文档：
- 记录引导行为、配置控制项、安全边界、兼容性限制和验证要求。

测试：
- 添加针对引导条件、浏览器启动契约、输入验证、现有数据保护、安全边界和清理机制的回归测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

引入一个可选且安全的基于浏览器的订阅设置流程，用于首次安装，同时保持升级兼容性和安装回退行为。

新功能：
- 为首次安装添加可选的浏览器引导页面，通过 kamfw 收集 HTTPS 订阅 URL，并支持多语言、自适应布局、主题适配和减少动画。

错误修复：
- 在升级过程中保留现有的订阅和独立配置，并移除无条件启动安装后 README 的行为。
- 当用户跳过引导、引导超时、不可用或无法打开时，允许安装继续进行。

增强功能：
- 通过仅允许回环访问、能力令牌身份验证、请求验证、原子化私有存储、冲突保护和清理处理，保护临时本地设置流程的安全。
- 将安装流程限制为暂存 HTTPS URL，不下载订阅、不启动核心服务，也不修改 SELinux 或防火墙设置。

CI：
- 添加 Install Onboarding 工作流，运行 ShellCheck 以及真实的 BusyBox HTTP/CGI/kamfw 契约测试。

文档：
- 记录引导行为、配置控制项、安全边界、兼容性限制和验证要求。

测试：
- 添加针对引导条件、浏览器启动契约、输入验证、现有数据保护、安全边界和清理行为的回归测试。

杂项：
- 改进用于安装时引导变更的模拟 Magisk 冒烟测试夹具和诊断信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an optional, secure browser-based subscription setup flow for first-time installs while preserving upgrade compatibility and installation fallback behavior.

New Features:
- Add an optional first-install browser onboarding page for collecting an HTTPS subscription URL through kamfw, with multilingual, responsive, theme-aware, and reduced-motion support.

Bug Fixes:
- Preserve existing subscription and standalone configuration during upgrades and remove the unconditional post-install README launch.
- Allow installation to continue when onboarding is skipped, times out, is unavailable, or fails to open.

Enhancements:
- Secure the temporary local setup flow with loopback-only access, capability-token authentication, request validation, atomic private storage, conflict protection, and cleanup handling.
- Keep installation limited to staging the HTTPS URL without downloading subscriptions, starting the core, or changing SELinux or firewall settings.

CI:
- Add an Install Onboarding workflow that runs ShellCheck and real BusyBox HTTP/CGI/kamfw contract tests.

Documentation:
- Document onboarding behavior, configuration controls, security boundaries, compatibility limitations, and verification requirements.

Tests:
- Add regression coverage for onboarding gates, browser-launch contracts, input validation, existing-data protection, security boundaries, and cleanup behavior.

Chores:
- Improve fake Magisk smoke-test fixtures and diagnostics for the install-time onboarding changes.

</details>

</details>

</details>

</details>