### PR TITLE
fix(ci): migrate ChatGPT Voice rules to maintained GitLab source

### DIFF
--- a/docs/chatgpt-voice.md
+++ b/docs/chatgpt-voice.md
@@ -6,12 +6,12 @@ OpenAI 的[网络建议](https://help.openai.com/en/articles/9247338)列出 UDP 
 以及 UDP 不可用时的 TCP 443 回退。这两条规则共同引用 `sukka-chatgpt-voice`，
 TCP 规则紧邻 UDP 规则，均指向 `ai-chatgpt`，配置不再内嵌业务 IP 清单。
 不会代理所有 443 连接，也不会将 UDP 443 或 TCP 3478 当作这条语音规则。
-构建从 [SukkaLab 的规则集](https://github.com/SukkaLab/ruleset.skk.moe/blob/master/sing-box/ip/ai.json)
+构建从 [SukkaW 的规则集](https://gitlab.com/SukkaW/ruleset.skk.moe/-/blob/master/sing-box/ip/ai.json)
 获取数据；[生成源码](https://github.com/SukkaW/Surge/blob/master/Build/build-ai-cidr.ts)
 从 OpenAI 官方清单更新。下载按不可变提交读取，校验后原子替换本地规则文件。
 下载失败、非法地址或空集合使构建失败，保留上次规则文件。
 
-这是构建时更新，规则随安装包分发，启动不依赖 GitHub 可达性。
+这是构建时更新，规则随安装包分发，启动不依赖 GitLab 可达性。
 普通订阅刷新不会更新该文件；安装新构建获取新的上游规则。
 Telegram IP 分流复用已有的 `lyc-geoip-telegram` 规则集。
 内网及保留地址规则仍保留。不要覆盖自定义规则来排障。

--- a/docs/maintained-routing.md
+++ b/docs/maintained-routing.md
@@ -7,12 +7,12 @@ in the MagicNet template:
 - [lyc8503/sing-box-rules](https://github.com/lyc8503/sing-box-rules): existing CN, advertising and Telegram GeoIP classifiers.
 - [KaringX/karing-ruleset](https://github.com/KaringX/karing-ruleset): existing WeChat and China domain/IP classifiers.
 - [HaGeZi via razaxq](https://github.com/razaxq/dns-blocklists-sing-box): light advertising/tracking classifier. Copyright/anti-piracy lists are not part of the default advertising policy.
-- [SukkaLab/ruleset.skk.moe](https://github.com/SukkaLab/ruleset.skk.moe/blob/master/sing-box/ip/ai.json): ChatGPT Voice IPs, generated from OpenAI's published feed.
+- [SukkaW/ruleset.skk.moe](https://gitlab.com/SukkaW/ruleset.skk.moe/-/blob/master/sing-box/ip/ai.json): ChatGPT Voice IPs, generated from OpenAI's published feed.
 
 Build hooks resolve immutable upstream revisions, download the referenced files,
 and package local rule sets. New upstream data arrives with a new build; ordinary
 subscription refresh does not update these classifiers. Startup works without
-fetching rules from GitHub. Build state records the resolved revisions.
+fetching rules from their upstream hosts. Build state records the resolved revisions.
 
 ## Policy that remains local
 

--- a/hooks/pre-build/5460.update_chatgpt_voice_rules.sh
+++ b/hooks/pre-build/5460.update_chatgpt_voice_rules.sh
@@ -13,10 +13,10 @@ CANDIDATE=$(mktemp "$RULE_DIR/.chatgpt-voice.XXXXXX")
 trap 'rm -f "$CANDIDATE"' EXIT
 # Resolve one immutable upstream revision per build; never rewrite config.json.
 REF=$(curl -fsSL --connect-timeout 5 --max-time 20 --retry 3 \
-    https://api.github.com/repos/SukkaLab/ruleset.skk.moe/git/ref/heads/master |
-    jq -er '.object.sha | select(test("^[0-9a-f]{40}$"))')
+    https://gitlab.com/api/v4/projects/61399101/repository/branches/master |
+    jq -er '.commit.id | select(test("^[0-9a-f]{40}$"))')
 curl -fsSL --connect-timeout 5 --max-time 20 --retry 3 \
-    "https://raw.githubusercontent.com/SukkaLab/ruleset.skk.moe/$REF/sing-box/ip/ai.json" \
+    "https://gitlab.com/SukkaW/ruleset.skk.moe/-/raw/$REF/sing-box/ip/ai.json" \
     -o "$CANDIDATE"
 python3 - "$CANDIDATE" <<'PY'
 import ipaddress
@@ -38,4 +38,4 @@ PY
 chmod 644 "$CANDIDATE"
 mv -f "$CANDIDATE" "$RULE_DIR/sukka-chatgpt-voice.json"
 printf '%s\n' "$REF" >"$STATE_DIR/upstream-revision"
-log_success "ChatGPT Voice rule-set refreshed from SukkaLab@$REF"
+log_success "ChatGPT Voice rule-set refreshed from SukkaW/ruleset.skk.moe@$REF"

--- a/scripts/test-chatgpt-voice-rules.sh
+++ b/scripts/test-chatgpt-voice-rules.sh
@@ -25,8 +25,10 @@ from pathlib import Path
 mode = os.environ.get("VOICE_TEST", "valid")
 if mode == "failure": sys.exit(22)
 if "-o" not in sys.argv:
-    print(json.dumps({"object":{"sha":"a"*40}}))
+    assert any("gitlab.com/api/v4/projects/61399101/repository/branches/master" in arg for arg in sys.argv)
+    print(json.dumps({"commit":{"id":"a"*40}}))
 else:
+    assert any("gitlab.com/SukkaW/ruleset.skk.moe/-/raw/" in arg for arg in sys.argv)
     assert any("/" + "a"*40 + "/" in arg for arg in sys.argv)
     prefixes = ["203.0.113.8/32", "2001:db8::8/128"]
     if mode == "empty": prefixes = []


### PR DESCRIPTION
## Summary

Restore `Build Kam Module` after the retired GitHub mirror for `ruleset.skk.moe` started returning 404.

The maintained output repository is now `SukkaW/ruleset.skk.moe` on GitLab (project ID `61399101`). This change preserves the existing reproducibility contract:

- resolve the current `master` commit through GitLab's repository API;
- require a full 40-character commit ID;
- fetch `sing-box/ip/ai.json` from that exact immutable commit;
- keep the existing JSON/IP-prefix validation and atomic replacement behavior;
- update the offline mock test to assert both the GitLab revision endpoint and commit-pinned raw URL;
- update the two documentation links that still pointed at the retired GitHub mirror.

No routing policy, selector behavior, bundled rule schema, or release policy changes.

## Verification

`compare main...fix/chatgpt-voice-gitlab-source` is limited to 4 files and 20 changed lines. Existing CI should exercise the mocked failure/invalid/catch-all cases and the real `kam build` upstream fetch.

Closes #190.

## Sourcery 总结

将 ChatGPT Voice 规则获取迁移到维护中的 GitLab 源，同时保留可复现且经过验证的构建。

错误修复：
- 将上游规则获取从已停用的 GitHub 镜像迁移到维护中的 GitLab 仓库，以恢复 ChatGPT Voice 规则构建。

改进：
- 在更新 GitLab 源相关文档和离线覆盖的同时，保留不可变的修订版本固定和现有的规则验证。

文档：
- 更新 ChatGPT Voice 和维护路由文档，以引用托管在 GitLab 上的规则集及其上游可用性。

测试：
- 更新离线模拟测试，以验证 GitLab 修订版本解析和固定到提交版本的规则下载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate ChatGPT Voice rule fetching to the maintained GitLab source while preserving reproducible, validated builds.

Bug Fixes:
- Restore ChatGPT Voice rule builds by migrating upstream rule retrieval from the retired GitHub mirror to the maintained GitLab repository.

Enhancements:
- Preserve immutable revision pinning and existing rule validation while updating documentation and offline coverage for the GitLab source.

Documentation:
- Update ChatGPT Voice and maintained-routing documentation to reference the GitLab-hosted rule set and upstream availability.

Tests:
- Update the offline mock test to validate GitLab revision resolution and commit-pinned rule downloads.

</details>