### PR TITLE
fix(installer): wrap footer utilities on mobile

### DIFF
--- a/src/MagicNet/lib/magicnet/onboarding/style.css
+++ b/src/MagicNet/lib/magicnet/onboarding/style.css
@@ -105,7 +105,7 @@ footer { display: flex; align-items: center; justify-content: space-between; gap
   .communities { width: 100%; gap: 12px; }
   .community { flex: 1; min-width: 0; padding: 12px 14px; font-size: 12px; gap: 9px; }
   .community .out { margin-left: auto; width: 12px; height: 12px; }
-  .utilities { width: 100%; justify-content: center; }
+  .utilities { width: 100%; justify-content: center; flex-wrap: wrap; }
   .utilities .lmm { margin-left: 14px; }
   #completion { padding: 0; }
   .complete-mark { margin: 0 auto 18px; }


### PR DESCRIPTION
## Summary

Fixes the installer/onboarding horizontal overflow introduced when the second LMM source link was added to the footer.

The production browser matrix currently stops at `zh-CN/320/light overflows`. The immediately preceding installer/hotspot commit was green; `f2d9820` then added a second `.lmm` item to the single-line `.utilities` flex row without giving that row a mobile wrapping rule.

This change keeps the existing links and sizing, and only allows the mobile utilities row to wrap when its contents no longer fit.

Closes #191.

## Verification

Expected CI coverage:

- Install Onboarding real-browser matrix, including 320/390px and light/dark locales
- Validate Kam Module
- Code Quality
- Build Kam Module

No desktop layout, installer protocol, link target, or runtime behavior is changed.

## Sourcery 总结

错误修复：
- 允许实用工具链接在空间不足时换行，防止移动端安装程序/引导页页脚出现水平溢出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent horizontal overflow in the mobile installer/onboarding footer by allowing utility links to wrap when they do not fit.

</details>