### PR TITLE
fix(installer): 自动打开订阅配置页，取消复制链接流程

### DIFF
--- a/scripts/install-onboarding-test.py
+++ b/scripts/install-onboarding-test.py
@@ -60,7 +60,8 @@ magicnet_onboarding_collect
         self.port = 0
         self.token = ""
         for _ in range(350):
-            text = self.log_path.read_text()
+            args = self.root / "am-arguments"
+            text = args.read_text() if args.exists() else ""
             match = re.search(r"http://127\.0\.0\.1:(\d+)/\?lang=zh#([a-f0-9]{48})", text)
             if match:
                 self.port, self.token = int(match[1]), match[2]
@@ -161,12 +162,11 @@ class OnboardingTests(unittest.TestCase):
             os.killpg(session.proc.pid, signal.SIGTERM)
             self.assertNotEqual(session.wait(), 0)
 
-    def test_browser_failure_keeps_manual_page_usable(self):
+    def test_browser_failure_exits_without_manual_wait(self):
         with Session(am_status=7) as session:
-            time.sleep(0.1)
-            self.assertIn("MN_SETUP_MANUAL", session.log_path.read_text())
-            self.assertEqual(session.request("save", "https://feed.example.test/list")[0], 200)
-            self.assertEqual(session.wait(), 0)
+            self.assertEqual(session.wait(), 1)
+            self.assertNotIn(session.url, session.log_path.read_text())
+            self.assertNotIn("MN_SETUP_MANUAL", session.log_path.read_text())
 
     def test_kamfw_launcher_keeps_default_browser_current_user_and_exit_status(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/test-magicnet-i18n.sh
+++ b/scripts/test-magicnet-i18n.sh
@@ -101,7 +101,7 @@ next_steps=$(KAM_UI_LANGUAGE=ru i18n INSTALL_NEXT_STEPS)
 case "$next_steps" in *'WebUI'*'cli api ui'*'REJECT / block'*'hostname=127.0.0.1&port=9090') ;; *) fail 'installer translated command or URL values' ;; esac
 
 . "$ROOT/src/MagicNet/lib/magicnet/onboarding/messages.sh"
-for key in MN_SETUP_WAIT MN_SETUP_OPEN MN_SETUP_MANUAL MN_SETUP_SAVED MN_SETUP_CLOSED MN_SETUP_UNAVAILABLE; do
+for key in MN_SETUP_WAIT MN_SETUP_OPEN MN_SETUP_SAVED MN_SETUP_CLOSED MN_SETUP_UNAVAILABLE; do
     for locale in zh en ru ja ko; do
         # Both names come from the fixed lists above, never from user input.
         eval "translated=\${_I18N_${key}_${locale}:-}"

--- a/scripts/test-onboarding-browser.py
+++ b/scripts/test-onboarding-browser.py
@@ -23,7 +23,9 @@ case "$3 $4" in
     '/system/bin/cmd role')
         [ "${TEST_ROLE_FAIL:-0}" = 0 ] || exit 9
         printf '%s' "${TEST_ROLE-}" ;;
+    '/system/bin/cmd activity') exit "${TEST_CMD_RC:-7}" ;;
     '/system/bin/am start')
+        if [ "${TEST_ERROR_OUTPUT:-0}" = 1 ]; then echo 'Error: Activity not started'; exit 0; fi
         [ "${TEST_ALL_FAIL:-0}" = 0 ] || exit 7
         for arg in "$@"; do
             if [ "$arg" = -p ] && [ "${TEST_BOUND_FAIL:-0}" = 1 ]; then exit 8; fi
@@ -69,8 +71,8 @@ class BrowserTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(calls[0][2:], ['/system/bin/am', 'get-current-user'])
         self.assertEqual(calls[1][2:], ['/system/bin/cmd', 'role', 'get-role-holders', '--user', '10', 'android.app.role.BROWSER'])
-        self.assertEqual(calls[2][2:10], ['/system/bin/am', 'start', '--user', 'current', '-a', 'android.intent.action.VIEW', '-c', 'android.intent.category.BROWSABLE'])
-        self.assertEqual(calls[2][10:12], ['-p', 'org.example.browser'])
+        self.assertEqual(calls[2][2:12], ['/system/bin/am', 'start', '--user', 'current', '-a', 'android.intent.action.VIEW', '-f', '0x10000000', '-c', 'android.intent.category.BROWSABLE'])
+        self.assertEqual(calls[2][12:14], ['-p', 'org.example.browser'])
 
     def test_no_browser_role_uses_action_view(self):
         rc, calls = self.launch(TEST_ROLE='')
@@ -97,6 +99,16 @@ class BrowserTests(unittest.TestCase):
     def test_launch_failure_is_not_reported_as_success(self):
         rc, _ = self.launch(TEST_ALL_FAIL='1')
         self.assertEqual(rc, 7)
+
+    def test_direct_activity_fallback(self):
+        rc, calls = self.launch(TEST_ALL_FAIL='1', TEST_CMD_RC='0')
+        self.assertEqual(rc, 0)
+        self.assertEqual(calls[-1][2:5], ['/system/bin/cmd', 'activity', 'start-activity'])
+
+    def test_zero_exit_with_error_uses_fallback(self):
+        rc, calls = self.launch(TEST_ERROR_OUTPUT='1', TEST_CMD_RC='0')
+        self.assertEqual(rc, 0)
+        self.assertEqual(calls[-1][3], 'activity')
 
     def test_invalid_user_does_not_reach_role_service(self):
         rc, calls = self.launch(TEST_USER='not-a-user')

--- a/src/MagicNet/lib/kamfw-web/launcher.sh
+++ b/src/MagicNet/lib/kamfw-web/launcher.sh
@@ -16,6 +16,14 @@ _launch_url() (
     _launch_run am start --user current -a android.intent.action.VIEW -d "$1" >/dev/null 2>&1
 )
 
+# Android can print an ActivityManager error while returning status zero.
+_launch_browser_start() (
+    _lbs_output=$(_launch_run "$@" 2>&1) || exit "$?"
+    case "$_lbs_output" in
+        *Error*|*Exception*|*'Permission Denial'*|*'Background activity'*|*'background activity'*) exit 1 ;;
+    esac
+)
+
 # Ask Android for its current user's browser, never assume Chrome is installed.
 # A browser-role lookup is optional: ACTION_VIEW remains the portable fallback.
 _launch_browser() (
@@ -31,11 +39,15 @@ _launch_browser() (
     fi
     case "$_lb_package" in ''|*[!A-Za-z0-9_.]*) _lb_package='' ;; esac
     if [ -n "$_lb_package" ]; then
-        _launch_run am start --user current -a android.intent.action.VIEW \
-            -c android.intent.category.BROWSABLE -p "$_lb_package" -d "$1" >/dev/null 2>&1 && exit 0
+        _launch_browser_start am start --user current -a android.intent.action.VIEW \
+            -f 0x10000000 -c android.intent.category.BROWSABLE -p "$_lb_package" -d "$1" >/dev/null 2>&1 && exit 0
     fi
-    _launch_run am start --user current -a android.intent.action.VIEW \
-        -c android.intent.category.BROWSABLE -d "$1" >/dev/null 2>&1
+    _launch_browser_start am start --user current -a android.intent.action.VIEW \
+        -f 0x10000000 -c android.intent.category.BROWSABLE -d "$1" && exit 0
+    # Direct Binder shell entry also works when the am wrapper fails in installers.
+    _launch_browser_start cmd activity start-activity --user current \
+        -a android.intent.action.VIEW -f 0x10000000 \
+        -c android.intent.category.BROWSABLE -d "$1"
 )
 
 _launch_app() (

--- a/src/MagicNet/lib/magicnet/install_onboarding.sh
+++ b/src/MagicNet/lib/magicnet/install_onboarding.sh
@@ -195,14 +195,21 @@ magicnet_onboarding_collect() (
     esac
     _url="$MN_SETUP_ORIGIN/?lang=$_lang#$MN_SETUP_TOKEN"
     print "$(i18n MN_SETUP_WAIT)"
-    # A short-lived local capability, never the subscription itself.
-    print "$_url"
     if [ -x /system/bin/cmd ]; then
         "$_bb" timeout 4 /system/bin/cmd notification post -t MagicNet \
             -c activity "$_url" "$_tag" "$(i18n MN_SETUP_OPEN)" \
             >/dev/null 2>&1 && _notice=1
     fi
-    magicnet_onboarding_open "$_url" || print "$(i18n MN_SETUP_MANUAL)"
+    _opened=0
+    for _retry in 1 2 3; do
+        if magicnet_onboarding_open "$_url"; then
+            _opened=1
+            break
+        fi
+        [ "$_retry" = 3 ] || "$_bb" sleep 1
+    done
+    # Never wait for an inaccessible installer link to be copied.
+    [ "$_opened" = 1 ] || exit 1
     _elapsed=0
     while [ "$_elapsed" -lt "$_wait" ]; do
         if [ -f "$MN_SETUP_RUN/result" ]; then

--- a/src/MagicNet/lib/magicnet/onboarding/messages.sh
+++ b/src/MagicNet/lib/magicnet/onboarding/messages.sh
@@ -1,20 +1,11 @@
 # shellcheck shell=ash
 # Registered through kamfw, using the installer's already selected language.
 set_i18n MN_SETUP_WAIT \
-    zh '请在浏览器填写订阅；默认等待 180 秒，也可稍后配置。临时地址请勿分享：' \
-    en 'Add a subscription in your browser, or skip. Default timeout: 180 seconds. Do not share this temporary link:' \
-    ru 'Добавьте подписку в браузере или пропустите. Ожидание по умолчанию: 180 секунд. Не передавайте эту временную ссылку:' \
-    ja 'ブラウザーで購読を入力するか、スキップしてください。既定の待機時間は180秒です。この一時リンクを共有しないでください:' \
-    ko '브라우저에서 구독을 입력하거나 건너뛰세요. 기본 대기 시간은 180초입니다. 임시 링크를 공유하지 마세요:'
+    zh '正在打开订阅配置页…' en 'Opening subscription setup…' \
+    ru 'Открываем настройку подписки…' ja '購読設定を開いています…' ko '구독 설정을 여는 중…'
 set_i18n MN_SETUP_OPEN \
     zh '点击填写订阅链接' en 'Tap to add your subscription' ru 'Нажмите, чтобы добавить подписку' \
     ja 'タップして購読を追加' ko '눌러서 구독 추가'
-set_i18n MN_SETUP_MANUAL \
-    zh '未能自动打开浏览器，请手动打开上面的完整地址。' \
-    en 'Could not open your browser. Open the complete link above manually.' \
-    ru 'Не удалось открыть браузер. Откройте полную ссылку выше вручную.' \
-    ja 'ブラウザーを開けませんでした。上のリンク全体を手動で開いてください。' \
-    ko '브라우저를 열지 못했습니다. 위의 전체 링크를 직접 열어 주세요.'
 set_i18n MN_SETUP_SAVED \
     zh '订阅链接已保存。完成安装并重启后，MagicNet 会按正常启动流程加载订阅。' \
     en 'Subscription saved. Finish installing and reboot; MagicNet will load it during normal startup.' \


### PR DESCRIPTION
安装器无法复制链接时，浏览器启动失败会让用户停留在不可操作的等待界面。

改为自动打开配置页，失败时尝试 cmd activity 启动并最多重试三轮；识别 ActivityManager 返回零退出码但输出错误的情况。移除安装日志中的临时链接和手动复制提示，启动全部失败时立即清理页面并提示通过 WebUI 配置，不再等待 180 秒。

验证：10 项浏览器启动测试、22 项 BusyBox HTTP/CGI 安装测试及多语言检查通过。Android 系统调用由测试模拟，尚未真机验证。

## Sourcery 摘要

当浏览器启动不可用时，自动打开订阅设置页面，并通过 WebUI 提供指导以快速失败。

新功能：
- 自动打开订阅设置页面，并支持浏览器启动回退机制和有限次数的重试。

错误修复：
- 检测报告零退出状态但实际启动失败的 Android activity 启动错误，避免用户陷入无法使用的手动等待状态。

增强功能：
- 从安装程序输出中移除临时订阅 URL 和手动复制说明。
- 当所有浏览器启动尝试均失败时，立即退出并通过 WebUI 提供指导。
- 更新 onboarding 和 Android 启动器测试，以覆盖回退行为、错误检测和调整后的设置流程。

测试：
- 扩展浏览器启动和 onboarding 测试，以覆盖直接 activity 回退、具有误导性的零退出状态以及立即失败后的清理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automatically launch the subscription setup page and fail fast with WebUI guidance when browser startup is unavailable.

New Features:
- Automatically open the subscription setup page with browser-launch fallbacks and limited retries.

Bug Fixes:
- Detect Android activity-launch failures that report errors with a zero exit status and avoid leaving users in an unusable manual-wait state.

Enhancements:
- Remove temporary subscription URLs and manual-copy instructions from installer output.
- Exit promptly with WebUI guidance when all browser-launch attempts fail.
- Update onboarding and Android launcher tests for fallback behavior, error detection, and revised setup flow.

Tests:
- Extend browser-launch and onboarding tests to cover direct activity fallback, misleading zero exit statuses, and immediate failure cleanup.

</details>