### PR TITLE
feat(webui): Tailscale 可视化接入，无需手改 JSON

### DIFF
--- a/webui/about-overview.test.mjs
+++ b/webui/about-overview.test.mjs
@@ -80,7 +80,7 @@ assert.match(app, /type TabKey =[\s\S]*"about"/);
 assert.match(app, /import\("@\/components\/pages\/AboutPage\.vue"\)/);
 assert.match(app, /key: "about", label: "流量路径"/);
 assert.match(app, /@goto-tab="setTab"/);
-assert.match(app, /<KeepAlive :max="11">/);
+assert.match(app, /<KeepAlive :max="12">/);
 
 const controlPage = readFileSync(
   new URL("./src/components/pages/ControlPage.vue", import.meta.url),

--- a/webui/e2e/i18n.spec.mjs
+++ b/webui/e2e/i18n.spec.mjs
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-const tabs = ['control', 'about', 'apps', 'block', 'chain', 'subs', 'config', 'webui', 'health', 'tools', 'output'];
+const tabs = ['control', 'about', 'apps', 'block', 'chain', 'subs', 'tailscale', 'config', 'webui', 'health', 'tools', 'output'];
 async function changeLanguage(page, language) {
   const header = page.locator('.mn-language-header select');
   if (await header.isVisible()) {

--- a/webui/e2e/tailscale.spec.mjs
+++ b/webui/e2e/tailscale.spec.mjs
@@ -1,0 +1,119 @@
+import { expect, test } from "@playwright/test";
+
+const authKey = ["tskey", "auth", "browser-fixture-not-real"].join("-");
+async function mount(page, failure = "") {
+  await page.addInitScript(({ failure, authKey }) => {
+    localStorage.setItem("magicnet.webui.onboarding.v1", "dismissed");
+    const config = { outbounds: [{ type: "direct", tag: "direct" }], route: { final: "direct" } };
+    window.__tailscale = { config, payload: "", saves: 0, restarts: 0, removals: 0, failure };
+    window.ksu = {
+      spawn(command, _args, _options, callbackName) {
+        setTimeout(() => {
+          const callback = window[callbackName];
+          const fixture = window.__tailscale;
+          let output = "";
+          let errno = 0;
+          if (command.includes("config-editor get sing-box")) output = JSON.stringify(fixture.config);
+          else if (command.includes("webui payload create tmp")) {
+            const basename = command.match(/tailscale-[0-9]+-[a-z0-9]+\.json/)?.[0];
+            fixture.payload = "";
+            output = `/data/adb/modules/MagicNet/.tmp/webui-payload/${basename}`;
+          } else if (command.includes("webui payload append tmp")) {
+            const chunks = command.match(/[a-zA-Z0-9+/]{32,}={0,2}/g);
+            fixture.payload += new TextDecoder().decode(Uint8Array.from(atob(chunks.at(-1)), (char) => char.charCodeAt(0)));
+          } else if (command.includes("webui payload remove tmp")) fixture.removals += 1;
+          else if (command.includes("config-editor save-file sing-box")) {
+            fixture.saves += 1;
+            if (fixture.failure === "validation") { errno = 1; output = `private validator detail ${authKey}`; }
+            else {
+              fixture.config = JSON.parse(fixture.payload);
+              fixture.config.endpoints.forEach((endpoint) => { delete endpoint.auth_key; });
+              output = "[info] Saved and validated sing-box config";
+            }
+          } else if (command.includes("service restart sing-box")) {
+            fixture.restarts += 1;
+            if (fixture.failure === "restart") errno = 1;
+          }
+          if (output) callback.stdout.emit("data", output);
+          callback.emit("exit", errno);
+        }, command.includes("config-editor save-file") ? 120 : 0);
+      },
+    };
+  }, { failure, authKey });
+  await page.goto("/#/tailscale", { waitUntil: "networkidle" });
+  await expect(page.getByLabel("设备名称", { exact: true })).toBeEnabled();
+}
+
+async function fill(page) {
+  await page.getByLabel("设备名称", { exact: true }).fill("my-phone");
+  await page.getByLabel("Auth key", { exact: true }).fill(authKey);
+}
+async function expectNoSecret(page) {
+  await expect(page.getByLabel("Auth key", { exact: true })).toHaveValue("");
+  const displayed = await page.evaluate(async () => {
+    const { state } = (await import("/src/composables/useMagicNet.ts")).useMagicNet();
+    return [state.output, state.notice, state.lastCommand, JSON.stringify(state.operationCapture), JSON.stringify(localStorage), JSON.stringify(sessionStorage), document.body.innerText].join("\n");
+  });
+  expect(displayed).not.toContain(authKey);
+}
+
+test("connects without JSON editing, prevents duplicate submission and keeps secrets private", async ({ page }) => {
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  await mount(page);
+  await fill(page);
+  await page.locator(".tailscale-page form").evaluate((form) => {
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+  });
+  await expect(page.getByRole("status").filter({ hasText: "配置已保存，核心已重启" })).toBeVisible();
+  expect(await page.evaluate(() => ({ saves: window.__tailscale.saves, restarts: window.__tailscale.restarts, removals: window.__tailscale.removals }))).toEqual({ saves: 1, restarts: 1, removals: 1 });
+  expect(await page.evaluate(() => window.__tailscale.config.endpoints[0].hostname)).toBe("my-phone");
+  await expectNoSecret(page);
+  expect(await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1)).toBe(false);
+  expect(errors).toEqual([]);
+});
+
+test("validation failure does not restart or expose validator output", async ({ page }) => {
+  await mount(page, "validation");
+  await fill(page);
+  await page.getByRole("button", { name: "接入并重启", exact: true }).click();
+  await expect(page.getByRole("alert").filter({ hasText: "配置保存未确认" })).toBeVisible();
+  expect(await page.evaluate(() => window.__tailscale.restarts)).toBe(0);
+  expect(await page.evaluate(() => window.__tailscale.removals)).toBe(1);
+  await expectNoSecret(page);
+});
+
+test("restart failure can be retried without another key or config save", async ({ page }) => {
+  await mount(page, "restart");
+  await fill(page);
+  await page.getByRole("button", { name: "接入并重启", exact: true }).click();
+  await expect(page.getByRole("alert").filter({ hasText: "配置已保存，但核心重启失败" })).toBeVisible();
+  await page.evaluate(() => { window.__tailscale.failure = ""; });
+  await page.getByRole("button", { name: "重试重启核心", exact: true }).click();
+  await expect(page.getByRole("status").filter({ hasText: "配置已保存，核心已重启" })).toBeVisible();
+  expect(await page.evaluate(() => ({ saves: window.__tailscale.saves, restarts: window.__tailscale.restarts }))).toEqual({ saves: 1, restarts: 2 });
+  await expectNoSecret(page);
+});
+
+test("leaving the cached page clears only the key, not the device-name draft", async ({ page }) => {
+  await mount(page);
+  await fill(page);
+  await page.evaluate(() => { window.location.hash = "/output"; });
+  await expect(page.locator(".page-surface")).toHaveAttribute("data-page", "output");
+  await page.evaluate(() => { window.location.hash = "/tailscale"; });
+  await expect(page.getByLabel("设备名称", { exact: true })).toHaveValue("my-phone");
+  await expectNoSecret(page);
+});
+
+test("unsaved JSON editor work blocks the form instead of being discarded", async ({ page }) => {
+  await mount(page);
+  await page.evaluate(async () => {
+    const { state } = (await import("/src/composables/useMagicNet.ts")).useMagicNet();
+    state.config.text = '{"myDraft":true}';
+    state.config.dirty = true;
+  });
+  await expect(page.getByRole("button", { name: "接入并重启", exact: true })).toBeDisabled();
+  await expect(page.getByRole("alert").filter({ hasText: "配置编辑器还有未保存" })).toBeVisible();
+  expect(await page.evaluate(() => window.__tailscale.saves)).toBe(0);
+});

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -30,7 +30,7 @@ import { useTheme } from "@/composables/useTheme";
 import { useMobileKeyboard } from "@/composables/useMobileKeyboard";
 import { restoreFocusAfterUpdate, trapFocusWithin } from "@/lib/focus";
 
-type TabKey = "control" | "about" | "config" | "apps" | "block" | "chain" | "subs" | "tools" | "health" | "webui" | "output";
+type TabKey = "control" | "tailscale" | "about" | "config" | "apps" | "block" | "chain" | "subs" | "tools" | "health" | "webui" | "output";
 type WorkspaceKey = "run" | "route" | "configure" | "diagnose";
 type OnboardingPreference = "dismissed" | "completed";
 
@@ -52,6 +52,7 @@ const ONBOARDING_STORAGE_KEY = "magicnet.webui.onboarding.v1";
 const pageLoaders: Record<TabKey, () => Promise<{ default: Component }>> = {
   control: () => import("@/components/pages/ControlPage.vue"),
   about: () => import("@/components/pages/AboutPage.vue"),
+  tailscale: () => import("@/components/pages/TailscalePage.vue"),
   config: () => import("@/components/pages/ConfigPage.vue"),
   apps: () => import("@/components/pages/AppsPage.vue"),
   block: () => import("@/components/pages/BlocklistPage.vue"),
@@ -82,6 +83,7 @@ const tabs: readonly TabDefinition[] = [
   { key: "block", label: "拦截规则", workspace: "route" },
   { key: "chain", label: "链式代理", workspace: "route" },
   { key: "subs", label: "订阅", workspace: "configure" },
+  { key: "tailscale", label: "Tailscale", workspace: "configure" },
   { key: "config", label: "配置文件", workspace: "configure" },
   { key: "webui", label: "管理面板", workspace: "configure" },
   { key: "health", label: "健康检查", workspace: "diagnose" },
@@ -604,7 +606,7 @@ onUnmounted(() => {
         <!-- KeepAlive preserves form state across all four workspaces. -->
         <section class="page-surface" :data-page="activeTab">
           <Suspense>
-            <KeepAlive :max="11">
+            <KeepAlive :max="12">
               <component
                 :is="activeComponent"
                 @goto-output="setTab('output')"

--- a/webui/src/components/pages/TailscalePage.vue
+++ b/webui/src/components/pages/TailscalePage.vue
@@ -97,7 +97,7 @@ async function submit(): Promise<void> {
     }
     message.value = resultMessage(result);
     hasError.value = result.stage !== "done";
-    if (result.stage === "done" || result.stage === "restart") await refreshStatus(true);
+    if (result.stage === "done" || result.stage === "restart") await refreshStatus(undefined, false);
   } finally {
     draft.authKey = "";
     saving.value = false;
@@ -110,7 +110,7 @@ async function retryRestart(): Promise<void> {
     const outcome = await runPrivateCli("service restart sing-box", t("重启核心"), "service restart sing-box");
     message.value = resultMessage({ stage: outcome.ok ? "done" : "restart", saved: true });
     hasError.value = !outcome.ok;
-    await refreshStatus(true);
+    await refreshStatus(undefined, false);
   } finally { saving.value = false; }
 }
 function discardDraft(): void {

--- a/webui/src/components/pages/TailscalePage.vue
+++ b/webui/src/components/pages/TailscalePage.vue
@@ -1,0 +1,179 @@
+<script setup lang="ts">
+import { computed, onDeactivated, onMounted, ref, watch } from "vue";
+import { ArrowUpRight, KeyRound, RefreshCw } from "lucide-vue-next";
+import { t } from "@/i18n";
+import Button from "@/components/ui/Button.vue";
+import Input from "@/components/ui/Input.vue";
+import PageHeader from "@/components/ui/PageHeader.vue";
+import { useMagicNet } from "@/composables/useMagicNet";
+import {
+  inspectTailscale, saveTailscale, TailscaleSetupError,
+  TAILSCALE_KEYS_URL, TAILSCALE_MACHINES_URL,
+  type SaveResult, type SetupErrorCode, type TailscaleSnapshot,
+} from "./tailscaleSetup";
+
+const { state, runPrivateCli, stagePrivatePayload, removePrivatePayload, shellQuote, openExternal, refreshStatus } = useMagicNet();
+const snapshot = ref<TailscaleSnapshot | null>(null);
+const hostname = ref("magicnet-phone");
+const authKey = ref("");
+const loading = ref(false);
+const saving = ref(false);
+const edited = ref(false);
+const message = ref("");
+const hasError = ref(false);
+let attemptedRead = false;
+const locked = computed(() => loading.value || saving.value || state.busy || !state.hasKsu);
+const customControl = computed(() => Boolean(snapshot.value && snapshot.value.controlUrl.replace(/\/$/, "") !== "https://controlplane.tailscale.com"));
+const saveDisabled = computed(() => locked.value || !snapshot.value || state.config.dirty || customControl.value);
+
+function errorMessage(code?: SetupErrorCode): string {
+  switch (code) {
+    case "hostname": return t("设备名称需为 1–63 位字母、数字或短横线，首尾不能是短横线。");
+    case "auth-key": return t("请填写以 tskey-auth- 开头的 Tailscale Auth key。");
+    case "multiple": return t("检测到多个 Tailscale 节点，请使用配置编辑器管理，避免修改错误的网络。");
+    case "custom-control": return t("当前节点使用自建控制服务器，此入口不会覆盖它或向它发送 Tailscale 密钥。");
+    case "conflict": return t("配置已在其他位置修改，请重新读取后再保存。");
+    default: return t("无法读取有效的 sing-box 配置，请先检查核心配置。");
+  }
+}
+function resultMessage(result: SaveResult): string {
+  if (result.error) return errorMessage(result.error);
+  switch (result.stage) {
+    case "done": return t("配置已保存，核心已重启。请在设备后台确认授权和在线状态。");
+    case "restart": return t("配置已保存，但核心重启失败。可重试重启，无需再次填写密钥。");
+    case "cleanup": return result.saved
+      ? t("配置已保存，但私密临时文件清理未确认，未重启核心。")
+      : t("私密临时文件清理未确认，请检查设备状态后重试。");
+    case "conflict": return errorMessage("conflict");
+    case "stage": return t("私密数据传输失败，配置未保存。");
+    case "validate": return t("配置保存未确认，未重启。请检查内核是否支持 Tailscale。");
+    default: return errorMessage();
+  }
+}
+async function read(): Promise<void> {
+  if (locked.value || edited.value) return;
+  attemptedRead = true;
+  loading.value = true;
+  hasError.value = false;
+  try {
+    const result = await runPrivateCli("config-editor get sing-box", t("读取 Tailscale 配置"), "config-editor get sing-box [private-output]");
+    if (!result.ok) throw new TailscaleSetupError("config");
+    const current = inspectTailscale(result.stdout);
+    snapshot.value = current;
+    hostname.value = current.hostname;
+    message.value = "";
+  } catch (cause) {
+    snapshot.value = null;
+    hasError.value = true;
+    message.value = errorMessage(cause instanceof TailscaleSetupError ? cause.code : undefined);
+  } finally { loading.value = false; }
+}
+async function submit(): Promise<void> {
+  if (saveDisabled.value || !snapshot.value) return;
+  saving.value = true;
+  hasError.value = false;
+  message.value = t("正在校验并接入 Tailscale…");
+  const draft = { hostname: hostname.value, authKey: authKey.value };
+  authKey.value = "";
+  try {
+    const result = await saveTailscale({
+      run: (args) => runPrivateCli(args, t("配置 Tailscale"), args.startsWith("config-editor save-file")
+        ? "config-editor save-file sing-box [private-payload]" : `${args} [private-output]`),
+      stage: (text) => stagePrivatePayload("tmp", `tailscale-${Date.now()}-${Math.random().toString(36).slice(2, 10)}.json`, text, t("Tailscale 私密配置")),
+      remove: (name) => removePrivatePayload("tmp", name, t("Tailscale 私密配置")),
+      quote: shellQuote,
+      canSave: () => !state.config.dirty,
+    }, draft, snapshot.value);
+    if (result.saved && result.snapshot) {
+      snapshot.value = result.snapshot;
+      edited.value = false;
+      // An inactive, clean JSON editor must not later save a stale copy over
+      // the endpoint. Never discard an unsaved editor draft.
+      if (!state.config.dirty) {
+        state.config.text = "";
+        state.config.status = t("Tailscale 已更新，请重新加载配置。");
+        state.config.validation = { status: "idle", summary: state.config.status, checkedAt: "" };
+      }
+    }
+    message.value = resultMessage(result);
+    hasError.value = result.stage !== "done";
+    if (result.stage === "done" || result.stage === "restart") await refreshStatus(true);
+  } finally {
+    draft.authKey = "";
+    saving.value = false;
+  }
+}
+async function retryRestart(): Promise<void> {
+  if (locked.value) return;
+  saving.value = true;
+  try {
+    const outcome = await runPrivateCli("service restart sing-box", t("重启核心"), "service restart sing-box");
+    message.value = resultMessage({ stage: outcome.ok ? "done" : "restart", saved: true });
+    hasError.value = !outcome.ok;
+    await refreshStatus(true);
+  } finally { saving.value = false; }
+}
+function discardDraft(): void {
+  authKey.value = "";
+  edited.value = false;
+  void read();
+}
+onMounted(() => { void read(); });
+watch(() => state.busy, (busy) => { if (!busy && !attemptedRead) void read(); });
+// KeepAlive retains the page, but never retains a password when leaving it.
+onDeactivated(() => { authKey.value = ""; });
+</script>
+
+<template>
+  <div class="tailscale-page space-y-8">
+    <PageHeader title="Tailscale">
+      <Button variant="ghost" :disabled="locked || edited" :loading="loading" @click="read">
+        <RefreshCw :size="16" aria-hidden="true" />{{ t("重新读取") }}
+      </Button>
+    </PageHeader>
+    <p v-if="!state.hasKsu" class="text-sm text-[var(--mn-ink-muted)]">{{ t("请在支持 KernelSU 异步接口的真机 WebUI 中接入。") }}</p>
+    <div v-if="snapshot" class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+      <span class="text-xl font-medium">{{ t(snapshot.configured ? "已配置" : "连接你的设备") }}</span>
+      <span class="text-sm text-[var(--mn-ink-muted)]">{{ snapshot.configured ? snapshot.hostname : t("使用自己的 Tailscale 账号") }}</span>
+    </div>
+    <p v-if="state.config.dirty" role="alert" class="text-sm text-[var(--mn-warning)]">{{ t("配置编辑器还有未保存的修改，请先处理后再接入。") }}</p>
+    <p v-if="customControl" role="alert" class="text-sm text-[var(--mn-warning)]">{{ errorMessage("custom-control") }}</p>
+    <form class="max-w-xl space-y-7" @submit.prevent="submit" @input="edited = true" @change="edited = true">
+      <fieldset :disabled="locked || !snapshot || customControl" class="min-w-0 space-y-7">
+        <div class="space-y-2">
+          <label for="tailscale-hostname" class="block text-sm font-medium">{{ t("设备名称") }}</label>
+          <Input id="tailscale-hostname" v-model="hostname" autocomplete="off" autocapitalize="none" :spellcheck="false" maxlength="63" required />
+        </div>
+        <div class="space-y-2">
+          <div class="flex flex-wrap items-center justify-between gap-2">
+            <label for="tailscale-key" class="text-sm font-medium">Auth key</label>
+            <Button variant="ghost" size="sm" @click="openExternal(TAILSCALE_KEYS_URL)">
+              <KeyRound :size="15" aria-hidden="true" />{{ t("获取密钥") }}<ArrowUpRight :size="14" aria-hidden="true" />
+            </Button>
+          </div>
+          <Input id="tailscale-key" v-model="authKey" type="password" autocomplete="new-password" autocapitalize="none" :spellcheck="false" maxlength="251" :required="!snapshot?.configured" placeholder="tskey-auth-…" aria-describedby="tailscale-key-note" />
+          <p id="tailscale-key-note" class="text-xs leading-5 text-[var(--mn-ink-muted)]">{{ t(snapshot?.configured ? "留空保留当前登录。新密钥不会自动切换已登录账号。" : "使用你账号生成的 Auth key，不要使用 API access token。") }}</p>
+        </div>
+        <details class="border-t border-[var(--mn-border)] pt-3">
+          <summary class="min-h-12 cursor-pointer content-center text-sm">{{ t("高级选项") }}</summary>
+          <dl v-if="snapshot" class="mt-3 space-y-3 text-xs leading-5 text-[var(--mn-ink-muted)]">
+            <div><dt>{{ t("节点标识") }}</dt><dd class="break-all font-mono">{{ snapshot.tag }}</dd></div>
+            <div><dt>{{ t("控制服务器") }}</dt><dd class="break-all font-mono">{{ snapshot.controlUrl }}</dd></div>
+          </dl>
+        </details>
+      </fieldset>
+      <div class="flex flex-wrap gap-3">
+        <Button type="submit" :disabled="saveDisabled" :loading="saving">{{ t(snapshot?.configured ? "保存并重启" : "接入并重启") }}</Button>
+        <Button v-if="edited" variant="ghost" :disabled="locked" @click="discardDraft">{{ t("放弃修改并重新读取") }}</Button>
+      </div>
+      <p class="text-xs leading-5 text-[var(--mn-ink-muted)]">{{ t("重启会短暂中断现有连接。配置保留在本机。") }}</p>
+    </form>
+    <div v-if="message" :role="hasError ? 'alert' : 'status'" aria-live="polite" class="max-w-xl text-sm leading-6" :class="hasError ? 'text-[var(--mn-danger)]' : 'text-[var(--mn-ink-muted)]'">
+      {{ message }}
+    </div>
+    <div class="flex flex-wrap gap-3 border-t border-[var(--mn-border)] pt-5">
+      <Button variant="outline" @click="openExternal(TAILSCALE_MACHINES_URL)">{{ t("设备后台") }}<ArrowUpRight :size="16" aria-hidden="true" /></Button>
+      <Button v-if="snapshot?.configured && !customControl" variant="ghost" :disabled="locked" @click="retryRestart">{{ t("重试重启核心") }}</Button>
+    </div>
+  </div>
+</template>

--- a/webui/src/components/pages/tailscaleSetup.ts
+++ b/webui/src/components/pages/tailscaleSetup.ts
@@ -1,0 +1,170 @@
+/** Tailscale onboarding uses the existing private config-editor transaction. */
+export const TAILSCALE_KEYS_URL = "https://login.tailscale.com/admin/settings/keys";
+export const TAILSCALE_MACHINES_URL = "https://login.tailscale.com/admin/machines";
+const CONTROL_URL = "https://controlplane.tailscale.com";
+const STATE_DIRECTORY = "/data/adb/modules/MagicNet/.state/sing-box/tailscale";
+type JsonObject = Record<string, unknown>;
+
+export type TailscaleDraft = { hostname: string; authKey: string };
+export type TailscaleSnapshot = {
+  configured: boolean;
+  hostname: string;
+  tag: string;
+  controlUrl: string;
+  endpointRevision: string;
+};
+export type SetupErrorCode = "config" | "multiple" | "hostname" | "auth-key" | "conflict" | "custom-control";
+export class TailscaleSetupError extends Error {
+  readonly code: SetupErrorCode;
+  constructor(code: SetupErrorCode) {
+    // Do not put parser errors, configuration text or credentials in errors.
+    super(code);
+    this.code = code;
+  }
+}
+
+function object(value: unknown): value is JsonObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function parseConfig(text: string): JsonObject {
+  try {
+    const config: unknown = JSON.parse(text);
+    if (!object(config) || (config.endpoints !== undefined && !Array.isArray(config.endpoints))) {
+      throw new TailscaleSetupError("config");
+    }
+    if ((config.endpoints as unknown[] | undefined)?.some((item) => !object(item))) {
+      throw new TailscaleSetupError("config");
+    }
+    return config;
+  } catch {
+    throw new TailscaleSetupError("config");
+  }
+}
+function endpointOf(config: JsonObject): JsonObject | undefined {
+  const endpoints = (config.endpoints ?? []) as JsonObject[];
+  const matches = endpoints.filter((item) => item.type === "tailscale");
+  // Runtime routing currently chooses the first tailnet. Never silently edit
+  // an arbitrary network when a power user has configured several endpoints.
+  if (matches.length > 1) throw new TailscaleSetupError("multiple");
+  if (matches[0] && (typeof matches[0].tag !== "string" || !matches[0].tag)) {
+    throw new TailscaleSetupError("config");
+  }
+  return matches[0];
+}
+function withoutAuth(endpoint: JsonObject): JsonObject {
+  const copy = { ...endpoint };
+  delete copy.auth_key;
+  return copy;
+}
+function revision(endpoint?: JsonObject): string {
+  if (!endpoint) return "";
+  const copy = withoutAuth(endpoint);
+  return JSON.stringify(Object.fromEntries(Object.keys(copy).sort().map((key) => [key, copy[key]])));
+}
+function availableTag(config: JsonObject): string {
+  const used = new Set(["inbounds", "outbounds", "endpoints"].flatMap((key) =>
+    Array.isArray(config[key]) ? config[key].filter(object).map((item) => item.tag) : [],
+  ));
+  let tag = "magicnet-tailscale";
+  for (let suffix = 2; used.has(tag); suffix += 1) tag = `magicnet-tailscale-${suffix}`;
+  return tag;
+}
+
+export function inspectTailscale(text: string): TailscaleSnapshot {
+  const config = parseConfig(text);
+  const endpoint = endpointOf(config);
+  return {
+    configured: Boolean(endpoint),
+    hostname: typeof endpoint?.hostname === "string" ? endpoint.hostname : "magicnet-phone",
+    tag: endpoint ? String(endpoint.tag) : availableTag(config),
+    controlUrl: typeof endpoint?.control_url === "string" && endpoint.control_url ? endpoint.control_url : CONTROL_URL,
+    endpointRevision: revision(endpoint),
+  };
+}
+
+export function buildTailscaleConfig(text: string, draft: TailscaleDraft, baseline: TailscaleSnapshot): string {
+  const config = parseConfig(text);
+  const endpoint = endpointOf(config);
+  if (revision(endpoint) !== baseline.endpointRevision) throw new TailscaleSetupError("conflict");
+  const hostname = draft.hostname.trim();
+  if (!/^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/.test(hostname)) {
+    throw new TailscaleSetupError("hostname");
+  }
+  const authKey = draft.authKey.trim();
+  if ((!endpoint && !authKey) || (authKey && !/^tskey-auth-[a-zA-Z0-9-]{1,240}$/.test(authKey))) {
+    throw new TailscaleSetupError("auth-key");
+  }
+  // This form issues official Tailscale keys; never send them to a preexisting
+  // custom control server. Existing custom endpoints can still be inspected.
+  const controlUrl = typeof endpoint?.control_url === "string" && endpoint.control_url ? endpoint.control_url : CONTROL_URL;
+  if (controlUrl.replace(/\/$/, "") !== CONTROL_URL) throw new TailscaleSetupError("custom-control");
+  const next: JsonObject = {
+    ...(endpoint ?? { ephemeral: false, accept_routes: false }),
+    type: "tailscale",
+    tag: endpoint?.tag ?? availableTag(config),
+    hostname,
+    system_interface: false,
+    state_directory: endpoint?.state_directory || STATE_DIRECTORY,
+  };
+  if (authKey) next.auth_key = authKey;
+  const endpoints = (config.endpoints ?? []) as JsonObject[];
+  config.endpoints = endpoint ? endpoints.map((item) => item === endpoint ? next : item) : [...endpoints, next];
+  return `${JSON.stringify(config, null, 2)}\n`;
+}
+
+export type PrivateResult = { ok: boolean; stdout: string };
+export type TailscaleClient = {
+  run: (args: string) => Promise<PrivateResult>;
+  stage: (text: string) => Promise<{ path: string; basename: string } | null>;
+  remove: (basename: string) => Promise<boolean>;
+  quote: (value: string) => string;
+  canSave: () => boolean;
+};
+export type SaveStage = "read" | "stage" | "conflict" | "validate" | "cleanup" | "restart" | "done";
+export type SaveResult = { stage: SaveStage; saved: boolean; snapshot?: TailscaleSnapshot; error?: SetupErrorCode };
+
+export async function saveTailscale(
+  client: TailscaleClient,
+  draft: TailscaleDraft,
+  baseline: TailscaleSnapshot,
+): Promise<SaveResult> {
+  let payload: { path: string; basename: string } | null = null;
+  let stage: SaveStage = "read";
+  let saved = false;
+  let snapshot: TailscaleSnapshot | undefined;
+  let error: SetupErrorCode | undefined;
+  try {
+    if (!client.canSave()) return { stage: "conflict", saved };
+    const current = await client.run("config-editor get sing-box");
+    if (!current.ok) return { stage, saved };
+    const candidate = buildTailscaleConfig(current.stdout, draft, baseline);
+    snapshot = inspectTailscale(candidate);
+    stage = "stage";
+    payload = await client.stage(candidate);
+    if (!payload) return { stage, saved: false };
+    stage = "conflict";
+    // Read again after potentially chunked transport. Do not apply an old
+    // whole-config snapshot after a subscription or another editor changed it.
+    const latest = await client.run("config-editor get sing-box");
+    if (latest.ok && latest.stdout === current.stdout && client.canSave()) {
+      stage = "validate";
+      const result = await client.run(`config-editor save-file sing-box ${client.quote(payload.path)}`);
+      saved = result.ok && /\[info\]\s+Saved and validated\b/i.test(result.stdout);
+    }
+  } catch (cause) {
+    if (cause instanceof TailscaleSetupError) error = cause.code;
+  } finally {
+    if (payload) {
+      let cleaned = false;
+      try { cleaned = await client.remove(payload.basename); } catch { /* Report below without private output. */ }
+      if (!cleaned) stage = "cleanup";
+    }
+  }
+  if (!saved || stage === "cleanup") return { stage, saved, error, ...(saved ? { snapshot } : {}) };
+  try {
+    const result = await client.run("service restart sing-box");
+    return { stage: result.ok ? "done" : "restart", saved, snapshot };
+  } catch {
+    return { stage: "restart", saved, snapshot };
+  }
+}

--- a/webui/src/i18n/catalogs/tailscale.ts
+++ b/webui/src/i18n/catalogs/tailscale.ts
@@ -103,10 +103,6 @@ export default {
     "Use an auth key from your account, not an API access token.",
     "Используйте ключ авторизации своего аккаунта, а не токен доступа API."
   ],
-  "接受子网路由": [
-    "Accept subnet routes",
-    "Принимать маршруты подсетей"
-  ],
   "节点标识": [
     "Endpoint tag",
     "Метка узла"
@@ -134,5 +130,17 @@ export default {
   "重试重启核心": [
     "Retry core restart",
     "Повторить перезапуск ядра"
+  ],
+  "重启核心": [
+    "Restart core",
+    "Перезапустить ядро"
+  ],
+  "已配置": [
+    "Configured",
+    "Настроено"
+  ],
+  "高级选项": [
+    "Advanced",
+    "Дополнительно"
   ]
 } satisfies Record<string, readonly string[]>;

--- a/webui/src/i18n/catalogs/tailscale.ts
+++ b/webui/src/i18n/catalogs/tailscale.ts
@@ -1,0 +1,138 @@
+export default {
+  "Tailscale": [
+    "Tailscale",
+    "Tailscale"
+  ],
+  "设备名称需为 1–63 位字母、数字或短横线，首尾不能是短横线。": [
+    "Use 1–63 letters, digits or hyphens, with no leading or trailing hyphen.",
+    "Используйте 1–63 буквы, цифры или дефисы, без дефиса в начале и конце."
+  ],
+  "请填写以 tskey-auth- 开头的 Tailscale Auth key。": [
+    "Enter a Tailscale auth key beginning with tskey-auth-.",
+    "Введите ключ Tailscale, начинающийся с tskey-auth-."
+  ],
+  "检测到多个 Tailscale 节点，请使用配置编辑器管理，避免修改错误的网络。": [
+    "Multiple Tailscale endpoints found. Use the config editor to avoid changing the wrong network.",
+    "Обнаружено несколько узлов Tailscale. Используйте редактор конфигурации, чтобы не изменить другую сеть."
+  ],
+  "当前节点使用自建控制服务器，此入口不会覆盖它或向它发送 Tailscale 密钥。": [
+    "This endpoint uses a custom control server. This form will not overwrite it or send it a Tailscale key.",
+    "Этот узел использует собственный сервер управления. Форма не изменит его и не отправит ему ключ Tailscale."
+  ],
+  "配置已在其他位置修改，请重新读取后再保存。": [
+    "Configuration changed elsewhere. Reload it before saving.",
+    "Конфигурация изменена в другом месте. Загрузите её заново перед сохранением."
+  ],
+  "无法读取有效的 sing-box 配置，请先检查核心配置。": [
+    "Could not read a valid sing-box configuration. Check the core configuration first.",
+    "Не удалось прочитать корректную конфигурацию sing-box. Проверьте конфигурацию ядра."
+  ],
+  "配置已保存，核心已重启。请在设备后台确认授权和在线状态。": [
+    "Configuration saved and core restarted. Confirm authorization and online status in the device console.",
+    "Конфигурация сохранена, ядро перезапущено. Проверьте авторизацию и состояние устройства в консоли."
+  ],
+  "配置已保存，但核心重启失败。可重试重启，无需再次填写密钥。": [
+    "Configuration saved, but the core restart failed. Retry restarting without entering the key again.",
+    "Конфигурация сохранена, но перезапуск ядра не удался. Повторите перезапуск без повторного ввода ключа."
+  ],
+  "配置已保存，但私密临时文件清理未确认，未重启核心。": [
+    "Configuration saved, but private temporary-file cleanup was not confirmed. The core was not restarted.",
+    "Конфигурация сохранена, но удаление приватного временного файла не подтверждено. Ядро не перезапущено."
+  ],
+  "私密临时文件清理未确认，请检查设备状态后重试。": [
+    "Private temporary-file cleanup was not confirmed. Check the device before retrying.",
+    "Удаление приватного временного файла не подтверждено. Проверьте устройство перед повторной попыткой."
+  ],
+  "私密数据传输失败，配置未保存。": [
+    "Private payload transfer failed. Configuration was not saved.",
+    "Не удалось передать приватные данные. Конфигурация не сохранена."
+  ],
+  "配置保存未确认，未重启。请检查内核是否支持 Tailscale。": [
+    "Saving was not confirmed; no restart was attempted. Check whether the core supports Tailscale.",
+    "Сохранение не подтверждено; перезапуск не выполнялся. Проверьте поддержку Tailscale в ядре."
+  ],
+  "读取 Tailscale 配置": [
+    "Read Tailscale configuration",
+    "Чтение конфигурации Tailscale"
+  ],
+  "正在校验并接入 Tailscale…": [
+    "Validating and setting up Tailscale…",
+    "Проверка и настройка Tailscale…"
+  ],
+  "配置 Tailscale": [
+    "Configure Tailscale",
+    "Настройка Tailscale"
+  ],
+  "Tailscale 私密配置": [
+    "Private Tailscale configuration",
+    "Приватная конфигурация Tailscale"
+  ],
+  "Tailscale 已更新，请重新加载配置。": [
+    "Tailscale updated. Reload the configuration.",
+    "Tailscale обновлён. Загрузите конфигурацию заново."
+  ],
+  "请在支持 KernelSU 异步接口的真机 WebUI 中接入。": [
+    "Connect from the device WebUI with KernelSU asynchronous bridge support.",
+    "Подключайтесь через WebUI устройства с поддержкой асинхронного интерфейса KernelSU."
+  ],
+  "连接你的设备": [
+    "Connect your devices",
+    "Подключите свои устройства"
+  ],
+  "使用自己的 Tailscale 账号": [
+    "Use your own Tailscale account",
+    "Используйте свой аккаунт Tailscale"
+  ],
+  "配置编辑器还有未保存的修改，请先处理后再接入。": [
+    "Resolve unsaved changes in the configuration editor before connecting.",
+    "Сначала сохраните или отмените изменения в редакторе конфигурации."
+  ],
+  "设备名称": [
+    "Device name",
+    "Имя устройства"
+  ],
+  "获取密钥": [
+    "Get an auth key",
+    "Получить ключ"
+  ],
+  "留空保留当前登录。新密钥不会自动切换已登录账号。": [
+    "Leave blank to keep the existing login. A new key does not switch an already signed-in account.",
+    "Оставьте пустым для сохранения текущего входа. Новый ключ не переключает уже авторизованный аккаунт."
+  ],
+  "使用你账号生成的 Auth key，不要使用 API access token。": [
+    "Use an auth key from your account, not an API access token.",
+    "Используйте ключ авторизации своего аккаунта, а не токен доступа API."
+  ],
+  "接受子网路由": [
+    "Accept subnet routes",
+    "Принимать маршруты подсетей"
+  ],
+  "节点标识": [
+    "Endpoint tag",
+    "Метка узла"
+  ],
+  "控制服务器": [
+    "Control server",
+    "Сервер управления"
+  ],
+  "接入并重启": [
+    "Connect and restart",
+    "Подключить и перезапустить"
+  ],
+  "放弃修改并重新读取": [
+    "Discard changes and reload",
+    "Отменить изменения и загрузить заново"
+  ],
+  "重启会短暂中断现有连接。配置保留在本机。": [
+    "Restarting briefly interrupts existing connections. Configuration stays on this device.",
+    "Перезапуск ненадолго прервёт текущие соединения. Конфигурация остаётся на устройстве."
+  ],
+  "设备后台": [
+    "Device console",
+    "Консоль устройств"
+  ],
+  "重试重启核心": [
+    "Retry core restart",
+    "Повторить перезапуск ядра"
+  ]
+} satisfies Record<string, readonly string[]>;

--- a/webui/src/i18n/messages.ts
+++ b/webui/src/i18n/messages.ts
@@ -5,6 +5,8 @@ import control from "./catalogs/control.ts";
 import tools from "./catalogs/tools.ts";
 import diagnostics from "./catalogs/diagnostics.ts";
 
+import tailscale from "./catalogs/tailscale.ts";
+
 export const messages: Record<string, readonly string[]> = {
   ...shell,
   ...routing,
@@ -12,4 +14,5 @@ export const messages: Record<string, readonly string[]> = {
   ...control,
   ...tools,
   ...diagnostics,
+  ...tailscale,
 };

--- a/webui/tailscale-setup.test.mjs
+++ b/webui/tailscale-setup.test.mjs
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { buildTailscaleConfig, inspectTailscale, saveTailscale, TailscaleSetupError } from "./src/components/pages/tailscaleSetup.ts";
+
+const key = ["tskey", "auth", "fixture-only-not-a-real-key"].join("-");
+const draft = () => ({ hostname: "my-phone", authKey: key });
+const original = () => JSON.stringify({
+  dns: { final: "local", servers: [{ tag: "local", type: "udp", server: "192.0.2.1" }] },
+  inbounds: [{ type: "tun", tag: "tun-in" }],
+  outbounds: [{ type: "direct", tag: "direct" }],
+  route: { final: "direct", rules: [{ domain: ["example.org"], outbound: "direct" }] },
+});
+const fixture = () => JSON.parse(buildTailscaleConfig(original(), draft(), inspectTailscale(original())));
+function code(fn, expected) {
+  assert.throws(fn, (error) => error instanceof TailscaleSetupError && error.code === expected && !error.message.includes(key));
+}
+
+test("creates a persistent userspace endpoint without changing unrelated configuration", () => {
+  const config = fixture();
+  const { endpoints, ...rest } = config;
+  assert.deepEqual(rest, JSON.parse(original()));
+  assert.equal(endpoints.length, 1);
+  assert.equal(endpoints[0].type, "tailscale");
+  assert.equal(endpoints[0].auth_key, key);
+  assert.equal(endpoints[0].system_interface, false);
+  assert.equal(endpoints[0].state_directory, "/data/adb/modules/MagicNet/.state/sing-box/tailscale");
+});
+
+test("repeated saves preserve tags, state and unknown endpoint options without keeping a key in the snapshot", () => {
+  const config = fixture();
+  config.endpoints[0].tag = "existing-tailnet";
+  config.endpoints[0].state_directory = "/existing/state";
+  config.endpoints[0].accept_routes = true;
+  config.endpoints[0].advertise_routes = ["192.168.9.0/24"];
+  const source = JSON.stringify(config);
+  const view = inspectTailscale(source);
+  assert.equal(JSON.stringify(view).includes(key), false);
+  const updated = JSON.parse(buildTailscaleConfig(source, { ...draft(), authKey: "" }, view));
+  assert.equal(updated.endpoints.length, 1);
+  assert.equal(updated.endpoints[0].tag, "existing-tailnet");
+  assert.equal(updated.endpoints[0].state_directory, "/existing/state");
+  assert.deepEqual(updated.endpoints[0].advertise_routes, ["192.168.9.0/24"]);
+  assert.equal(updated.endpoints[0].accept_routes, true);
+  assert.equal(updated.endpoints[0].auth_key, key); // Backend moves this into the protected key store.
+});
+
+test("avoids endpoint tag collisions and preserves other endpoint types", () => {
+  const config = JSON.parse(original());
+  config.outbounds.push({ tag: "magicnet-tailscale", type: "direct" });
+  config.endpoints = [{ tag: "magicnet-tailscale-2", type: "wireguard", address: ["192.0.2.2/32"] }];
+  const source = JSON.stringify(config);
+  const updated = JSON.parse(buildTailscaleConfig(source, draft(), inspectTailscale(source)));
+  assert.deepEqual(updated.endpoints[0], config.endpoints[0]);
+  assert.equal(updated.endpoints[1].tag, "magicnet-tailscale-3");
+});
+
+test("rejects invalid config, ambiguous tailnets and keys without leaking private inputs", () => {
+  for (const source of ["[]", "null", `{"secret":"${key}",`, '{"endpoints":{}}', '{"endpoints":[null]}']) {
+    code(() => inspectTailscale(source), "config");
+  }
+  const config = fixture();
+  config.endpoints.push({ type: "tailscale", tag: "second" });
+  code(() => inspectTailscale(JSON.stringify(config)), "multiple");
+  for (const hostname of ["", "-phone", "phone-", "x".repeat(64), "$(touch file)"]) {
+    code(() => buildTailscaleConfig(original(), { ...draft(), hostname }, inspectTailscale(original())), "hostname");
+  }
+  for (const authKey of ["", "tskey-api-not-an-auth-key", `${key}\ncommand`, "a".repeat(500)]) {
+    code(() => buildTailscaleConfig(original(), { ...draft(), authKey }, inspectTailscale(original())), "auth-key");
+  }
+});
+
+test("never sends an official auth key to a custom control server", () => {
+  const config = fixture();
+  config.endpoints[0].control_url = "https://example.org/headscale";
+  const source = JSON.stringify(config);
+  assert.equal(inspectTailscale(source).controlUrl, "https://example.org/headscale");
+  code(() => buildTailscaleConfig(source, draft(), inspectTailscale(source)), "custom-control");
+});
+
+test("refuses endpoint conflicts, while merging the latest unrelated configuration", () => {
+  const baseline = inspectTailscale(original());
+  const config = JSON.parse(original());
+  config.route.final = "updated";
+  const result = JSON.parse(buildTailscaleConfig(JSON.stringify(config), draft(), baseline));
+  assert.equal(result.route.final, "updated");
+  code(() => buildTailscaleConfig(JSON.stringify(fixture()), draft(), baseline), "conflict");
+});
+
+function client(options = {}) {
+  const calls = [];
+  let reads = 0;
+  let staged = "";
+  return {
+    calls,
+    get staged() { return staged; },
+    run: async (args) => {
+      calls.push(args);
+      if (args === "config-editor get sing-box") {
+        reads += 1;
+        return { ok: !options.readFailure, stdout: reads > 1 && options.conflict ? `${original()} ` : original() };
+      }
+      if (args.startsWith("config-editor save-file")) return { ok: !options.validationFailure, stdout: options.missingReceipt ? "" : "[info] Saved and validated sing-box config" };
+      if (options.restartThrow) throw Error("private output");
+      return { ok: !options.restartFailure, stdout: "" };
+    },
+    stage: async (text) => {
+      calls.push("stage"); staged = text;
+      return options.stageFailure ? null : { path: "/private/tailscale.json", basename: "tailscale.json" };
+    },
+    remove: async (name) => { calls.push(`remove ${name}`); if (options.cleanupThrow) throw Error("private"); return !options.cleanupFailure; },
+    quote: (value) => `'${value}'`,
+    canSave: () => !options.dirty,
+  };
+}
+
+test("private save checks the receipt and cleans its payload before restarting", async () => {
+  const transport = client();
+  const result = await saveTailscale(transport, draft(), inspectTailscale(original()));
+  assert.equal(result.stage, "done");
+  assert.equal(result.saved, true);
+  assert.deepEqual(transport.calls, ["config-editor get sing-box", "stage", "config-editor get sing-box", "config-editor save-file sing-box '/private/tailscale.json'", "remove tailscale.json", "service restart sing-box"]);
+  assert.equal(transport.staged.includes(key), true);
+  assert.equal(JSON.stringify(transport.calls).includes(key), false);
+  assert.equal(JSON.stringify(result).includes(key), false);
+});
+
+for (const [option, expected] of Object.entries({
+  dirty: "conflict", readFailure: "read", stageFailure: "stage", conflict: "conflict",
+  validationFailure: "validate", missingReceipt: "validate", cleanupFailure: "cleanup", cleanupThrow: "cleanup",
+})) {
+  test(`${option} never restarts the core`, async () => {
+    const transport = client({ [option]: true });
+    const result = await saveTailscale(transport, draft(), inspectTailscale(original()));
+    assert.equal(result.stage, expected);
+    assert.equal(transport.calls.includes("service restart sing-box"), false);
+    if (["conflict", "validationFailure", "missingReceipt", "cleanupFailure", "cleanupThrow"].includes(option)) assert.ok(transport.calls.includes("remove tailscale.json"));
+    if (option === "conflict") assert.equal(transport.calls.some((call) => call.startsWith("config-editor save-file")), false);
+  });
+}
+
+for (const option of ["restartFailure", "restartThrow"]) {
+  test(`${option} reports that saving already succeeded`, async () => {
+    const result = await saveTailscale(client({ [option]: true }), draft(), inspectTailscale(original()));
+    assert.equal(result.stage, "restart");
+    assert.equal(result.saved, true);
+    assert.equal(result.snapshot.configured, true);
+  });
+}
+
+test("page uses the private transport and clears credentials when leaving KeepAlive", () => {
+  const source = readFileSync(new URL("./src/components/pages/TailscalePage.vue", import.meta.url), "utf8");
+  assert.match(source, /type="password"/);
+  assert.match(source, /onDeactivated\(\(\) => \{ authKey.value = "";/);
+  assert.match(source, /stagePrivatePayload\("tmp"/);
+  assert.doesNotMatch(source, /localStorage|sessionStorage|console\.(?:log|error)|v-html|JSON\.parse/);
+  assert.match(source, /state\.config\.dirty/);
+  const app = readFileSync(new URL("./src/App.vue", import.meta.url), "utf8");
+  assert.match(app, /tailscale: \(\) => import\("@\/components\/pages\/TailscalePage.vue"\)/);
+});


### PR DESCRIPTION
## 改动

在 WebUI「配置」（手机底栏「订阅」工作区）新增独立 Tailscale 页面。用户点击「获取密钥」打开官方后台，填写设备名称及自己账号的 Auth key，然后「接入并重启」，不再手动编辑 endpoints / JSON。

- 复用现有私密 payload、config-editor 校验/保护密钥和核心重启流程；不新增密钥存储实现，不把密钥放进可见命令、输出或浏览器持久存储。
- 读取现有节点，保留 tag、state_directory 及自定义选项；留空保留现有登录凭据，离开 KeepAlive 页面清空密码输入。
- 保存前重新读取配置，传输后再次检测变化；有未保存的 JSON 草稿时禁止覆盖，保存后使干净但过期的编辑器缓存失效。
- 保存、私密临时文件清理、重启分别确认；失败不会继续自动重启。重启失败可以单独重试，不必重复提交密钥。
- 页面明确区分「已配置」和后台实际授权/在线状态；不使用 state_created 冒充账号连接成功。
- 保持 Paper 布局、明暗主题、移动端触控目标，补充中英俄翻译、导航和缓存容量。

## 验证

本地已运行：`node --experimental-strip-types --test webui/tailscale-setup.test.mjs`（18/18 通过）、新逻辑模块 TypeScript strict 检查及 `git diff --check`。

新增浏览器回归使用 KernelSU 异步回调 fixture，覆盖正常接入、重复提交、失败不重启、私密输出、重启重试、页面切换清密钥和草稿保护；由现有 Code Quality workflow 在 6 个尺寸项目运行。完整仓库测试、Vue typecheck/build、Shell/Rust 和浏览器结果以本 PR CI 为准，合并前复核。

## 边界

此入口面向官方 Tailscale Auth key 接入，不是 OAuth 登录/账号切换器。已有登录状态不会因更换 Auth key 自动换号。多个 Tailscale endpoints 或自建控制服务器保留不变并阻止误操作，不把官方密钥发往自建服务器。没有修改 DNS/子网路由策略、没有读取任何用户密钥，也没有实际连接用户的 Android 设备或 Tailnet；浏览器 fixture 不替代真机联网验证。

## Sourcery 摘要

提供安全、本地化的 WebUI 工作流，用于配置官方 Tailscale 端点并重启核心，无需手动修改 JSON。

新功能：
- 添加专用 WebUI 页面，用于连接和管理官方 Tailscale Auth 密钥配置，无需手动编辑 JSON。

错误修复：
- 当编辑器中有未保存的更改，或配置在设置过程中发生变化时，防止配置被覆盖。
- 防止保存、清理或验证失败触发核心重启，同时允许独立重试重启失败。

增强功能：
- 保留现有的 Tailscale 端点设置，并区分已配置状态与实际账户授权状态或在线状态。
- 通过现有的私有载荷流程保护 Auth 密钥，避免在 UI 状态或存储中暴露密钥，并在离开页面时清除密钥。
- 阻止对含义不明确的多端点配置和自定义控制服务器配置进行不安全修改。
- 添加 Tailscale 导航、响应式主题 UI 支持，并扩展 KeepAlive 容量。

测试：
- 添加针对安全设置、重复提交、失败处理、重启重试、草稿保护和凭据清理的单元测试及浏览器回归测试。
- 扩展新 Tailscale 页面在英语和俄语中的本地化覆盖范围。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在 WebUI 中提供安全且本地化的 Tailscale 设置页面，用于管理官方端点凭据和核心重启。

新功能：
- 添加专用的 WebUI 工作流，用于配置官方 Tailscale 端点、设置 Auth 密钥，并在无需手动编辑 JSON 的情况下重启核心。

错误修复：
- 防止覆盖并发进行或尚未保存的配置更改，并确保保存失败、清理失败或验证失败不会触发核心重启。

改进：
- 通过现有的私有负载流程保护 Auth 密钥，离开页面时清除密钥，保留现有端点设置，并区分配置状态与实际的 Tailscale 授权状态或在线状态。

文档：
- 为 Tailscale 设置页面和导航添加英文和俄文本地化内容。

测试：
- 添加单元测试和浏览器回归测试，覆盖安全凭据处理、重复提交、冲突保护、失败处理、重启重试以及草稿清理。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在 WebUI 中新增安全、本地化的 Tailscale 设置页面，用于配置官方 Auth 密钥和管理核心重启。

新功能：
- 在 WebUI 中新增专用工作流，可使用 Auth 密钥配置官方 Tailscale 端点，并重启核心，无需手动编辑 JSON。

错误修复：
- 防止未保存的编辑器更改、并发配置更改、验证失败以及不完整的私有负载清理覆盖配置或触发重启。

增强功能：
- 保留现有端点设置，并区分已配置状态与实际的 Tailscale 授权状态或在线状态。
- 通过现有的私有负载流程保护 Auth 密钥，离开页面时清除密钥，并阻止对多个端点或自定义控制服务器进行不安全的更改。
- 添加响应式 Tailscale 导航，以及本地化的英语和俄语 UI 消息。

测试：
- 为凭据隐私、重复提交、冲突保护、失败处理、重启重试、草稿保护和凭据清理添加单元测试及浏览器回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a secure, localized Tailscale setup page to the WebUI for configuring official Auth keys and managing core restarts.

New Features:
- Add a dedicated WebUI workflow for configuring official Tailscale endpoints with an Auth key and restarting the core without manual JSON editing.

Bug Fixes:
- Prevent unsaved editor changes, concurrent configuration changes, failed validation, and incomplete private-payload cleanup from overwriting configuration or triggering a restart.

Enhancements:
- Preserve existing endpoint settings and distinguish configured state from actual Tailscale authorization or online status.
- Protect Auth keys through the existing private payload flow, clear them when leaving the page, and block unsafe changes to multiple endpoints or custom control servers.
- Add responsive Tailscale navigation and localized English and Russian UI messaging.

Tests:
- Add unit and browser regression coverage for credential privacy, duplicate submissions, conflict protection, failure handling, restart retries, draft protection, and credential cleanup.

</details>

</details>

</details>